### PR TITLE
Add basic lexer framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c99
 BIN = vc
-SRC = src/main.c
+SRC = src/main.c src/lexer.c
+HDR = include/token.h
+PREFIX ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include/vc
 
 all: $(BIN)
 
-$(BIN): $(SRC)
-	$(CC) $(CFLAGS) -o $@ $(SRC)
+$(BIN): $(SRC) $(HDR)
+	$(CC) $(CFLAGS) -Iinclude -o $@ $(SRC)
+
+install: $(BIN)
+	install -d $(DESTDIR)$(INCLUDEDIR)
+	install -m 644 $(HDR) $(DESTDIR)$(INCLUDEDIR)
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install $(BIN) $(DESTDIR)$(PREFIX)/bin/
 
 clean:
 	rm -f $(BIN)
 
-.PHONY: all clean
+.PHONY: all clean install

--- a/include/token.h
+++ b/include/token.h
@@ -1,0 +1,44 @@
+#ifndef VC_TOKEN_H
+#define VC_TOKEN_H
+
+#include <stddef.h>
+
+/* Token types used by the lexer */
+typedef enum {
+    TOK_EOF = 0,
+    TOK_IDENT,
+    TOK_NUMBER,
+    TOK_STRING,
+    TOK_CHAR,
+    TOK_KW_INT,
+    TOK_KW_RETURN,
+    TOK_LPAREN,
+    TOK_RPAREN,
+    TOK_LBRACE,
+    TOK_RBRACE,
+    TOK_SEMI,
+    TOK_COMMA,
+    TOK_PLUS,
+    TOK_MINUS,
+    TOK_STAR,
+    TOK_SLASH,
+    TOK_UNKNOWN
+} token_type_t;
+
+/* Representation of a single lexical token */
+typedef struct {
+    token_type_t type;
+    char *lexeme; /* NUL terminated string */
+    size_t line;
+    size_t column;
+} token_t;
+
+/* Tokenize the given C source string. The returned array must be freed
+ * with lexer_free_tokens(). If out_count is not NULL it is set to the
+ * number of tokens returned. */
+token_t *lexer_tokenize(const char *src, size_t *out_count);
+
+/* Free an array of tokens returned by lexer_tokenize(). */
+void lexer_free_tokens(token_t *tokens, size_t count);
+
+#endif /* VC_TOKEN_H */

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,0 +1,131 @@
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "token.h"
+
+static void append_token(token_t **tokens, size_t *count, size_t *cap,
+                         token_type_t type, const char *lexeme,
+                         size_t len, size_t line, size_t column)
+{
+    if (*count >= *cap) {
+        *cap *= 2;
+        *tokens = realloc(*tokens, (*cap) * sizeof(**tokens));
+        if (!*tokens)
+            exit(1);
+    }
+    char *text = malloc(len + 1);
+    if (!text)
+        exit(1);
+    memcpy(text, lexeme, len);
+    text[len] = '\0';
+    (*tokens)[(*count)++] = (token_t){ type, text, line, column };
+}
+
+static void skip_whitespace(const char *src, size_t *i, size_t *line,
+                            size_t *col)
+{
+    while (src[*i]) {
+        char c = src[*i];
+        if (c == '\n') {
+            (*line)++;
+            *col = 1;
+            (*i)++;
+        } else if (isspace((unsigned char)c)) {
+            (*i)++;
+            (*col)++;
+        } else {
+            break;
+        }
+    }
+}
+
+static void read_identifier(const char *src, size_t *i, size_t *col,
+                            token_t **tokens, size_t *count, size_t *cap,
+                            size_t line)
+{
+    size_t start = *i;
+    while (isalnum((unsigned char)src[*i]) || src[*i] == '_')
+        (*i)++;
+    size_t len = *i - start;
+    token_type_t type = TOK_IDENT;
+    if (len == 3 && strncmp(src + start, "int", 3) == 0)
+        type = TOK_KW_INT;
+    else if (len == 6 && strncmp(src + start, "return", 6) == 0)
+        type = TOK_KW_RETURN;
+    append_token(tokens, count, cap, type, src + start, len, line, *col);
+    *col += len;
+}
+
+static void read_number(const char *src, size_t *i, size_t *col,
+                        token_t **tokens, size_t *count, size_t *cap,
+                        size_t line)
+{
+    size_t start = *i;
+    while (isdigit((unsigned char)src[*i]))
+        (*i)++;
+    size_t len = *i - start;
+    append_token(tokens, count, cap, TOK_NUMBER, src + start, len, line, *col);
+    *col += len;
+}
+
+static void read_punct(char c, token_t **tokens, size_t *count, size_t *cap,
+                       size_t line, size_t column)
+{
+    token_type_t type = TOK_UNKNOWN;
+    switch (c) {
+    case '+': type = TOK_PLUS; break;
+    case '-': type = TOK_MINUS; break;
+    case '*': type = TOK_STAR; break;
+    case '/': type = TOK_SLASH; break;
+    case ';': type = TOK_SEMI; break;
+    case ',': type = TOK_COMMA; break;
+    case '(': type = TOK_LPAREN; break;
+    case ')': type = TOK_RPAREN; break;
+    case '{': type = TOK_LBRACE; break;
+    case '}': type = TOK_RBRACE; break;
+    default: type = TOK_UNKNOWN; break;
+    }
+    append_token(tokens, count, cap, type, &c, 1, line, column);
+}
+
+/* Public API */
+
+token_t *lexer_tokenize(const char *src, size_t *out_count)
+{
+    size_t cap = 16;
+    size_t count = 0;
+    token_t *tokens = malloc(cap * sizeof(*tokens));
+    if (!tokens)
+        return NULL;
+
+    size_t i = 0, line = 1, col = 1;
+    while (src[i]) {
+        skip_whitespace(src, &i, &line, &col);
+        if (!src[i])
+            break;
+        char c = src[i];
+        if (isalpha((unsigned char)c) || c == '_') {
+            read_identifier(src, &i, &col, &tokens, &count, &cap, line);
+        } else if (isdigit((unsigned char)c)) {
+            read_number(src, &i, &col, &tokens, &count, &cap, line);
+        } else {
+            read_punct(c, &tokens, &count, &cap, line, col);
+            i++;
+            col++;
+        }
+    }
+
+    append_token(&tokens, &count, &cap, TOK_EOF, "", 0, line, col);
+    if (out_count)
+        *out_count = count;
+    return tokens;
+}
+
+void lexer_free_tokens(token_t *tokens, size_t count)
+{
+    for (size_t i = 0; i < count; i++)
+        free(tokens[i].lexeme);
+    free(tokens);
+}
+


### PR DESCRIPTION
## Summary
- introduce `token.h` defining lexer token types
- implement tokenization helpers in `lexer.c`
- compile lexer and install header via Makefile

## Testing
- `make clean`
- `make`
- `make install DESTDIR=/tmp/vc-test`

------
https://chatgpt.com/codex/tasks/task_e_6859e9934eac83248c5f1a35fb93dedb