### PR TITLE
Add simple IR optimization pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+vc

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c99
 BIN = vc
-SRC = src/main.c src/lexer.c src/ast.c src/parser.c src/semantic.c src/ir.c
-HDR = include/token.h include/ast.h include/parser.h include/semantic.h include/ir.h
+SRC = src/main.c src/lexer.c src/ast.c src/parser.c src/semantic.c src/ir.c src/opt.c
+HDR = include/token.h include/ast.h include/parser.h include/semantic.h include/ir.h include/opt.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 

--- a/include/opt.h
+++ b/include/opt.h
@@ -1,0 +1,9 @@
+#ifndef VC_OPT_H
+#define VC_OPT_H
+
+#include "ir.h"
+
+/* Run all optimization passes on the given IR builder */
+void opt_run(ir_builder_t *ir);
+
+#endif /* VC_OPT_H */

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include "parser.h"
 #include "semantic.h"
 #include "ir.h"
+#include "opt.h"
 
 #define VERSION "0.1.0"
 
@@ -131,6 +132,10 @@ int main(int argc, char **argv)
         }
         ast_free_stmt(stmt);
     }
+
+    /* Run optimizations on the generated IR */
+    if (ok)
+        opt_run(&ir);
 
     ir_builder_free(&ir);
 

--- a/src/opt.c
+++ b/src/opt.c
@@ -1,0 +1,68 @@
+#include <stdlib.h>
+#include "opt.h"
+
+/* Simple constant folding optimization pass */
+static void fold_constants(ir_builder_t *ir)
+{
+    if (!ir)
+        return;
+    int max_id = ir->next_value_id;
+    int *is_const = calloc((size_t)max_id, sizeof(int));
+    int *values = calloc((size_t)max_id, sizeof(int));
+    if (!is_const || !values) {
+        free(is_const);
+        free(values);
+        return;
+    }
+
+    for (ir_instr_t *ins = ir->head; ins; ins = ins->next) {
+        switch (ins->op) {
+        case IR_CONST:
+            if (ins->dest >= 0 && ins->dest < max_id) {
+                is_const[ins->dest] = 1;
+                values[ins->dest] = ins->imm;
+            }
+            break;
+        case IR_ADD: case IR_SUB: case IR_MUL: case IR_DIV:
+            if (ins->src1 < max_id && ins->src2 < max_id &&
+                is_const[ins->src1] && is_const[ins->src2]) {
+                int a = values[ins->src1];
+                int b = values[ins->src2];
+                int result = 0;
+                switch (ins->op) {
+                case IR_ADD: result = a + b; break;
+                case IR_SUB: result = a - b; break;
+                case IR_MUL: result = a * b; break;
+                case IR_DIV: result = b != 0 ? a / b : 0; break;
+                default: break;
+                }
+                ins->op = IR_CONST;
+                ins->imm = result;
+                ins->src1 = ins->src2 = 0;
+                if (ins->dest >= 0 && ins->dest < max_id) {
+                    is_const[ins->dest] = 1;
+                    values[ins->dest] = result;
+                }
+            } else if (ins->dest >= 0 && ins->dest < max_id) {
+                is_const[ins->dest] = 0;
+            }
+            break;
+        case IR_LOAD:
+            if (ins->dest >= 0 && ins->dest < max_id)
+                is_const[ins->dest] = 0;
+            break;
+        case IR_RETURN:
+            /* nothing to do */
+            break;
+        }
+    }
+
+    free(is_const);
+    free(values);
+}
+
+void opt_run(ir_builder_t *ir)
+{
+    fold_constants(ir);
+}
+


### PR DESCRIPTION
## Summary
- implement constant folding in `src/opt.c`
- expose optimizer via new `include/opt.h`
- compile optimizer in the build
- call optimizer after semantic analysis
- ignore built `vc` executable

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6859f26c65b083248fc936e4d1adebe4