### PR TITLE
Implement end-to-end compilation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "semantic.h"
 #include "ir.h"
 #include "opt.h"
+#include "codegen.h"
 
 #define VERSION "0.1.0"
 
@@ -136,6 +137,18 @@ int main(int argc, char **argv)
     /* Run optimizations on the generated IR */
     if (ok)
         opt_run(&ir);
+
+    /* Generate assembly output */
+    if (ok) {
+        FILE *outf = fopen(output, "w");
+        if (!outf) {
+            perror("fopen");
+            ok = 0;
+        } else {
+            codegen_emit_x86(outf, &ir);
+            fclose(outf);
+        }
+    }
 
     ir_builder_free(&ir);
 


### PR DESCRIPTION
## Summary
- add missing codegen include to main.c
- run code generation and write output file after optimization
- emit errors when output file cannot be opened

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6859f46c37f083248a63987a74462e01