### PR TITLE
Add string and char literal support

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -14,6 +14,8 @@ typedef enum {
 typedef enum {
     EXPR_NUMBER,
     EXPR_IDENT,
+    EXPR_STRING,
+    EXPR_CHAR,
     EXPR_BINARY,
     EXPR_ASSIGN,
     EXPR_CALL
@@ -44,6 +46,12 @@ struct expr {
         struct {
             char *name;
         } ident;
+        struct {
+            char *value;
+        } string;
+        struct {
+            char value;
+        } ch;
         struct {
             binop_t op;
             expr_t *left;
@@ -95,6 +103,8 @@ struct stmt {
 /* Constructors */
 expr_t *ast_make_number(const char *value);
 expr_t *ast_make_ident(const char *name);
+expr_t *ast_make_string(const char *value);
+expr_t *ast_make_char(char value);
 expr_t *ast_make_binary(binop_t op, expr_t *left, expr_t *right);
 expr_t *ast_make_assign(const char *name, expr_t *value);
 expr_t *ast_make_call(const char *name);

--- a/include/ir.h
+++ b/include/ir.h
@@ -8,6 +8,7 @@ typedef enum {
     IR_SUB,
     IR_MUL,
     IR_DIV,
+    IR_GLOB_STRING,
     IR_LOAD,
     IR_STORE,
     IR_RETURN,
@@ -34,7 +35,8 @@ typedef struct ir_instr {
     int src1;             /* first operand */
     int src2;             /* second operand */
     int imm;              /* immediate value for constants */
-    char *name;           /* identifier for loads */
+    char *name;           /* identifier / label */
+    char *data;           /* for string literals */
     struct ir_instr *next;
 } ir_instr_t;
 
@@ -59,5 +61,6 @@ void ir_build_func_end(ir_builder_t *b);
 void ir_build_br(ir_builder_t *b, const char *label);
 void ir_build_bcond(ir_builder_t *b, ir_value_t cond, const char *label);
 void ir_build_label(ir_builder_t *b, const char *label);
+ir_value_t ir_build_string(ir_builder_t *b, const char *data);
 
 #endif /* VC_IR_H */

--- a/src/ast.c
+++ b/src/ast.c
@@ -40,6 +40,30 @@ expr_t *ast_make_ident(const char *name)
     return expr;
 }
 
+expr_t *ast_make_string(const char *value)
+{
+    expr_t *expr = malloc(sizeof(*expr));
+    if (!expr)
+        return NULL;
+    expr->kind = EXPR_STRING;
+    expr->string.value = dup_string(value ? value : "");
+    if (!expr->string.value) {
+        free(expr);
+        return NULL;
+    }
+    return expr;
+}
+
+expr_t *ast_make_char(char value)
+{
+    expr_t *expr = malloc(sizeof(*expr));
+    if (!expr)
+        return NULL;
+    expr->kind = EXPR_CHAR;
+    expr->ch.value = value;
+    return expr;
+}
+
 expr_t *ast_make_binary(binop_t op, expr_t *left, expr_t *right)
 {
     expr_t *expr = malloc(sizeof(*expr));
@@ -167,6 +191,11 @@ void ast_free_expr(expr_t *expr)
         break;
     case EXPR_IDENT:
         free(expr->ident.name);
+        break;
+    case EXPR_STRING:
+        free(expr->string.value);
+        break;
+    case EXPR_CHAR:
         break;
     case EXPR_BINARY:
         ast_free_expr(expr->binary.left);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -107,6 +107,11 @@ static void emit_instr(strbuf_t *sb, ir_instr_t *ins)
         if (strcmp(reg_for(ins->dest), "%eax") != 0)
             sb_appendf(sb, "    movl %s, %s\n", "%eax", reg_for(ins->dest));
         break;
+    case IR_GLOB_STRING:
+        sb_appendf(sb, "%s:\n", ins->name);
+        sb_appendf(sb, "    .asciz \"%s\"\n", ins->data);
+        sb_appendf(sb, "    movl $%s, %s\n", ins->name, reg_for(ins->dest));
+        break;
     case IR_RETURN:
         sb_appendf(sb, "    movl %s, %s\n", reg_for(ins->src1), "%eax");
         sb_append(sb, "    ret\n");

--- a/src/ir.c
+++ b/src/ir.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include "ir.h"
 
 static char *dup_string(const char *s)
@@ -24,6 +25,7 @@ void ir_builder_free(ir_builder_t *b)
     while (ins) {
         ir_instr_t *next = ins->next;
         free(ins->name);
+        free(ins->data);
         free(ins);
         ins = next;
     }
@@ -37,6 +39,8 @@ static ir_instr_t *append_instr(ir_builder_t *b)
     if (!ins)
         return NULL;
     ins->dest = -1;
+    ins->name = NULL;
+    ins->data = NULL;
     if (!b->head)
         b->head = ins;
     else
@@ -53,6 +57,20 @@ ir_value_t ir_build_const(ir_builder_t *b, int value)
     ins->op = IR_CONST;
     ins->dest = b->next_value_id++;
     ins->imm = value;
+    return (ir_value_t){ins->dest};
+}
+
+ir_value_t ir_build_string(ir_builder_t *b, const char *str)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return (ir_value_t){0};
+    ins->op = IR_GLOB_STRING;
+    ins->dest = b->next_value_id++;
+    char label[32];
+    snprintf(label, sizeof(label), "Lstr%d", ins->dest);
+    ins->name = dup_string(label);
+    ins->data = dup_string(str ? str : "");
     return (ir_value_t){ins->dest};
 }
 

--- a/src/opt.c
+++ b/src/opt.c
@@ -56,6 +56,10 @@ static void fold_constants(ir_builder_t *ir)
         case IR_RETURN:
             /* nothing to do */
             break;
+        case IR_GLOB_STRING:
+            if (ins->dest >= 0 && ins->dest < max_id)
+                is_const[ins->dest] = 0;
+            break;
         case IR_CALL: case IR_FUNC_BEGIN: case IR_FUNC_END:
             if (ins->dest >= 0 && ins->dest < max_id)
                 is_const[ins->dest] = 0;

--- a/src/parser.c
+++ b/src/parser.c
@@ -43,6 +43,10 @@ static expr_t *parse_primary(parser_t *p)
 
     if (match(p, TOK_NUMBER)) {
         return ast_make_number(tok->lexeme);
+    } else if (match(p, TOK_STRING)) {
+        return ast_make_string(tok->lexeme);
+    } else if (match(p, TOK_CHAR)) {
+        return ast_make_char(tok->lexeme[0]);
     } else if (tok->type == TOK_IDENT) {
         token_t *next = p->pos + 1 < p->count ? &p->tokens[p->pos + 1] : NULL;
         if (next && next->type == TOK_LPAREN) {

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -92,6 +92,14 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
         if (out)
             *out = ir_build_const(ir, (int)strtol(expr->number.value, NULL, 10));
         return TYPE_INT;
+    case EXPR_STRING:
+        if (out)
+            *out = ir_build_string(ir, expr->string.value);
+        return TYPE_INT;
+    case EXPR_CHAR:
+        if (out)
+            *out = ir_build_const(ir, (int)expr->ch.value);
+        return TYPE_INT;
     case EXPR_IDENT: {
         symbol_t *sym = symtable_lookup(vars, expr->ident.name);
         if (!sym)

--- a/tests/fixtures/char_constant.c
+++ b/tests/fixtures/char_constant.c
@@ -1,0 +1,3 @@
+int main() {
+    return 'A';
+}

--- a/tests/fixtures/char_constant.s
+++ b/tests/fixtures/char_constant.s
@@ -1,0 +1,6 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $65, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/string_literal.c
+++ b/tests/fixtures/string_literal.c
@@ -1,0 +1,4 @@
+int main() {
+    "hi";
+    return 0;
+}

--- a/tests/fixtures/string_literal.s
+++ b/tests/fixtures/string_literal.s
@@ -1,0 +1,9 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+Lstr1:
+    .asciz "hi"
+    movl $Lstr1, %eax
+    movl $0, %ebx
+    movl %ebx, %eax
+    ret


### PR DESCRIPTION
## Summary
- handle quoted strings and character constants in the lexer
- add `EXPR_STRING` and `EXPR_CHAR` AST nodes with constructors
- parse new literals as primary expressions
- build IR for literals and output assembly for string data
- extend optimizer and add tests for the new features

## Testing
- `make`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a02581d6c8324a5daac0ca6a6a2c3