### PR TITLE
Implement dead code elimination with CLI toggles

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,8 @@ The compiler is composed of several distinct phases:
    token stream.
 3. **Semantic analysis** – the AST is checked for correctness and is
    transformed into an intermediate representation (IR).
-4. **Optimization** – optional passes that operate on the IR.
+4. **Optimization** – optional passes that operate on the IR. See
+   [optimization passes](optimization.md) for details.
 5. **Code generation** – the IR is lowered to target specific assembly
    language.
 

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -1,0 +1,16 @@
+# Optimization Passes
+
+The optimizer in **vc** operates on the intermediate representation (IR).
+Two passes are currently available:
+
+- **Constant folding** – evaluates arithmetic instructions with constant
+  operands and replaces them with a single constant.
+- **Dead code elimination** – removes instructions that produce values
+  which are never used and have no side effects.
+
+Both optimizations are enabled by default. They may be toggled from the
+command line:
+
+```sh
+vc --no-fold --no-dce -o out.s source.c
+```

--- a/include/opt.h
+++ b/include/opt.h
@@ -3,7 +3,12 @@
 
 #include "ir.h"
 
-/* Run all optimization passes on the given IR builder */
-void opt_run(ir_builder_t *ir);
+typedef struct {
+    int fold_constants; /* enable constant folding */
+    int dead_code;      /* enable dead code elimination */
+} opt_config_t;
+
+/* Run optimization passes on the given IR builder */
+void opt_run(ir_builder_t *ir, const opt_config_t *cfg);
 
 #endif /* VC_OPT_H */

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,8 @@ static void print_usage(const char *prog)
     printf("  -o, --output <file>  Output path\n");
     printf("  -h, --help           Display this help and exit\n");
     printf("  -v, --version        Print version information and exit\n");
+    printf("      --no-fold        Disable constant folding\n");
+    printf("      --no-dce         Disable dead code elimination\n");
 }
 
 static char *read_file(const char *path)
@@ -59,11 +61,14 @@ int main(int argc, char **argv)
         {"help",    no_argument,       0, 'h'},
         {"version", no_argument,       0, 'v'},
         {"output",  required_argument, 0, 'o'},
+        {"no-fold", no_argument,       0, 1},
+        {"no-dce",  no_argument,       0, 2},
         {0, 0, 0, 0}
     };
 
     char *output = NULL;
     int opt;
+    opt_config_t opt_cfg = {1, 1};
 
     while ((opt = getopt_long(argc, argv, "hvo:", long_opts, NULL)) != -1) {
         switch (opt) {
@@ -75,6 +80,12 @@ int main(int argc, char **argv)
             return 0;
         case 'o':
             output = optarg;
+            break;
+        case 1:
+            opt_cfg.fold_constants = 0;
+            break;
+        case 2:
+            opt_cfg.dead_code = 0;
             break;
         default:
             print_usage(argv[0]);
@@ -154,7 +165,7 @@ int main(int argc, char **argv)
 
     /* Run optimizations on the generated IR */
     if (ok)
-        opt_run(&ir);
+        opt_run(&ir, &opt_cfg);
 
     /* Generate assembly output */
     if (ok) {

--- a/src/opt.c
+++ b/src/opt.c
@@ -73,8 +73,88 @@ static void fold_constants(ir_builder_t *ir)
     free(values);
 }
 
-void opt_run(ir_builder_t *ir)
+
+/* Instructions that must be preserved even if their result is unused */
+static int has_side_effect(ir_instr_t *ins)
 {
-    fold_constants(ir);
+    switch (ins->op) {
+    case IR_STORE:
+    case IR_STORE_PTR:
+    case IR_CALL:
+    case IR_RETURN:
+    case IR_BR:
+    case IR_BCOND:
+    case IR_FUNC_BEGIN:
+    case IR_FUNC_END:
+    case IR_LABEL:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* Remove instructions whose results are never used */
+static void dead_code_elim(ir_builder_t *ir)
+{
+    if (!ir)
+        return;
+
+    int max_id = ir->next_value_id;
+    int count = 0;
+    for (ir_instr_t *i = ir->head; i; i = i->next)
+        count++;
+
+    ir_instr_t **list = malloc((size_t)count * sizeof(*list));
+    if (!list)
+        return;
+
+    int idx = 0;
+    for (ir_instr_t *i = ir->head; i; i = i->next)
+        list[idx++] = i;
+
+    int *used = calloc((size_t)max_id, sizeof(int));
+    if (!used) {
+        free(list);
+        return;
+    }
+
+    for (int i = count - 1; i >= 0; i--) {
+        ir_instr_t *ins = list[i];
+        int dest = ins->dest;
+        int side = has_side_effect(ins);
+
+        if (dest >= 0 && !side && !used[dest]) {
+            if (i == 0)
+                ir->head = ins->next;
+            else
+                list[i - 1]->next = ins->next;
+
+            if (ins == ir->tail)
+                ir->tail = (i == 0) ? NULL : list[i - 1];
+
+            free(ins->name);
+            free(ins->data);
+            free(ins);
+            continue;
+        }
+
+        if (ins->src1 >= 0 && ins->src1 < max_id)
+            used[ins->src1] = 1;
+        if (ins->src2 >= 0 && ins->src2 < max_id)
+            used[ins->src2] = 1;
+    }
+
+    free(used);
+    free(list);
+}
+
+void opt_run(ir_builder_t *ir, const opt_config_t *cfg)
+{
+    opt_config_t def = {1, 1};
+    const opt_config_t *c = cfg ? cfg : &def;
+    if (c->fold_constants)
+        fold_constants(ir);
+    if (c->dead_code)
+        dead_code_elim(ir);
 }
 

--- a/tests/fixtures/simple_add.s
+++ b/tests/fixtures/simple_add.s
@@ -1,10 +1,6 @@
 main:
     pushl %ebp
     movl %esp, %ebp
-    movl $1, %eax
-    movl $2, %ebx
-    movl $3, %ecx
-    movl $6, %edx
     movl $7, %esi
     movl %esi, %eax
     ret

--- a/tests/fixtures/string_literal.s
+++ b/tests/fixtures/string_literal.s
@@ -1,9 +1,6 @@
 main:
     pushl %ebp
     movl %esp, %ebp
-Lstr1:
-    .asciz "hi"
-    movl $Lstr1, %eax
     movl $0, %ebx
     movl %ebx, %eax
     ret


### PR DESCRIPTION
## Summary
- add configurable optimization passes
- implement a dead code elimination pass
- expose `--no-fold` and `--no-dce` flags
- document optimization passes
- update expected assembly after optimization

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a076c1a348324976a5c1a2980a0d2