### PR TITLE
Add simple register allocator module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS ?= -Wall -Wextra -std=c99
 OPTFLAGS ?=
 BIN = vc
 # Core compiler sources
-CORE_SRC = src/main.c src/lexer.c src/ast.c src/parser.c src/semantic.c src/ir.c src/codegen.c
+CORE_SRC = src/main.c src/lexer.c src/ast.c src/parser.c src/semantic.c src/ir.c src/codegen.c src/regalloc.c
 # Optional optimization sources
 OPT_SRC = src/opt.c
 # Additional sources can be specified by the user

--- a/include/regalloc.h
+++ b/include/regalloc.h
@@ -1,0 +1,21 @@
+#ifndef VC_REGALLOC_H
+#define VC_REGALLOC_H
+
+#include "ir.h"
+
+/* Location mapping for IR values */
+typedef struct {
+    int *loc;       /* >=0 register index, <0 stack slot (-n) */
+    int stack_slots;/* number of stack slots used */
+} regalloc_t;
+
+/* Assign locations to IR values using a simple linear scan allocator */
+void regalloc_run(ir_builder_t *ir, regalloc_t *ra);
+
+/* Free resources held by the allocator */
+void regalloc_free(regalloc_t *ra);
+
+/* Return physical register name for given index */
+const char *regalloc_reg_name(int idx);
+
+#endif /* VC_REGALLOC_H */

--- a/src/regalloc.c
+++ b/src/regalloc.c
@@ -1,0 +1,85 @@
+#include <stdlib.h>
+#include "regalloc.h"
+
+#define NUM_REGS 6
+
+static const char *phys_regs[NUM_REGS] = {
+    "%eax", "%ebx", "%ecx", "%edx", "%esi", "%edi"
+};
+
+const char *regalloc_reg_name(int idx)
+{
+    if (idx >= 0 && idx < NUM_REGS)
+        return phys_regs[idx];
+    return "%eax";
+}
+
+static int *compute_last_use(ir_builder_t *ir, int max_id)
+{
+    int *last = malloc((size_t)max_id * sizeof(int));
+    if (!last)
+        return NULL;
+    for (int i = 0; i < max_id; i++)
+        last[i] = -1;
+
+    int idx = 0;
+    for (ir_instr_t *ins = ir->head; ins; ins = ins->next, idx++) {
+        if (ins->src1 > 0 && ins->src1 < max_id)
+            last[ins->src1] = idx;
+        if (ins->src2 > 0 && ins->src2 < max_id)
+            last[ins->src2] = idx;
+    }
+    return last;
+}
+
+void regalloc_run(ir_builder_t *ir, regalloc_t *ra)
+{
+    int max_id = ir->next_value_id;
+    ra->loc = malloc((size_t)max_id * sizeof(int));
+    ra->stack_slots = 0;
+    if (!ra->loc)
+        return;
+    for (int i = 0; i < max_id; i++)
+        ra->loc[i] = -1;
+
+    int *last = compute_last_use(ir, max_id);
+    if (!last)
+        return;
+
+    int free_regs[NUM_REGS];
+    int free_count = NUM_REGS;
+    for (int i = 0; i < NUM_REGS; i++)
+        free_regs[i] = NUM_REGS - 1 - i; /* allocate from high to low */
+
+    int idx = 0;
+    for (ir_instr_t *ins = ir->head; ins; ins = ins->next, idx++) {
+        if (ins->dest > 0 && ins->dest < max_id && ra->loc[ins->dest] == -1) {
+            if (free_count > 0) {
+                ra->loc[ins->dest] = free_regs[--free_count];
+            } else {
+                ra->loc[ins->dest] = -(++ra->stack_slots);
+            }
+        }
+
+        if (ins->src1 > 0 && ins->src1 < max_id &&
+            ra->loc[ins->src1] >= 0 && last[ins->src1] == idx) {
+            free_regs[free_count++] = ra->loc[ins->src1];
+        }
+        if (ins->src2 > 0 && ins->src2 < max_id &&
+            ra->loc[ins->src2] >= 0 && last[ins->src2] == idx) {
+            free_regs[free_count++] = ra->loc[ins->src2];
+        }
+        if (ins->dest > 0 && ins->dest < max_id &&
+            ra->loc[ins->dest] >= 0 && last[ins->dest] == idx) {
+            free_regs[free_count++] = ra->loc[ins->dest];
+        }
+    }
+    free(last);
+}
+
+void regalloc_free(regalloc_t *ra)
+{
+    free(ra->loc);
+    ra->loc = NULL;
+    ra->stack_slots = 0;
+}

--- a/tests/fixtures/call_function.s
+++ b/tests/fixtures/call_function.s
@@ -8,6 +8,6 @@ main:
     pushl %ebp
     movl %esp, %ebp
     call foo
-    movl %eax, %ebx
-    movl %ebx, %eax
+    movl %eax, %eax
+    movl %eax, %eax
     ret

--- a/tests/fixtures/pointer_basic.s
+++ b/tests/fixtures/pointer_basic.s
@@ -3,9 +3,9 @@ main:
     movl %esp, %ebp
     movl $x, %eax
     movl %eax, p
-    movl $42, %ebx
-    movl %ebx, x
-    movl p, %ecx
-    movl (%ecx), %edx
-    movl %edx, %eax
+    movl $42, %eax
+    movl %eax, x
+    movl p, %eax
+    movl (%eax), %ebx
+    movl %ebx, %eax
     ret

--- a/tests/fixtures/simple_add.s
+++ b/tests/fixtures/simple_add.s
@@ -1,6 +1,6 @@
 main:
     pushl %ebp
     movl %esp, %ebp
-    movl $7, %esi
-    movl %esi, %eax
+    movl $7, %eax
+    movl %eax, %eax
     ret

--- a/tests/fixtures/string_literal.s
+++ b/tests/fixtures/string_literal.s
@@ -1,6 +1,6 @@
 main:
     pushl %ebp
     movl %esp, %ebp
-    movl $0, %ebx
-    movl %ebx, %eax
+    movl $0, %eax
+    movl %eax, %eax
     ret

--- a/tests/fixtures/var_assign.s
+++ b/tests/fixtures/var_assign.s
@@ -3,6 +3,6 @@ main:
     movl %esp, %ebp
     movl $5, %eax
     movl %eax, x
-    movl x, %ebx
-    movl %ebx, %eax
+    movl x, %eax
+    movl %eax, %eax
     ret

--- a/tests/fixtures/while_loop.s
+++ b/tests/fixtures/while_loop.s
@@ -4,16 +4,16 @@ main:
     movl $3, %eax
     movl %eax, i
 L0_start:
-    movl i, %ebx
-    cmpl $0, %ebx
+    movl i, %eax
+    cmpl $0, %eax
     je L0_end
-    movl i, %ecx
-    movl $1, %edx
-    movl %ecx, %esi
-    subl %edx, %esi
-    movl %esi, i
+    movl i, %eax
+    movl $1, %ebx
+    movl %eax, %ecx
+    subl %ebx, %ecx
+    movl %ecx, i
     jmp L0_start
 L0_end:
-    movl i, %edi
-    movl %edi, %eax
+    movl i, %ecx
+    movl %ecx, %eax
     ret


### PR DESCRIPTION
## Summary
- implement linear scan register allocator
- integrate allocator into `codegen.c`
- compile new module via Makefile
- update expected assembly outputs

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a08ca380c83249c20490aa3e031c8