### PR TITLE
Add lexer and parser unit tests

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -32,3 +32,16 @@ make EXTRA_SRC="src/utils.c src/driver.c" OPTFLAGS="-O2"
 ```
 
 See the [README](../README.md) for an overview of the project.
+
+## Running the test suite
+
+The project includes a small set of unit and integration tests. They can be
+executed from the repository root with:
+
+```sh
+tests/run.sh
+```
+
+This script builds the compiler, compiles the unit test harness for the lexer
+and parser, and then runs both the unit tests and the integration tests found
+under `tests/`.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+DIR=$(dirname "$0")
+# build the compiler
+make
+# build unit test binary
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/unit_tests" "$DIR/unit/test_lexer_parser.c" \
+    src/lexer.c src/parser.c src/ast.c
+# run unit tests
+"$DIR/unit_tests"
+# run integration tests
+"$DIR/run_tests.sh"


### PR DESCRIPTION
## Summary
- create a small C test harness to exercise lexer and parser
- provide a `tests/run.sh` helper to build vc and run all tests
- document how to execute the suite in `docs/building.md`

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a0ba468e4832487f3976b89872c13