### PR TITLE
Add comment handling to lexer

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -27,7 +27,31 @@ static void skip_whitespace(const char *src, size_t *i, size_t *line,
 {
     while (src[*i]) {
         char c = src[*i];
-        if (c == '\n') {
+        if (c == '/' && src[*i + 1] == '/') { /* line comment */
+            (*i) += 2;
+            (*col) += 2;
+            while (src[*i] && src[*i] != '\n') {
+                (*i)++;
+                (*col)++;
+            }
+        } else if (c == '/' && src[*i + 1] == '*') { /* block comment */
+            (*i) += 2;
+            (*col) += 2;
+            while (src[*i]) {
+                if (src[*i] == '\n') {
+                    (*line)++;
+                    *col = 1;
+                    (*i)++;
+                } else if (src[*i] == '*' && src[*i + 1] == '/') {
+                    (*i) += 2;
+                    (*col) += 2;
+                    break;
+                } else {
+                    (*i)++;
+                    (*col)++;
+                }
+            }
+        } else if (c == '\n') {
             (*line)++;
             *col = 1;
             (*i)++;

--- a/tests/fixtures/block_comment.c
+++ b/tests/fixtures/block_comment.c
@@ -1,0 +1,5 @@
+int main() {
+    /* block comment start
+       still in comment */
+    return 42;
+}

--- a/tests/fixtures/block_comment.s
+++ b/tests/fixtures/block_comment.s
@@ -1,0 +1,6 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $42, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/line_comment.c
+++ b/tests/fixtures/line_comment.c
@@ -1,0 +1,4 @@
+int main() {
+    // this is a line comment
+    return 42;
+}

--- a/tests/fixtures/line_comment.s
+++ b/tests/fixtures/line_comment.s
@@ -1,0 +1,6 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $42, %eax
+    movl %eax, %eax
+    ret

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -25,6 +25,30 @@ static void test_lexer_basic(void)
     lexer_free_tokens(toks, count);
 }
 
+static void test_lexer_comments(void)
+{
+    const char *src =
+        "int main() {\n"
+        "    // line comment\n"
+        "    /* block\n"
+        "       comment */\n"
+        "    return 0;\n"
+        "}";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    ASSERT(toks[0].type == TOK_KW_INT);
+    ASSERT(toks[1].type == TOK_IDENT && strcmp(toks[1].lexeme, "main") == 0);
+    ASSERT(toks[2].type == TOK_LPAREN);
+    ASSERT(toks[3].type == TOK_RPAREN);
+    ASSERT(toks[4].type == TOK_LBRACE);
+    ASSERT(toks[5].type == TOK_KW_RETURN);
+    ASSERT(toks[6].type == TOK_NUMBER && strcmp(toks[6].lexeme, "0") == 0);
+    ASSERT(toks[7].type == TOK_SEMI);
+    ASSERT(toks[8].type == TOK_RBRACE);
+    ASSERT(toks[9].type == TOK_EOF);
+    lexer_free_tokens(toks, count);
+}
+
 static void test_parser_expr(void)
 {
     const char *src = "1 + 2 * 3";
@@ -79,6 +103,7 @@ static void test_parser_func(void)
 int main(void)
 {
     test_lexer_basic();
+    test_lexer_comments();
     test_parser_expr();
     test_parser_stmt_return();
     test_parser_func();


### PR DESCRIPTION
## Summary
- support line and block comments in the lexer
- add lexer unit test for comments
- add integration tests with comment-containing source files

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a0d6174dc83249a90bab9c40b7db8