### PR TITLE
Support void return without expression

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -94,6 +94,7 @@ struct stmt {
             expr_t *expr;
         } expr;
         struct {
+            /* expression may be NULL for 'return;' in void functions */
             expr_t *expr;
         } ret;
         struct {

--- a/include/semantic.h
+++ b/include/semantic.h
@@ -30,7 +30,7 @@ symbol_t *symtable_lookup(symtable_t *table, const char *name);
 type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                        ir_builder_t *ir, ir_value_t *out);
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-               ir_builder_t *ir);
+               ir_builder_t *ir, type_kind_t func_ret_type);
 int check_func(func_t *func, symtable_t *funcs, ir_builder_t *ir);
 
 #endif /* VC_SEMANTIC_H */

--- a/src/parser.c
+++ b/src/parser.c
@@ -190,10 +190,13 @@ stmt_t *parser_parse_stmt(parser_t *p)
     }
 
     if (match(p, TOK_KW_RETURN)) {
-        expr_t *expr = parse_expression(p);
-        if (!expr || !match(p, TOK_SEMI)) {
-            ast_free_expr(expr);
-            return NULL;
+        expr_t *expr = NULL;
+        if (!match(p, TOK_SEMI)) {
+            expr = parse_expression(p);
+            if (!expr || !match(p, TOK_SEMI)) {
+                ast_free_expr(expr);
+                return NULL;
+            }
         }
         return ast_make_return(expr);
     }

--- a/tests/fixtures/return_void.c
+++ b/tests/fixtures/return_void.c
@@ -1,0 +1,7 @@
+void foo() {
+    return;
+}
+int main() {
+    foo();
+    return 0;
+}

--- a/tests/fixtures/return_void.s
+++ b/tests/fixtures/return_void.s
@@ -1,0 +1,14 @@
+foo:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $0, %eax
+    movl %eax, %eax
+    ret
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    call foo
+    movl %eax, %eax
+    movl $0, %ebx
+    movl %ebx, %eax
+    ret

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -84,6 +84,20 @@ static void test_parser_stmt_return(void)
     lexer_free_tokens(toks, count);
 }
 
+static void test_parser_stmt_return_void(void)
+{
+    const char *src = "return;";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    stmt_t *stmt = parser_parse_stmt(&p);
+    ASSERT(stmt);
+    ASSERT(stmt->kind == STMT_RETURN);
+    ASSERT(stmt->ret.expr == NULL);
+    ast_free_stmt(stmt);
+    lexer_free_tokens(toks, count);
+}
+
 static void test_parser_func(void)
 {
     const char *src = "int main() { return 0; }";
@@ -106,6 +120,7 @@ int main(void)
     test_lexer_comments();
     test_parser_expr();
     test_parser_stmt_return();
+    test_parser_stmt_return_void();
     test_parser_func();
     if (failures == 0) {
         printf("All unit tests passed\n");


### PR DESCRIPTION
## Summary
- allow `STMT_RETURN` to store a `NULL` expression
- parse `return;` in statements
- handle void returns in the semantic checker
- add unit test for parsing void returns
- add integration fixture exercising void-returning function

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a0e35531c8324adb09f2f6fde6225