### PR TITLE
Support functions with parameters

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -137,11 +137,16 @@ void ast_free_stmt(stmt_t *stmt);
 struct func {
     char *name;
     type_kind_t return_type;
+    char **param_names;
+    type_kind_t *param_types;
+    size_t param_count;
     stmt_t **body;
     size_t body_count;
 };
 
 func_t *ast_make_func(const char *name, type_kind_t ret_type,
+                      char **param_names, type_kind_t *param_types,
+                      size_t param_count,
                       stmt_t **body, size_t body_count);
 void ast_free_func(func_t *func);
 

--- a/include/ir.h
+++ b/include/ir.h
@@ -11,6 +11,8 @@ typedef enum {
     IR_GLOB_STRING,
     IR_LOAD,
     IR_STORE,
+    IR_LOAD_PARAM,
+    IR_STORE_PARAM,
     IR_ADDR,
     IR_LOAD_PTR,
     IR_STORE_PTR,
@@ -57,6 +59,8 @@ ir_value_t ir_build_const(ir_builder_t *b, int value);
 ir_value_t ir_build_load(ir_builder_t *b, const char *name);
 ir_value_t ir_build_binop(ir_builder_t *b, ir_op_t op, ir_value_t left, ir_value_t right);
 void ir_build_store(ir_builder_t *b, const char *name, ir_value_t val);
+ir_value_t ir_build_load_param(ir_builder_t *b, int index);
+void ir_build_store_param(ir_builder_t *b, int index, ir_value_t val);
 ir_value_t ir_build_addr(ir_builder_t *b, const char *name);
 ir_value_t ir_build_load_ptr(ir_builder_t *b, ir_value_t addr);
 void ir_build_store_ptr(ir_builder_t *b, ir_value_t addr, ir_value_t val);

--- a/include/semantic.h
+++ b/include/semantic.h
@@ -8,6 +8,7 @@
 typedef struct symbol {
     char *name;
     type_kind_t type;
+    int param_index; /* -1 for locals */
     struct symbol *next;
 } symbol_t;
 
@@ -22,6 +23,8 @@ void symtable_free(symtable_t *table);
 
 /* Add a symbol to the table. Returns non-zero on success. */
 int symtable_add(symtable_t *table, const char *name, type_kind_t type);
+int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
+                       int index);
 
 /* Look up a symbol by name. Returns NULL if not found. */
 symbol_t *symtable_lookup(symtable_t *table, const char *name);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -105,6 +105,18 @@ static void emit_instr(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64)
                    loc_str(buf1, ra, ins->src1, x64),
                    ins->name);
         break;
+    case IR_LOAD_PARAM: {
+        int off = 8 + ins->imm * (x64 ? 8 : 4);
+        sb_appendf(sb, "    mov%s %d(%s), %s\n", sfx, off, bp,
+                   loc_str(buf1, ra, ins->dest, x64));
+        break;
+    }
+    case IR_STORE_PARAM: {
+        int off = 8 + ins->imm * (x64 ? 8 : 4);
+        sb_appendf(sb, "    mov%s %s, %d(%s)\n", sfx,
+                   loc_str(buf1, ra, ins->src1, x64), off, bp);
+        break;
+    }
     case IR_ADDR:
         sb_appendf(sb, "    mov%s $%s, %s\n", sfx, ins->name,
                    loc_str(buf1, ra, ins->dest, x64));

--- a/src/ir.c
+++ b/src/ir.c
@@ -95,6 +95,27 @@ void ir_build_store(ir_builder_t *b, const char *name, ir_value_t val)
     ins->name = dup_string(name ? name : "");
 }
 
+ir_value_t ir_build_load_param(ir_builder_t *b, int index)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return (ir_value_t){0};
+    ins->op = IR_LOAD_PARAM;
+    ins->dest = b->next_value_id++;
+    ins->imm = index;
+    return (ir_value_t){ins->dest};
+}
+
+void ir_build_store_param(ir_builder_t *b, int index, ir_value_t val)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return;
+    ins->op = IR_STORE_PARAM;
+    ins->imm = index;
+    ins->src1 = val.id;
+}
+
 ir_value_t ir_build_addr(ir_builder_t *b, const char *name)
 {
     ir_instr_t *ins = append_instr(b);

--- a/src/opt.c
+++ b/src/opt.c
@@ -52,6 +52,11 @@ static void fold_constants(ir_builder_t *ir)
                 is_const[ins->dest] = 0;
             break;
         case IR_STORE:
+        case IR_LOAD_PARAM:
+            if (ins->dest >= 0 && ins->dest < max_id)
+                is_const[ins->dest] = 0;
+            break;
+        case IR_STORE_PARAM:
             break;
         case IR_RETURN:
             /* nothing to do */
@@ -80,6 +85,7 @@ static int has_side_effect(ir_instr_t *ins)
     switch (ins->op) {
     case IR_STORE:
     case IR_STORE_PTR:
+    case IR_STORE_PARAM:
     case IR_CALL:
     case IR_RETURN:
     case IR_BR:

--- a/tests/fixtures/func_params.c
+++ b/tests/fixtures/func_params.c
@@ -1,0 +1,6 @@
+int id(int x) {
+    return x;
+}
+int main() {
+    return id();
+}

--- a/tests/fixtures/func_params.s
+++ b/tests/fixtures/func_params.s
@@ -1,0 +1,13 @@
+id:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %eax
+    movl %eax, %eax
+    ret
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    call id
+    movl %eax, %eax
+    movl %eax, %eax
+    ret


### PR DESCRIPTION
## Summary
- store parameter names/types in AST
- parse parameter lists in function definitions
- insert parameters into symbol tables when checking functions
- load/store parameters from the stack via new IR instructions
- add integration test for a function with parameters

## Testing
- `make`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a0f7788008324bd3343ac0f5c1b83