### PR TITLE
Support variable initializers

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -100,6 +100,8 @@ struct stmt {
         struct {
             char *name;
             type_kind_t type;
+            /* optional initializer expression */
+            expr_t *init;
         } var_decl;
         struct {
             expr_t *cond;
@@ -125,7 +127,7 @@ expr_t *ast_make_call(const char *name);
 
 stmt_t *ast_make_expr_stmt(expr_t *expr);
 stmt_t *ast_make_return(expr_t *expr);
-stmt_t *ast_make_var_decl(const char *name, type_kind_t type);
+stmt_t *ast_make_var_decl(const char *name, type_kind_t type, expr_t *init);
 stmt_t *ast_make_if(expr_t *cond, stmt_t *then_branch, stmt_t *else_branch);
 stmt_t *ast_make_while(expr_t *cond, stmt_t *body);
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -137,7 +137,7 @@ stmt_t *ast_make_return(expr_t *expr)
     return stmt;
 }
 
-stmt_t *ast_make_var_decl(const char *name, type_kind_t type)
+stmt_t *ast_make_var_decl(const char *name, type_kind_t type, expr_t *init)
 {
     stmt_t *stmt = malloc(sizeof(*stmt));
     if (!stmt)
@@ -149,6 +149,7 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type)
         return NULL;
     }
     stmt->var_decl.type = type;
+    stmt->var_decl.init = init;
     return stmt;
 }
 
@@ -265,6 +266,7 @@ void ast_free_stmt(stmt_t *stmt)
         break;
     case STMT_VAR_DECL:
         free(stmt->var_decl.name);
+        ast_free_expr(stmt->var_decl.init);
         break;
     case STMT_IF:
         ast_free_expr(stmt->if_stmt.cond);

--- a/src/parser.c
+++ b/src/parser.c
@@ -184,9 +184,18 @@ stmt_t *parser_parse_stmt(parser_t *p)
             return NULL;
         p->pos++;
         char *name = tok->lexeme;
-        if (!match(p, TOK_SEMI))
-            return NULL;
-        return ast_make_var_decl(name, t);
+        expr_t *init = NULL;
+        if (match(p, TOK_ASSIGN)) {
+            init = parse_expression(p);
+            if (!init || !match(p, TOK_SEMI)) {
+                ast_free_expr(init);
+                return NULL;
+            }
+        } else {
+            if (!match(p, TOK_SEMI))
+                return NULL;
+        }
+        return ast_make_var_decl(name, t, init);
     }
 
     if (match(p, TOK_KW_RETURN)) {

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -247,8 +247,18 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         ir_build_label(ir, end_label);
         return 1;
     }
-    case STMT_VAR_DECL:
-        return symtable_add(vars, stmt->var_decl.name, stmt->var_decl.type);
+    case STMT_VAR_DECL: {
+        if (!symtable_add(vars, stmt->var_decl.name, stmt->var_decl.type))
+            return 0;
+        if (stmt->var_decl.init) {
+            ir_value_t val;
+            if (check_expr(stmt->var_decl.init, vars, funcs, ir, &val) !=
+                stmt->var_decl.type)
+                return 0;
+            ir_build_store(ir, stmt->var_decl.name, val);
+        }
+        return 1;
+    }
     }
     return 0;
 }

--- a/tests/fixtures/pointer_init.c
+++ b/tests/fixtures/pointer_init.c
@@ -1,0 +1,6 @@
+int main() {
+    int x;
+    int *p = &x;
+    x = 42;
+    return *p;
+}

--- a/tests/fixtures/pointer_init.s
+++ b/tests/fixtures/pointer_init.s
@@ -1,0 +1,11 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $x, %eax
+    movl %eax, p
+    movl $42, %eax
+    movl %eax, x
+    movl p, %eax
+    movl (%eax), %ebx
+    movl %ebx, %eax
+    ret

--- a/tests/fixtures/var_init.c
+++ b/tests/fixtures/var_init.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 5;
+    return x;
+}

--- a/tests/fixtures/var_init.s
+++ b/tests/fixtures/var_init.s
@@ -1,0 +1,8 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $5, %eax
+    movl %eax, x
+    movl x, %eax
+    movl %eax, %eax
+    ret

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -98,6 +98,23 @@ static void test_parser_stmt_return_void(void)
     lexer_free_tokens(toks, count);
 }
 
+static void test_parser_var_decl_init(void)
+{
+    const char *src = "int x = 5;";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    stmt_t *stmt = parser_parse_stmt(&p);
+    ASSERT(stmt);
+    ASSERT(stmt->kind == STMT_VAR_DECL);
+    ASSERT(strcmp(stmt->var_decl.name, "x") == 0);
+    ASSERT(stmt->var_decl.type == TYPE_INT);
+    ASSERT(stmt->var_decl.init && stmt->var_decl.init->kind == EXPR_NUMBER &&
+           strcmp(stmt->var_decl.init->number.value, "5") == 0);
+    ast_free_stmt(stmt);
+    lexer_free_tokens(toks, count);
+}
+
 static void test_parser_func(void)
 {
     const char *src = "int main() { return 0; }";
@@ -121,6 +138,7 @@ int main(void)
     test_parser_expr();
     test_parser_stmt_return();
     test_parser_stmt_return_void();
+    test_parser_var_decl_init();
     test_parser_func();
     if (failures == 0) {
         printf("All unit tests passed\n");


### PR DESCRIPTION
## Summary
- allow declarations like `int x = 5;`
- parse optional initializer expressions
- store initializer value in IR after semantic analysis
- test variable declaration initialization for ints and pointers

## Testing
- `make clean && make`
- `tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a1180306483248358b510249cccd9