### PR TITLE
Add install option & manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 HDR = include/token.h include/ast.h include/parser.h include/semantic.h include/ir.h include/opt.h include/codegen.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
+MANDIR ?= $(PREFIX)/share/man
 
 all: $(BIN)
 
@@ -27,6 +28,8 @@ install: $(BIN)
 	install -m 644 $(HDR) $(DESTDIR)$(INCLUDEDIR)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install $(BIN) $(DESTDIR)$(PREFIX)/bin/
+	install -d $(DESTDIR)$(MANDIR)/man1
+	install -m 644 man/vc.1 $(DESTDIR)$(MANDIR)/man1/
 
 clean:
 	rm -f $(BIN)

--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ pass `--dump-ir`:
 ```sh
 vc --dump-ir source.c
 ```
+
+## Installation
+
+To install the compiler, run:
+
+```sh
+make install PREFIX=/usr/local
+```
+
+This installs `vc` under `PREFIX/bin`, the public headers under
+`PREFIX/include/vc`, and the manual page under `PREFIX/share/man/man1`.

--- a/man/vc.1
+++ b/man/vc.1
@@ -1,0 +1,44 @@
+.TH VC 1 "2025-06-24" "vc 0.1.0" "User Commands"
+.SH NAME
+vc \- lightweight ANSI C compiler
+.SH SYNOPSIS
+.B vc
+.RI [ options ] " source.c"
+.SH DESCRIPTION
+.B vc
+is a lightweight ANSI C compiler with experimental C99 support.
+It processes input through lexical analysis, parsing, semantic analysis,
+optional optimizations, register allocation and code generation.
+The resulting assembly can be written to a file or printed to stdout.
+.SH OPTIONS
+.TP
+.BR -o "," \fB--output\fR \fIfile\fR
+Write assembly output to \fIfile\fR.
+.TP
+.BR -h "," \fB--help\fR
+Display usage information and exit.
+.TP
+.BR -v "," \fB--version\fR
+Print version information and exit.
+.TP
+.B --no-fold
+Disable constant folding optimization.
+.TP
+.B --no-dce
+Disable dead code elimination.
+.TP
+.B --x86-64
+Generate x86-64 assembly instead of 32-bit.
+.TP
+.B --dump-ir
+Print generated assembly to stdout rather than creating a file.
+.SH EXAMPLES
+Compile a source file to \fIout.s\fR:
+.PP
+.B vc -o out.s source.c
+.PP
+Print the generated assembly:
+.PP
+.B vc --dump-ir source.c
+.SH SEE ALSO
+README.md, docs/vcdoc.md


### PR DESCRIPTION
## Summary
- include installation path for manual pages in Makefile
- add vc(1) manual
- document installation in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a24dd1d64832497d81f028ef0606e