### PR TITLE
Add argument support to function calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Module.symvers
 Mkfile.old
 dkms.conf
 vc
+tests/unit_tests

--- a/include/ast.h
+++ b/include/ast.h
@@ -82,6 +82,8 @@ struct expr {
         } assign;
         struct {
             char *name;
+            expr_t **args;
+            size_t arg_count;
         } call;
     };
 };
@@ -143,7 +145,8 @@ expr_t *ast_make_unary(unop_t op, expr_t *operand,
                        size_t line, size_t column);
 expr_t *ast_make_assign(const char *name, expr_t *value,
                         size_t line, size_t column);
-expr_t *ast_make_call(const char *name, size_t line, size_t column);
+expr_t *ast_make_call(const char *name, expr_t **args, size_t arg_count,
+                      size_t line, size_t column);
 
 stmt_t *ast_make_expr_stmt(expr_t *expr, size_t line, size_t column);
 stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column);

--- a/include/ir.h
+++ b/include/ir.h
@@ -23,6 +23,7 @@ typedef enum {
     IR_ADDR,
     IR_LOAD_PTR,
     IR_STORE_PTR,
+    IR_ARG,
     IR_RETURN,
     IR_CALL,
     IR_FUNC_BEGIN,
@@ -72,7 +73,8 @@ ir_value_t ir_build_addr(ir_builder_t *b, const char *name);
 ir_value_t ir_build_load_ptr(ir_builder_t *b, ir_value_t addr);
 void ir_build_store_ptr(ir_builder_t *b, ir_value_t addr, ir_value_t val);
 void ir_build_return(ir_builder_t *b, ir_value_t val);
-ir_value_t ir_build_call(ir_builder_t *b, const char *name);
+void ir_build_arg(ir_builder_t *b, ir_value_t val);
+ir_value_t ir_build_call(ir_builder_t *b, const char *name, size_t arg_count);
 void ir_build_func_begin(ir_builder_t *b, const char *name);
 void ir_build_func_end(ir_builder_t *b);
 void ir_build_br(ir_builder_t *b, const char *label);

--- a/include/semantic.h
+++ b/include/semantic.h
@@ -9,6 +9,8 @@ typedef struct symbol {
     char *name;
     type_kind_t type;
     int param_index; /* -1 for locals */
+    type_kind_t *param_types; /* for functions */
+    size_t param_count;
     struct symbol *next;
 } symbol_t;
 
@@ -24,6 +26,8 @@ void symtable_free(symtable_t *table);
 
 /* Add a symbol to the table. Returns non-zero on success. */
 int symtable_add(symtable_t *table, const char *name, type_kind_t type);
+int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
+                      type_kind_t *param_types, size_t param_count);
 int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
                        int index);
 int symtable_add_global(symtable_t *table, const char *name, type_kind_t type);

--- a/src/ast.c
+++ b/src/ast.c
@@ -119,7 +119,8 @@ expr_t *ast_make_assign(const char *name, expr_t *value,
     return expr;
 }
 
-expr_t *ast_make_call(const char *name, size_t line, size_t column)
+expr_t *ast_make_call(const char *name, expr_t **args, size_t arg_count,
+                      size_t line, size_t column)
 {
     expr_t *expr = malloc(sizeof(*expr));
     if (!expr)
@@ -132,6 +133,8 @@ expr_t *ast_make_call(const char *name, size_t line, size_t column)
         free(expr);
         return NULL;
     }
+    expr->call.args = args;
+    expr->call.arg_count = arg_count;
     return expr;
 }
 
@@ -295,6 +298,9 @@ void ast_free_expr(expr_t *expr)
         ast_free_expr(expr->assign.value);
         break;
     case EXPR_CALL:
+        for (size_t i = 0; i < expr->call.arg_count; i++)
+            ast_free_expr(expr->call.args[i]);
+        free(expr->call.args);
         free(expr->call.name);
         break;
     }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -131,6 +131,10 @@ static void emit_instr(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64)
                    loc_str(buf1, ra, ins->src2, x64),
                    loc_str(buf2, ra, ins->src1, x64));
         break;
+    case IR_ARG:
+        sb_appendf(sb, "    push%s %s\n", sfx,
+                   loc_str(buf1, ra, ins->src1, x64));
+        break;
     case IR_ADD:
         sb_appendf(sb, "    mov%s %s, %s\n", sfx,
                    loc_str(buf1, ra, ins->src1, x64),
@@ -203,6 +207,9 @@ static void emit_instr(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64)
         break;
     case IR_CALL:
         sb_appendf(sb, "    call %s\n", ins->name);
+        if (ins->imm > 0)
+            sb_appendf(sb, "    add%s $%d, %s\n", sfx,
+                       ins->imm * (x64 ? 8 : 4), sp);
         sb_appendf(sb, "    mov%s %s, %s\n", sfx, ax,
                    loc_str(buf1, ra, ins->dest, x64));
         break;

--- a/src/ir.c
+++ b/src/ir.c
@@ -160,6 +160,15 @@ ir_value_t ir_build_binop(ir_builder_t *b, ir_op_t op, ir_value_t left, ir_value
     return (ir_value_t){ins->dest};
 }
 
+void ir_build_arg(ir_builder_t *b, ir_value_t val)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return;
+    ins->op = IR_ARG;
+    ins->src1 = val.id;
+}
+
 void ir_build_return(ir_builder_t *b, ir_value_t val)
 {
     ir_instr_t *ins = append_instr(b);
@@ -169,7 +178,7 @@ void ir_build_return(ir_builder_t *b, ir_value_t val)
     ins->src1 = val.id;
 }
 
-ir_value_t ir_build_call(ir_builder_t *b, const char *name)
+ir_value_t ir_build_call(ir_builder_t *b, const char *name, size_t arg_count)
 {
     ir_instr_t *ins = append_instr(b);
     if (!ins)
@@ -177,6 +186,7 @@ ir_value_t ir_build_call(ir_builder_t *b, const char *name)
     ins->op = IR_CALL;
     ins->dest = b->next_value_id++;
     ins->name = dup_string(name ? name : "");
+    ins->imm = (int)arg_count;
     return (ir_value_t){ins->dest};
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -185,7 +185,10 @@ int main(int argc, char **argv)
     }
 
     for (size_t i = 0; i < fcount; i++)
-        symtable_add(&funcs, func_list[i]->name, func_list[i]->return_type);
+        symtable_add_func(&funcs, func_list[i]->name,
+                          func_list[i]->return_type,
+                          func_list[i]->param_types,
+                          func_list[i]->param_count);
     for (size_t i = 0; i < gcount; i++) {
         if (!check_global(glob_list[i], &globals, &ir)) {
             semantic_print_error("Semantic error");

--- a/src/opt.c
+++ b/src/opt.c
@@ -79,6 +79,7 @@ static void propagate_load_consts(ir_builder_t *ir)
         }
         case IR_STORE_PTR:
         case IR_CALL:
+        case IR_ARG:
             clear_var_list(vars);
             if (ins->dest >= 0 && ins->dest < max_id)
                 is_const[ins->dest] = 0;
@@ -188,7 +189,7 @@ static void fold_constants(ir_builder_t *ir)
             if (ins->dest >= 0 && ins->dest < max_id)
                 is_const[ins->dest] = 0;
             break;
-        case IR_CALL: case IR_FUNC_BEGIN: case IR_FUNC_END:
+        case IR_CALL: case IR_FUNC_BEGIN: case IR_FUNC_END: case IR_ARG:
             if (ins->dest >= 0 && ins->dest < max_id)
                 is_const[ins->dest] = 0;
             break;
@@ -210,6 +211,7 @@ static int has_side_effect(ir_instr_t *ins)
     case IR_STORE_PTR:
     case IR_STORE_PARAM:
     case IR_CALL:
+    case IR_ARG:
     case IR_RETURN:
     case IR_BR:
     case IR_BCOND:

--- a/tests/fixtures/call_args.c
+++ b/tests/fixtures/call_args.c
@@ -1,0 +1,6 @@
+int mul(int a, int b) {
+    return a * b;
+}
+int main() {
+    return mul(2, 3);
+}

--- a/tests/fixtures/call_args.s
+++ b/tests/fixtures/call_args.s
@@ -1,0 +1,21 @@
+mul:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %eax
+    movl 12(%ebp), %ebx
+    movl %eax, %ecx
+    imull %ebx, %ecx
+    movl %ecx, %eax
+    ret
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $2, %ecx
+    movl $3, %ebx
+    pushl %ebx
+    pushl %ecx
+    call mul
+    addl $8, %esp
+    movl %eax, %ecx
+    movl %ecx, %eax
+    ret

--- a/tests/fixtures/func_params.c
+++ b/tests/fixtures/func_params.c
@@ -2,5 +2,5 @@ int id(int x) {
     return x;
 }
 int main() {
-    return id();
+    return id(5);
 }

--- a/tests/fixtures/func_params.s
+++ b/tests/fixtures/func_params.s
@@ -7,7 +7,10 @@ id:
 main:
     pushl %ebp
     movl %esp, %ebp
+    movl $5, %eax
+    pushl %eax
     call id
+    addl $4, %esp
     movl %eax, %eax
     movl %eax, %eax
     ret


### PR DESCRIPTION
## Summary
- extend AST call nodes to store argument expressions
- parse argument lists in function calls
- validate call arguments against function declarations
- emit IR for arguments and stack cleanup
- support IR_ARG in backend
- add tests for calling functions with arguments

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ab1aac79483249a9c1ebfc41706f2