### PR TITLE
Add unary negation support

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -39,7 +39,8 @@ typedef enum {
 
 typedef enum {
     UNOP_ADDR,
-    UNOP_DEREF
+    UNOP_DEREF,
+    UNOP_NEG
 } unop_t;
 
 struct expr;

--- a/src/parser.c
+++ b/src/parser.c
@@ -67,6 +67,12 @@ static expr_t *parse_primary(parser_t *p)
         if (!op)
             return NULL;
         return ast_make_unary(UNOP_ADDR, op, op_tok->line, op_tok->column);
+    } else if (match(p, TOK_MINUS)) {
+        token_t *op_tok = &p->tokens[p->pos - 1];
+        expr_t *op = parse_primary(p);
+        if (!op)
+            return NULL;
+        return ast_make_unary(UNOP_NEG, op, op_tok->line, op_tok->column);
     }
 
     if (match(p, TOK_NUMBER)) {

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -260,6 +260,17 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
             if (out)
                 *out = ir_build_addr(ir, sym->name);
             return TYPE_PTR;
+        } else if (expr->unary.op == UNOP_NEG) {
+            ir_value_t val;
+            if (check_expr(expr->unary.operand, vars, funcs, ir, &val) == TYPE_INT) {
+                if (out) {
+                    ir_value_t zero = ir_build_const(ir, 0);
+                    *out = ir_build_binop(ir, IR_SUB, zero, val);
+                }
+                return TYPE_INT;
+            }
+            set_error(expr->unary.operand->line, expr->unary.operand->column);
+            return TYPE_UNKNOWN;
         }
         return TYPE_UNKNOWN;
     case EXPR_IDENT: {

--- a/tests/fixtures/neg_constant.c
+++ b/tests/fixtures/neg_constant.c
@@ -1,0 +1,3 @@
+int main() {
+    return -5;
+}

--- a/tests/fixtures/neg_constant.s
+++ b/tests/fixtures/neg_constant.s
@@ -1,0 +1,6 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $-5, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/neg_var.c
+++ b/tests/fixtures/neg_var.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 3;
+    return -x;
+}

--- a/tests/fixtures/neg_var.s
+++ b/tests/fixtures/neg_var.s
@@ -1,0 +1,8 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $3, %eax
+    movl %eax, x
+    movl $-3, %eax
+    movl %eax, %eax
+    ret

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -115,6 +115,22 @@ static void test_parser_var_decl_init(void)
     lexer_free_tokens(toks, count);
 }
 
+static void test_parser_unary_neg(void)
+{
+    const char *src = "-5";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    expr_t *expr = parser_parse_expr(&p);
+    ASSERT(expr);
+    ASSERT(expr->kind == EXPR_UNARY);
+    ASSERT(expr->unary.op == UNOP_NEG);
+    ASSERT(expr->unary.operand->kind == EXPR_NUMBER &&
+           strcmp(expr->unary.operand->number.value, "5") == 0);
+    ast_free_expr(expr);
+    lexer_free_tokens(toks, count);
+}
+
 static void test_parser_func(void)
 {
     const char *src = "int main() { return 0; }";
@@ -157,6 +173,7 @@ int main(void)
     test_parser_stmt_return();
     test_parser_stmt_return_void();
     test_parser_var_decl_init();
+    test_parser_unary_neg();
     test_parser_func();
     test_parser_block();
     if (failures == 0) {


### PR DESCRIPTION
## Summary
- support unary minus via new `UNOP_NEG`
- parse unary negation in the parser
- lower negation to `IR_SUB` from zero during semantic analysis
- add unit test for unary minus
- add integration fixtures for negative constants and unary negation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685abe3dca7c8324b701d3c4b43f4e5b