### PR TITLE
Add support for global variable initializers

### DIFF
--- a/include/ir.h
+++ b/include/ir.h
@@ -81,6 +81,6 @@ void ir_build_br(ir_builder_t *b, const char *label);
 void ir_build_bcond(ir_builder_t *b, ir_value_t cond, const char *label);
 void ir_build_label(ir_builder_t *b, const char *label);
 ir_value_t ir_build_string(ir_builder_t *b, const char *data);
-void ir_build_glob_var(ir_builder_t *b, const char *name);
+void ir_build_glob_var(ir_builder_t *b, const char *name, int value);
 
 #endif /* VC_IR_H */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -266,7 +266,7 @@ void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x64)
             }
             fprintf(out, "%s:\n", ins->name);
             if (ins->op == IR_GLOB_VAR)
-                fprintf(out, "    %s 0\n", size_directive);
+                fprintf(out, "    %s %d\n", size_directive, ins->imm);
             else
                 fprintf(out, "    .asciz \"%s\"\n", ins->data);
         }

--- a/src/ir.c
+++ b/src/ir.c
@@ -235,12 +235,13 @@ void ir_build_label(ir_builder_t *b, const char *label)
     ins->name = dup_string(label ? label : "");
 }
 
-void ir_build_glob_var(ir_builder_t *b, const char *name)
+void ir_build_glob_var(ir_builder_t *b, const char *name, int value)
 {
     ir_instr_t *ins = append_instr(b);
     if (!ins)
         return;
     ins->op = IR_GLOB_VAR;
     ins->name = dup_string(name ? name : "");
+    ins->imm = value;
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -644,6 +644,22 @@ int parser_parse_toplevel(parser_t *p, func_t **out_func, stmt_t **out_global)
             *out_global = ast_make_var_decl(id->lexeme, t, NULL,
                                            tok->line, tok->column);
         return *out_global != NULL;
+    } else if (next && next->type == TOK_ASSIGN) {
+        if (t == TYPE_VOID) {
+            p->pos = save;
+            return 0;
+        }
+        p->pos++; /* consume '=' */
+        expr_t *init = parser_parse_expr(p);
+        if (!init || !match(p, TOK_SEMI)) {
+            ast_free_expr(init);
+            p->pos = save;
+            return 0;
+        }
+        if (out_global)
+            *out_global = ast_make_var_decl(id->lexeme, t, init,
+                                           tok->line, tok->column);
+        return *out_global != NULL;
     }
 
     p->pos = save;

--- a/tests/fixtures/global_init.c
+++ b/tests/fixtures/global_init.c
@@ -1,0 +1,4 @@
+int x = 5;
+int main() {
+    return x;
+}

--- a/tests/fixtures/global_init.s
+++ b/tests/fixtures/global_init.s
@@ -1,0 +1,10 @@
+.data
+x:
+    .long 5
+.text
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl x, %eax
+    movl %eax, %eax
+    ret


### PR DESCRIPTION
## Summary
- allow `parser_parse_toplevel` to handle global initializers
- evaluate constant initializers in `check_global`
- store initializer values in `IR_GLOB_VAR` and emit them in `.data`
- add regression tests for initialized globals

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ac03a15988324b2fd6f5b161942d3