### PR TITLE
Enhance parser error messages

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -31,7 +31,10 @@ expr_t *parser_parse_expr(parser_t *p);
 /* Returns non-zero if the parser has reached EOF */
 int parser_is_eof(parser_t *p);
 
-/* Print a parser error message with source location */
-void parser_print_error(parser_t *p, const char *msg);
+/* Print a parser error message showing the unexpected token and a list of
+ * expected tokens. The expected token array may be NULL if there are none. */
+void parser_print_error(parser_t *p,
+                        const token_type_t *expected,
+                        size_t expected_count);
 
 #endif /* VC_PARSER_H */

--- a/src/main.c
+++ b/src/main.c
@@ -153,7 +153,8 @@ int main(int argc, char **argv)
         func_t *fn = NULL;
         stmt_t *g = NULL;
         if (!parser_parse_toplevel(&parser, &fn, &g)) {
-            parser_print_error(&parser, "Parse error");
+            token_type_t expected[] = { TOK_KW_INT, TOK_KW_VOID };
+            parser_print_error(&parser, expected, 2);
             ok = 0;
             break;
         }

--- a/src/parser.c
+++ b/src/parser.c
@@ -32,15 +32,69 @@ int parser_is_eof(parser_t *p)
     return !tok || tok->type == TOK_EOF;
 }
 
-void parser_print_error(parser_t *p, const char *msg)
+static const char *token_name(token_type_t type)
+{
+    switch (type) {
+    case TOK_EOF: return "end of file";
+    case TOK_IDENT: return "identifier";
+    case TOK_NUMBER: return "number";
+    case TOK_STRING: return "string";
+    case TOK_CHAR: return "character";
+    case TOK_KW_INT: return "\"int\"";
+    case TOK_KW_VOID: return "\"void\"";
+    case TOK_KW_RETURN: return "\"return\"";
+    case TOK_KW_IF: return "\"if\"";
+    case TOK_KW_ELSE: return "\"else\"";
+    case TOK_KW_WHILE: return "\"while\"";
+    case TOK_KW_FOR: return "\"for\"";
+    case TOK_KW_BREAK: return "\"break\"";
+    case TOK_KW_CONTINUE: return "\"continue\"";
+    case TOK_LPAREN: return "'('";
+    case TOK_RPAREN: return "')'";
+    case TOK_LBRACE: return "'{'";
+    case TOK_RBRACE: return "'}'";
+    case TOK_SEMI: return "';'";
+    case TOK_COMMA: return "','";
+    case TOK_PLUS: return "'+'";
+    case TOK_MINUS: return "'-'";
+    case TOK_AMP: return "'&'";
+    case TOK_STAR: return "'*'";
+    case TOK_SLASH: return "'/'";
+    case TOK_ASSIGN: return "'='";
+    case TOK_EQ: return "'=='";
+    case TOK_NEQ: return "'!='";
+    case TOK_LT: return "'<'";
+    case TOK_GT: return "'>'";
+    case TOK_LE: return "'<='";
+    case TOK_GE: return "'>='";
+    case TOK_LBRACKET: return "'['";
+    case TOK_RBRACKET: return "']'";
+    case TOK_UNKNOWN: return "unknown";
+    }
+    return "unknown";
+}
+
+void parser_print_error(parser_t *p, const token_type_t *expected,
+                        size_t expected_count)
 {
     token_t *tok = peek(p);
     if (tok) {
-        fprintf(stderr, "%s at line %zu, column %zu\n",
-                msg, tok->line, tok->column);
+        fprintf(stderr, "Unexpected token '%s' at line %zu, column %zu",
+                tok->lexeme, tok->line, tok->column);
     } else {
-        fprintf(stderr, "%s at end of file\n", msg);
+        fprintf(stderr, "Unexpected end of file");
     }
+
+    if (expected_count > 0) {
+        fprintf(stderr, ", expected ");
+        for (size_t i = 0; i < expected_count; i++) {
+            fprintf(stderr, "%s", token_name(expected[i]));
+            if (i + 1 < expected_count)
+                fprintf(stderr, ", ");
+        }
+    }
+
+    fprintf(stderr, "\n");
 }
 
 /* Forward declarations */

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -23,7 +23,7 @@ set +e
 "$BINARY" -o "$out" "$DIR/invalid/parse_error.c" 2> "$err"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "line" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Unexpected token" "$err" || ! grep -q "expected" "$err"; then
     echo "Test parse_error failed"
     fail=1
 fi


### PR DESCRIPTION
## Summary
- improve `parser_print_error` to display unexpected token and expected tokens
- update `main` to use the new API
- adjust test harness to look for the new message

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685accebe2908324b43c8f51aa2fd7fe