### PR TITLE
Add -O optimization flag

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -266,6 +266,7 @@ The compiler supports the following options:
 - `--no-dce` – disable dead code elimination.
 - `--x86-64` – generate 64‑bit x86 assembly.
 - `--dump-ir` – print the generated assembly to stdout instead of creating a file.
+- `-O<N>` – set optimization level (0 disables all passes).
 
 Use `vc -o out.s source.c` to compile a file, or `vc --dump-ir source.c` to
 print the output to the terminal.
@@ -277,7 +278,7 @@ Example source files can be found under `tests/fixtures`. The simplest is
 optimizations disabled and request 64‑bit assembly like so:
 
 ```sh
-vc --no-fold --no-dce --x86-64 -o simple_add.s tests/fixtures/simple_add.c
+vc -O0 --x86-64 -o simple_add.s tests/fixtures/simple_add.c
 ```
 
 The generated file `simple_add.s` should match

--- a/include/opt.h
+++ b/include/opt.h
@@ -4,6 +4,7 @@
 #include "ir.h"
 
 typedef struct {
+    int opt_level;     /* numeric optimization level */
     int fold_constants; /* enable constant folding */
     int dead_code;      /* enable dead code elimination */
     int const_prop;     /* enable store/load constant propagation */

--- a/man/vc.1
+++ b/man/vc.1
@@ -21,6 +21,9 @@ Display usage information and exit.
 .BR -v "," \fB--version\fR
 Print version information and exit.
 .TP
+.B \-O\fIN\fR
+Set optimization level (0 disables all optimizations).
+.TP
 .B --no-fold
 Disable constant folding optimization.
 .TP

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@ static void print_usage(const char *prog)
     printf("Usage: %s [options] <source>\n", prog);
     printf("Options:\n");
     printf("  -o, --output <file>  Output path\n");
+    printf("  -O<N>               Optimization level (0-3)\n");
     printf("  -h, --help           Display this help and exit\n");
     printf("  -v, --version        Print version information and exit\n");
     printf("      --no-fold        Disable constant folding\n");
@@ -72,11 +73,11 @@ int main(int argc, char **argv)
 
     char *output = NULL;
     int opt;
-    opt_config_t opt_cfg = {1, 1, 1};
+    opt_config_t opt_cfg = {1, 1, 1, 1};
     int use_x86_64 = 0;
     int dump_ir = 0;
 
-    while ((opt = getopt_long(argc, argv, "hvo:", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hvo:O:", long_opts, NULL)) != -1) {
         switch (opt) {
         case 'h':
             print_usage(argv[0]);
@@ -86,6 +87,18 @@ int main(int argc, char **argv)
             return 0;
         case 'o':
             output = optarg;
+            break;
+        case 'O':
+            opt_cfg.opt_level = atoi(optarg);
+            if (opt_cfg.opt_level <= 0) {
+                opt_cfg.fold_constants = 0;
+                opt_cfg.dead_code = 0;
+                opt_cfg.const_prop = 0;
+            } else {
+                opt_cfg.fold_constants = 1;
+                opt_cfg.dead_code = 1;
+                opt_cfg.const_prop = 1;
+            }
             break;
         case 1:
             opt_cfg.fold_constants = 0;

--- a/src/opt.c
+++ b/src/opt.c
@@ -293,7 +293,7 @@ static void dead_code_elim(ir_builder_t *ir)
 
 void opt_run(ir_builder_t *ir, const opt_config_t *cfg)
 {
-    opt_config_t def = {1, 1, 1};
+    opt_config_t def = {1, 1, 1, 1};
     const opt_config_t *c = cfg ? cfg : &def;
     if (c->const_prop)
         propagate_load_consts(ir);

--- a/tests/fixtures/const_load_O0.s
+++ b/tests/fixtures/const_load_O0.s
@@ -1,0 +1,10 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $5, %eax
+    movl %eax, x
+    movl x, %eax
+    movl %eax, y
+    movl y, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/simple_add_O0.s
+++ b/tests/fixtures/simple_add_O0.s
@@ -1,0 +1,12 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $1, %eax
+    movl $2, %ebx
+    movl $3, %ecx
+    movl %ebx, %edx
+    imull %ecx, %edx
+    movl %eax, %ecx
+    addl %edx, %ecx
+    movl %ecx, %eax
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,6 +16,19 @@ for cfile in "$DIR"/fixtures/*.c; do
     rm -f "$out"
 done
 
+# verify -O0 disables all optimizations for selected fixtures
+for o0asm in "$DIR"/fixtures/*_O0.s; do
+    base=$(basename "$o0asm" _O0.s)
+    cfile="$DIR/fixtures/$base.c"
+    out=$(mktemp)
+    "$BINARY" -O0 -o "$out" "$cfile"
+    if ! diff -u "$o0asm" "$out"; then
+        echo "Test O0_$base failed"
+        fail=1
+    fi
+    rm -f "$out"
+done
+
 # negative test for parse error message
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- extend `opt_config_t` with an `opt_level` field
- parse `-O` options in the driver
- generate unoptimized output with `-O0`
- document optimization level flag in docs and man page
- test `-O0` disables all optimizations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ace9f677883249600edb8b07fdbf3