### PR TITLE
Add fixtures and lexer/parser tests for new grammar

### DIFF
--- a/tests/fixtures/global_init_expr.c
+++ b/tests/fixtures/global_init_expr.c
@@ -1,0 +1,4 @@
+int y = 1 + 2;
+int main() {
+    return y;
+}

--- a/tests/fixtures/global_init_expr.s
+++ b/tests/fixtures/global_init_expr.s
@@ -1,0 +1,10 @@
+.data
+y:
+    .long 3
+.text
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl y, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/pointer_var_add.c
+++ b/tests/fixtures/pointer_var_add.c
@@ -1,0 +1,8 @@
+int main() {
+    int arr[2];
+    int i = 1;
+    int *p = arr;
+    p = p + i;
+    arr[1] = 4;
+    return *p;
+}

--- a/tests/fixtures/pointer_var_add.s
+++ b/tests/fixtures/pointer_var_add.s
@@ -1,0 +1,20 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $1, %eax
+    movl %eax, i
+    movl $arr, %eax
+    movl %eax, p
+    movl p, %eax
+    movl $1, %ebx
+    movl %ebx, %ecx
+    imull $4, %ecx
+    addl %eax, %ecx
+    movl %ecx, p
+    movl $1, %ecx
+    movl $4, %ebx
+    movl %ebx, arr(,%ecx,4)
+    movl p, %ebx
+    movl (%ebx), %ecx
+    movl %ecx, %eax
+    ret

--- a/tests/fixtures/unary_minus_expr.c
+++ b/tests/fixtures/unary_minus_expr.c
@@ -1,0 +1,3 @@
+int main() {
+    return -(1 + 2);
+}

--- a/tests/fixtures/unary_minus_expr.s
+++ b/tests/fixtures/unary_minus_expr.s
@@ -1,0 +1,6 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $-3, %eax
+    movl %eax, %eax
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,6 +8,7 @@ for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
     expect="$DIR/fixtures/$base.s"
     out=$(mktemp)
+    echo "Running fixture $base"
     "$BINARY" -o "$out" "$cfile"
     if ! diff -u "$expect" "$out"; then
         echo "Test $base failed"


### PR DESCRIPTION
## Summary
- add new fixtures testing pointer arithmetic with variables, constant global initializers and unary minus expressions
- show fixture progress in `run_tests.sh`
- extend lexer/parser unit tests with pointer arithmetic, global initialisers and complex unary minus

## Testing
- `make test`
- `gcc -Wall -Wextra -std=c99 -Iinclude tests/unit/test_lexer_parser.c src/lexer.c src/parser.c src/ast.c src/semantic.c src/ir.c src/codegen.c src/regalloc.c src/opt.c -o tests/unit/test_lexer_parser`
- `tests/unit/test_lexer_parser`

------
https://chatgpt.com/codex/tasks/task_e_685acea79338832481b336162267a1ab