### PR TITLE
Add IR dumping flag and rename dump-ir

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ vc -o out.s source.c
 ```
 
 To print the generated assembly to stdout instead of creating a file,
-pass `--dump-ir`:
+pass `--dump-asm`:
 
 ```sh
-vc --dump-ir source.c
+vc --dump-asm source.c
 ```
 
 ## Installation

--- a/docs/building.md
+++ b/docs/building.md
@@ -26,7 +26,7 @@ This disables any NetBSD specific extensions.
 default without this flag is 32-bit code.
 
 To dump the generated assembly to stdout instead of creating a file, use
-`--dump-ir`. When this flag is given the `-o` option is not required.
+`--dump-asm`. When this flag is given the `-o` option is not required.
 
 ## Additional build steps
 

--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -336,11 +336,12 @@ The compiler supports the following options:
 - `--no-dce` – disable dead code elimination.
 - `--no-cprop` – disable constant propagation.
 - `--x86-64` – generate 64‑bit x86 assembly.
-- `--dump-ir` – print the generated assembly to stdout instead of creating a file.
+- `--dump-asm` – print the generated assembly to stdout instead of creating a file.
+- `--dump-ir` – print the IR to stdout before code generation.
 - `-O<N>` – set optimization level (0 disables all passes).
 
-Use `vc -o out.s source.c` to compile a file, or `vc --dump-ir source.c` to
-print the output to the terminal.
+Use `vc -o out.s source.c` to compile a file, or `vc --dump-asm source.c` to
+print the assembly to the terminal.
 
 ## Compiling a Simple Program
 

--- a/include/ir.h
+++ b/include/ir.h
@@ -90,4 +90,7 @@ void ir_build_label(ir_builder_t *b, const char *label);
 ir_value_t ir_build_string(ir_builder_t *b, const char *data);
 void ir_build_glob_var(ir_builder_t *b, const char *name, int value);
 
+/* Generate a string representation of the IR. Caller must free. */
+char *ir_to_string(ir_builder_t *b);
+
 #endif /* VC_IR_H */

--- a/man/vc.1
+++ b/man/vc.1
@@ -39,8 +39,11 @@ Disable constant propagation.
 .B --x86-64
 Generate x86-64 assembly instead of 32-bit.
 .TP
-.B --dump-ir
+.B --dump-asm
 Print generated assembly to stdout rather than creating a file.
+.TP
+.B --dump-ir
+Print IR to stdout before generating assembly.
 .SH EXAMPLES
 Compile a source file to \fIout.s\fR:
 .PP
@@ -48,6 +51,6 @@ Compile a source file to \fIout.s\fR:
 .PP
 Print the generated assembly:
 .PP
-.B vc --dump-ir source.c
+.B vc --dump-asm source.c
 .SH SEE ALSO
 README.md, docs/vcdoc.md

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -43,14 +43,23 @@ if [ $ret -eq 0 ] || ! grep -q "Unexpected token" "$err" || ! grep -q "expected"
 fi
 rm -f "$out" "$err"
 
-# test --dump-ir option
+# test --dump-asm option
 dump_out=$(mktemp)
-"$BINARY" --dump-ir "$DIR/fixtures/simple_add.c" > "$dump_out"
+"$BINARY" --dump-asm "$DIR/fixtures/simple_add.c" > "$dump_out"
 if ! grep -q "movl \$7, %eax" "$dump_out"; then
-    echo "Test dump_ir failed"
+    echo "Test dump_asm failed"
     fail=1
 fi
 rm -f "$dump_out"
+
+# test --dump-ir option
+ir_out=$(mktemp)
+"$BINARY" --dump-ir "$DIR/fixtures/simple_add.c" > "$ir_out"
+if ! grep -q "IR_CONST" "$ir_out"; then
+    echo "Test dump_ir failed"
+    fail=1
+fi
+rm -f "$ir_out"
 
 # test --no-cprop option
 cprop_out=$(mktemp)


### PR DESCRIPTION
## Summary
- rename `--dump-ir` to `--dump-asm` in the CLI and docs
- implement new `--dump-ir` to emit a textual representation of the IR
- document both flags in README, docs, and man page
- update tests for the renamed option and add a new test for `--dump-ir`

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ae81b001c83249bcd51f293343abd