### PR TITLE
Add invalid variable test

### DIFF
--- a/tests/invalid/undef_var.c
+++ b/tests/invalid/undef_var.c
@@ -1,0 +1,1 @@
+int main() { return x; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -43,6 +43,19 @@ if [ $ret -eq 0 ] || ! grep -q "Unexpected token" "$err" || ! grep -q "expected"
 fi
 rm -f "$out" "$err"
 
+# negative test for undefined variable error message
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "$out" "$DIR/invalid/undef_var.c" 2> "$err"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Semantic error" "$err"; then
+    echo "Test undef_var failed"
+    fail=1
+fi
+rm -f "$out" "$err"
+
 # test --dump-asm option
 dump_out=$(mktemp)
 "$BINARY" --dump-asm "$DIR/fixtures/simple_add.c" > "$dump_out"


### PR DESCRIPTION
## Summary
- add a new invalid input referring to an undeclared variable
- extend `run_tests.sh` to expect a semantic error when building this new file

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685afa1f78a48324a146078a211164ff