### PR TITLE
Centralize common utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OPTFLAGS ?=
 BIN = vc
 # Core compiler sources
 CORE_SRC = src/main.c src/lexer.c src/ast.c src/parser.c src/semantic.c \
-    src/ir.c src/codegen.c src/regalloc.c src/strbuf.c
+    src/ir.c src/codegen.c src/regalloc.c src/strbuf.c src/util.c
 # Optional optimization sources
 OPT_SRC = src/opt.c
 # Additional sources can be specified by the user
@@ -12,7 +12,8 @@ EXTRA_SRC ?=
 # Final source list
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 HDR = include/token.h include/ast.h include/parser.h include/semantic.h \
-    include/ir.h include/opt.h include/codegen.h include/strbuf.h
+    include/ir.h include/opt.h include/codegen.h include/strbuf.h \
+    include/util.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man

--- a/include/util.h
+++ b/include/util.h
@@ -1,0 +1,7 @@
+#ifndef VC_UTIL_H
+#define VC_UTIL_H
+
+char *vc_strdup(const char *s);
+char *vc_read_file(const char *path);
+
+#endif /* VC_UTIL_H */

--- a/src/ast.c
+++ b/src/ast.c
@@ -1,16 +1,6 @@
 #include <stdlib.h>
-#include <string.h>
 #include "ast.h"
-
-static char *dup_string(const char *s)
-{
-    size_t len = strlen(s);
-    char *out = malloc(len + 1);
-    if (!out)
-        return NULL;
-    memcpy(out, s, len + 1);
-    return out;
-}
+#include "util.h"
 /* Constructors for expressions */
 expr_t *ast_make_number(const char *value, size_t line, size_t column)
 {
@@ -20,7 +10,7 @@ expr_t *ast_make_number(const char *value, size_t line, size_t column)
     expr->kind = EXPR_NUMBER;
     expr->line = line;
     expr->column = column;
-    expr->number.value = dup_string(value ? value : "");
+    expr->number.value = vc_strdup(value ? value : "");
     if (!expr->number.value) {
         free(expr);
         return NULL;
@@ -36,7 +26,7 @@ expr_t *ast_make_ident(const char *name, size_t line, size_t column)
     expr->kind = EXPR_IDENT;
     expr->line = line;
     expr->column = column;
-    expr->ident.name = dup_string(name ? name : "");
+    expr->ident.name = vc_strdup(name ? name : "");
     if (!expr->ident.name) {
         free(expr);
         return NULL;
@@ -52,7 +42,7 @@ expr_t *ast_make_string(const char *value, size_t line, size_t column)
     expr->kind = EXPR_STRING;
     expr->line = line;
     expr->column = column;
-    expr->string.value = dup_string(value ? value : "");
+    expr->string.value = vc_strdup(value ? value : "");
     if (!expr->string.value) {
         free(expr);
         return NULL;
@@ -110,7 +100,7 @@ expr_t *ast_make_assign(const char *name, expr_t *value,
     expr->kind = EXPR_ASSIGN;
     expr->line = line;
     expr->column = column;
-    expr->assign.name = dup_string(name ? name : "");
+    expr->assign.name = vc_strdup(name ? name : "");
     if (!expr->assign.name) {
         free(expr);
         return NULL;
@@ -157,7 +147,7 @@ expr_t *ast_make_call(const char *name, expr_t **args, size_t arg_count,
     expr->kind = EXPR_CALL;
     expr->line = line;
     expr->column = column;
-    expr->call.name = dup_string(name ? name : "");
+    expr->call.name = vc_strdup(name ? name : "");
     if (!expr->call.name) {
         free(expr);
         return NULL;
@@ -202,7 +192,7 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
     stmt->kind = STMT_VAR_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->var_decl.name = dup_string(name ? name : "");
+    stmt->var_decl.name = vc_strdup(name ? name : "");
     if (!stmt->var_decl.name) {
         free(stmt);
         return NULL;
@@ -318,7 +308,7 @@ func_t *ast_make_func(const char *name, type_kind_t ret_type,
     func_t *fn = malloc(sizeof(*fn));
     if (!fn)
         return NULL;
-    fn->name = dup_string(name ? name : "");
+    fn->name = vc_strdup(name ? name : "");
     if (!fn->name) {
         free(fn);
         return NULL;
@@ -335,7 +325,7 @@ func_t *ast_make_func(const char *name, type_kind_t ret_type,
         return NULL;
     }
     for (size_t i = 0; i < param_count; i++) {
-        fn->param_names[i] = dup_string(param_names[i] ? param_names[i] : "");
+        fn->param_names[i] = vc_strdup(param_names[i] ? param_names[i] : "");
         fn->param_types[i] = param_types[i];
         if (!fn->param_names[i]) {
             for (size_t j = 0; j < i; j++)

--- a/src/ir.c
+++ b/src/ir.c
@@ -1,19 +1,10 @@
 #include <stdlib.h>
-#include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include "ir.h"
 #include "strbuf.h"
+#include "util.h"
 
-static char *dup_string(const char *s)
-{
-    size_t len = strlen(s);
-    char *out = malloc(len + 1);
-    if (!out)
-        return NULL;
-    memcpy(out, s, len + 1);
-    return out;
-}
 
 void ir_builder_init(ir_builder_t *b)
 {
@@ -71,8 +62,8 @@ ir_value_t ir_build_string(ir_builder_t *b, const char *str)
     ins->dest = b->next_value_id++;
     char label[32];
     snprintf(label, sizeof(label), "Lstr%d", ins->dest);
-    ins->name = dup_string(label);
-    ins->data = dup_string(str ? str : "");
+    ins->name = vc_strdup(label);
+    ins->data = vc_strdup(str ? str : "");
     return (ir_value_t){ins->dest};
 }
 
@@ -83,7 +74,7 @@ ir_value_t ir_build_load(ir_builder_t *b, const char *name)
         return (ir_value_t){0};
     ins->op = IR_LOAD;
     ins->dest = b->next_value_id++;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
     return (ir_value_t){ins->dest};
 }
 
@@ -94,7 +85,7 @@ void ir_build_store(ir_builder_t *b, const char *name, ir_value_t val)
         return;
     ins->op = IR_STORE;
     ins->src1 = val.id;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
 }
 
 ir_value_t ir_build_load_param(ir_builder_t *b, int index)
@@ -125,7 +116,7 @@ ir_value_t ir_build_addr(ir_builder_t *b, const char *name)
         return (ir_value_t){0};
     ins->op = IR_ADDR;
     ins->dest = b->next_value_id++;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
     return (ir_value_t){ins->dest};
 }
 
@@ -158,7 +149,7 @@ ir_value_t ir_build_load_idx(ir_builder_t *b, const char *name, ir_value_t idx)
     ins->op = IR_LOAD_IDX;
     ins->dest = b->next_value_id++;
     ins->src1 = idx.id;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
     return (ir_value_t){ins->dest};
 }
 
@@ -171,7 +162,7 @@ void ir_build_store_idx(ir_builder_t *b, const char *name, ir_value_t idx,
     ins->op = IR_STORE_IDX;
     ins->src1 = idx.id;
     ins->src2 = val.id;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
 }
 
 ir_value_t ir_build_binop(ir_builder_t *b, ir_op_t op, ir_value_t left, ir_value_t right)
@@ -211,7 +202,7 @@ ir_value_t ir_build_call(ir_builder_t *b, const char *name, size_t arg_count)
         return (ir_value_t){0};
     ins->op = IR_CALL;
     ins->dest = b->next_value_id++;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
     ins->imm = (int)arg_count;
     return (ir_value_t){ins->dest};
 }
@@ -222,7 +213,7 @@ void ir_build_func_begin(ir_builder_t *b, const char *name)
     if (!ins)
         return;
     ins->op = IR_FUNC_BEGIN;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
 }
 
 void ir_build_func_end(ir_builder_t *b)
@@ -239,7 +230,7 @@ void ir_build_br(ir_builder_t *b, const char *label)
     if (!ins)
         return;
     ins->op = IR_BR;
-    ins->name = dup_string(label ? label : "");
+    ins->name = vc_strdup(label ? label : "");
 }
 
 void ir_build_bcond(ir_builder_t *b, ir_value_t cond, const char *label)
@@ -249,7 +240,7 @@ void ir_build_bcond(ir_builder_t *b, ir_value_t cond, const char *label)
         return;
     ins->op = IR_BCOND;
     ins->src1 = cond.id;
-    ins->name = dup_string(label ? label : "");
+    ins->name = vc_strdup(label ? label : "");
 }
 
 void ir_build_label(ir_builder_t *b, const char *label)
@@ -258,7 +249,7 @@ void ir_build_label(ir_builder_t *b, const char *label)
     if (!ins)
         return;
     ins->op = IR_LABEL;
-    ins->name = dup_string(label ? label : "");
+    ins->name = vc_strdup(label ? label : "");
 }
 
 void ir_build_glob_var(ir_builder_t *b, const char *name, int value)
@@ -267,7 +258,7 @@ void ir_build_glob_var(ir_builder_t *b, const char *name, int value)
     if (!ins)
         return;
     ins->op = IR_GLOB_VAR;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
     ins->imm = value;
 }
 
@@ -278,7 +269,7 @@ void ir_build_glob_array(ir_builder_t *b, const char *name,
     if (!ins)
         return;
     ins->op = IR_GLOB_ARRAY;
-    ins->name = dup_string(name ? name : "");
+    ins->name = vc_strdup(name ? name : "");
     ins->imm = (int)count;
     if (count) {
         int *vals = malloc(count * sizeof(int));

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <getopt.h>
+#include "util.h"
 #include "token.h"
 #include "parser.h"
 #include "semantic.h"
@@ -27,38 +27,6 @@ static void print_usage(const char *prog)
     printf("      --dump-ir        Print IR to stdout and exit\n");
 }
 
-static char *read_file(const char *path)
-{
-    FILE *f = fopen(path, "rb");
-    if (!f)
-        return NULL;
-    if (fseek(f, 0, SEEK_END) != 0) {
-        fclose(f);
-        return NULL;
-    }
-    long len = ftell(f);
-    if (len < 0) {
-        fclose(f);
-        return NULL;
-    }
-    if (fseek(f, 0, SEEK_SET) != 0) {
-        fclose(f);
-        return NULL;
-    }
-    char *buf = malloc((size_t)len + 1);
-    if (!buf) {
-        fclose(f);
-        return NULL;
-    }
-    if (fread(buf, 1, (size_t)len, f) != (size_t)len) {
-        fclose(f);
-        free(buf);
-        return NULL;
-    }
-    buf[len] = '\0';
-    fclose(f);
-    return buf;
-}
 
 int main(int argc, char **argv)
 {
@@ -143,9 +111,9 @@ int main(int argc, char **argv)
 
     const char *source = argv[optind];
 
-    char *src_text = read_file(source);
+    char *src_text = vc_read_file(source);
     if (!src_text) {
-        perror("read_file");
+        perror("vc_read_file");
         return 1;
     }
 

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -2,16 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "semantic.h"
-
-static char *dup_string(const char *s)
-{
-    size_t len = strlen(s);
-    char *out = malloc(len + 1);
-    if (!out)
-        return NULL;
-    memcpy(out, s, len + 1);
-    return out;
-}
+#include "util.h"
 
 static int is_intlike(type_kind_t t)
 {
@@ -95,7 +86,7 @@ int symtable_add(symtable_t *table, const char *name, type_kind_t type,
     symbol_t *sym = malloc(sizeof(*sym));
     if (!sym)
         return 0;
-    sym->name = dup_string(name ? name : "");
+    sym->name = vc_strdup(name ? name : "");
     if (!sym->name) {
         free(sym);
         return 0;
@@ -118,7 +109,7 @@ int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
     symbol_t *sym = malloc(sizeof(*sym));
     if (!sym)
         return 0;
-    sym->name = dup_string(name ? name : "");
+    sym->name = vc_strdup(name ? name : "");
     if (!sym->name) {
         free(sym);
         return 0;
@@ -143,7 +134,7 @@ int symtable_add_global(symtable_t *table, const char *name, type_kind_t type,
     symbol_t *sym = malloc(sizeof(*sym));
     if (!sym)
         return 0;
-    sym->name = dup_string(name ? name : "");
+    sym->name = vc_strdup(name ? name : "");
     if (!sym->name) {
         free(sym);
         return 0;
@@ -166,7 +157,7 @@ int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
     symbol_t *sym = malloc(sizeof(*sym));
     if (!sym)
         return 0;
-    sym->name = dup_string(name ? name : "");
+    sym->name = vc_strdup(name ? name : "");
     if (!sym->name) {
         free(sym);
         return 0;

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,48 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "util.h"
+
+char *vc_strdup(const char *s)
+{
+    size_t len = strlen(s);
+    char *out = malloc(len + 1);
+    if (!out)
+        return NULL;
+    memcpy(out, s, len + 1);
+    return out;
+}
+
+char *vc_read_file(const char *path)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        return NULL;
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    long len = ftell(f);
+    if (len < 0) {
+        fclose(f);
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    char *buf = malloc((size_t)len + 1);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+    if (fread(buf, 1, (size_t)len, f) != (size_t)len) {
+        fclose(f);
+        free(buf);
+        return NULL;
+    }
+    buf[len] = '\0';
+    fclose(f);
+    return buf;
+}
+


### PR DESCRIPTION
## Summary
- add `util.c` and `util.h` with helper functions
- use `vc_strdup` in AST, IR and semantic code
- move `read_file` logic into `vc_read_file`
- compile util.c via Makefile

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685afdc2570483249d13f08b513b2d9a