### PR TITLE
Add CLI argument parsing module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OPTFLAGS ?=
 BIN = vc
 # Core compiler sources
 
-CORE_SRC = src/main.c src/lexer.c src/ast.c src/parser.c src/symtable.c src/parser_expr.c \
+CORE_SRC = src/main.c src/cli.c src/lexer.c src/ast.c src/parser.c src/symtable.c src/parser_expr.c \
            src/parser_stmt.c src/semantic.c src/ir.c src/codegen.c src/regalloc.c src/strbuf.c src/util.c
 
 # Optional optimization sources
@@ -15,7 +15,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 HDR = include/token.h include/ast.h include/parser.h include/symtable.h include/semantic.h \
     include/ir.h include/opt.h include/codegen.h include/strbuf.h \
-    include/util.h
+    include/util.h include/cli.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,0 +1,19 @@
+#ifndef VC_CLI_H
+#define VC_CLI_H
+
+#include "opt.h"
+
+/* Command line options parsed from argv */
+typedef struct {
+    char *output;       /* output file path */
+    opt_config_t opt_cfg; /* optimization configuration */
+    int use_x86_64;     /* enable 64-bit codegen */
+    int dump_asm;       /* dump assembly to stdout */
+    int dump_ir;        /* dump IR to stdout */
+    const char *source; /* input source file */
+} cli_options_t;
+
+/* Parse command line arguments. Returns 0 on success, non-zero on error. */
+int cli_parse_args(int argc, char **argv, cli_options_t *opts);
+
+#endif /* VC_CLI_H */


### PR DESCRIPTION
## Summary
- move command line parsing into new `cli` module
- update `main` to use `cli_parse_args`
- add new header and source files for CLI utilities
- update Makefile to compile new module

## Testing
- `make`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b20b1f4a8832480121250c6373728