### PR TITLE
Refactor register allocator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = vc
 # Core compiler sources
 
 CORE_SRC = src/main.c src/cli.c src/lexer.c src/ast.c src/parser.c src/symtable.c src/parser_expr.c \
-           src/parser_stmt.c src/semantic.c src/ir.c src/codegen.c src/regalloc.c src/strbuf.c src/util.c \
+           src/parser_stmt.c src/semantic.c src/ir.c src/codegen.c src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c \
            src/vector.c src/ir_dump.c
 
 # Optional optimization sources
@@ -16,7 +16,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 HDR = include/token.h include/ast.h include/parser.h include/symtable.h include/semantic.h \
     include/ir.h include/ir_dump.h include/opt.h include/codegen.h include/strbuf.h \
-    include/util.h include/cli.h include/vector.h
+    include/util.h include/cli.h include/vector.h include/regalloc_x86.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man

--- a/include/regalloc.h
+++ b/include/regalloc.h
@@ -15,10 +15,5 @@ void regalloc_run(ir_builder_t *ir, regalloc_t *ra);
 /* Free resources held by the allocator */
 void regalloc_free(regalloc_t *ra);
 
-/* Return physical register name for given index */
-const char *regalloc_reg_name(int idx);
-
-/* Select register naming for 64-bit or 32-bit mode. */
-void regalloc_set_x86_64(int enable);
 
 #endif /* VC_REGALLOC_H */

--- a/include/regalloc_x86.h
+++ b/include/regalloc_x86.h
@@ -1,0 +1,13 @@
+#ifndef VC_REGALLOC_X86_H
+#define VC_REGALLOC_X86_H
+
+/* Number of allocatable general purpose registers */
+#define REGALLOC_NUM_REGS 6
+
+/* Return physical register name for given index */
+const char *regalloc_reg_name(int idx);
+
+/* Select register naming for 64-bit or 32-bit mode. */
+void regalloc_set_x86_64(int enable);
+
+#endif /* VC_REGALLOC_X86_H */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -4,6 +4,7 @@
 #include <stdarg.h>
 #include "codegen.h"
 #include "regalloc.h"
+#include "regalloc_x86.h"
 #include "strbuf.h"
 
 

--- a/src/regalloc.c
+++ b/src/regalloc.c
@@ -1,30 +1,8 @@
 #include <stdlib.h>
 #include "regalloc.h"
+#include "regalloc_x86.h"
 
-#define NUM_REGS 6
-
-static int use_x86_64 = 0;
-
-static const char *phys_regs_32[NUM_REGS] = {
-    "%eax", "%ebx", "%ecx", "%edx", "%esi", "%edi"
-};
-
-static const char *phys_regs_64[NUM_REGS] = {
-    "%rax", "%rbx", "%rcx", "%rdx", "%rsi", "%rdi"
-};
-
-const char *regalloc_reg_name(int idx)
-{
-    const char **regs = use_x86_64 ? phys_regs_64 : phys_regs_32;
-    if (idx >= 0 && idx < NUM_REGS)
-        return regs[idx];
-    return use_x86_64 ? "%rax" : "%eax";
-}
-
-void regalloc_set_x86_64(int enable)
-{
-    use_x86_64 = enable ? 1 : 0;
-}
+#define NUM_REGS REGALLOC_NUM_REGS
 
 static int *compute_last_use(ir_builder_t *ir, int max_id)
 {

--- a/src/regalloc_x86.c
+++ b/src/regalloc_x86.c
@@ -1,0 +1,24 @@
+#include "regalloc_x86.h"
+
+static int use_x86_64 = 0;
+
+static const char *phys_regs_32[REGALLOC_NUM_REGS] = {
+    "%eax", "%ebx", "%ecx", "%edx", "%esi", "%edi"
+};
+
+static const char *phys_regs_64[REGALLOC_NUM_REGS] = {
+    "%rax", "%rbx", "%rcx", "%rdx", "%rsi", "%rdi"
+};
+
+const char *regalloc_reg_name(int idx)
+{
+    const char **regs = use_x86_64 ? phys_regs_64 : phys_regs_32;
+    if (idx >= 0 && idx < REGALLOC_NUM_REGS)
+        return regs[idx];
+    return use_x86_64 ? "%rax" : "%eax";
+}
+
+void regalloc_set_x86_64(int enable)
+{
+    use_x86_64 = enable ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- drop backend-specific declarations from `regalloc.h`
- introduce `regalloc_x86.c` and `regalloc_x86.h`
- move x86 register handling into the new module
- update build files and includes

## Testing
- `make`
- `tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b2633a38c83249a9dbc54c700c094