### PR TITLE
Add label generator module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BIN = vc
 
 CORE_SRC = src/main.c src/cli.c src/lexer.c src/ast.c src/parser.c src/symtable.c src/parser_expr.c \
            src/parser_stmt.c src/semantic.c src/ir.c src/codegen.c src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c \
-           src/vector.c src/ir_dump.c
+           src/vector.c src/ir_dump.c src/label.c
 
 # Optional optimization sources
 OPT_SRC = src/opt.c
@@ -16,7 +16,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 HDR = include/token.h include/ast.h include/parser.h include/symtable.h include/semantic.h \
     include/ir.h include/ir_dump.h include/opt.h include/codegen.h include/strbuf.h \
-    include/util.h include/cli.h include/vector.h include/regalloc_x86.h
+    include/util.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man

--- a/include/label.h
+++ b/include/label.h
@@ -1,0 +1,8 @@
+#ifndef VC_LABEL_H
+#define VC_LABEL_H
+
+void label_init(void);
+int label_next_id(void);
+void label_reset(void);
+
+#endif /* VC_LABEL_H */

--- a/src/label.c
+++ b/src/label.c
@@ -1,0 +1,18 @@
+#include "label.h"
+
+static int next_label_id = 0;
+
+void label_init(void)
+{
+    next_label_id = 0;
+}
+
+int label_next_id(void)
+{
+    return next_label_id++;
+}
+
+void label_reset(void)
+{
+    next_label_id = 0;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include "ir_dump.h"
 #include "opt.h"
 #include "codegen.h"
+#include "label.h"
 
 int main(int argc, char **argv)
 {
@@ -24,6 +25,8 @@ int main(int argc, char **argv)
     int use_x86_64 = cli.use_x86_64;
     int dump_asm = cli.dump_asm;
     int dump_ir = cli.dump_ir;
+
+    label_init();
 
     char *src_text = vc_read_file(source);
     if (!src_text) {
@@ -141,6 +144,8 @@ int main(int argc, char **argv)
     symtable_free(&globals);
     lexer_free_tokens(tokens, tok_count);
     free(src_text);
+
+    label_reset();
 
     if (ok) {
         if (dump_ir)

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -4,13 +4,13 @@
 #include "semantic.h"
 #include "symtable.h"
 #include "util.h"
+#include "label.h"
 
 static int is_intlike(type_kind_t t)
 {
     return t == TYPE_INT || t == TYPE_CHAR;
 }
 
-static int next_label_id = 0;
 
 static size_t error_line = 0;
 static size_t error_column = 0;
@@ -365,7 +365,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
             return 0;
         char else_label[32];
         char end_label[32];
-        int id = next_label_id++;
+        int id = label_next_id();
         snprintf(else_label, sizeof(else_label), "L%d_else", id);
         snprintf(end_label, sizeof(end_label), "L%d_end", id);
         const char *target = stmt->if_stmt.else_branch ? else_label : end_label;
@@ -387,7 +387,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         ir_value_t cond_val;
         char start_label[32];
         char end_label[32];
-        int id = next_label_id++;
+        int id = label_next_id();
         snprintf(start_label, sizeof(start_label), "L%d_start", id);
         snprintf(end_label, sizeof(end_label), "L%d_end", id);
         ir_build_label(ir, start_label);
@@ -406,7 +406,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         char start_label[32];
         char cond_label[32];
         char end_label[32];
-        int id = next_label_id++;
+        int id = label_next_id();
         snprintf(start_label, sizeof(start_label), "L%d_start", id);
         snprintf(cond_label, sizeof(cond_label), "L%d_cond", id);
         snprintf(end_label, sizeof(end_label), "L%d_end", id);
@@ -426,7 +426,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         ir_value_t cond_val;
         char start_label[32];
         char end_label[32];
-        int id = next_label_id++;
+        int id = label_next_id();
         snprintf(start_label, sizeof(start_label), "L%d_start", id);
         snprintf(end_label, sizeof(end_label), "L%d_end", id);
         if (check_expr(stmt->for_stmt.init, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)


### PR DESCRIPTION
## Summary
- add new `label` module for label ID generation
- replace direct label counter usage in `semantic.c`
- initialize and reset labels from `main.c`
- compile new files via updated Makefile

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b270d04188324b08e72e65bfee20f