### PR TITLE
Improve codegen function documentation

### DIFF
--- a/include/codegen.h
+++ b/include/codegen.h
@@ -11,12 +11,23 @@
 #include <stdio.h>
 #include "ir.h"
 
-/* Emit x86 assembly for the given IR builder to the specified stream.
- * Set `x86_64` to a non-zero value to generate 64-bit code. */
+/*
+ * Emit the full x86 assembly for `ir` to `out`.
+ *
+ * The function first outputs any IR global directives under a `.data`
+ * section. The instruction stream is then translated to x86 using the
+ * register allocator and written after an optional `.text` directive.
+ * Pass a non-zero `x86_64` to produce 64-bit instructions.
+ */
 void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x86_64);
 
-/* Generate an assembly string for the given IR. The caller must free the
- * returned buffer. Pass `x86_64` to select 64-bit output. */
+/*
+ * Convert the IR to an assembly string.
+ *
+ * Only the instruction stream is returned. Global data directives are
+ * omitted. The caller owns the returned buffer and must free it. Use
+ * `x86_64` to choose between 32- and 64-bit code generation.
+ */
 char *codegen_ir_to_string(ir_builder_t *ir, int x86_64);
 
 #endif /* VC_CODEGEN_H */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -220,6 +220,13 @@ static void emit_instr(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64)
     }
 }
 
+/*
+ * Translate the IR instruction stream to x86 and return it as a string.
+ *
+ * Register allocation is performed and each instruction is lowered by
+ * `emit_instr`. Global data directives are not included. The returned
+ * buffer is heap allocated and must be freed by the caller.
+ */
 char *codegen_ir_to_string(ir_builder_t *ir, int x64)
 {
     if (!ir)
@@ -237,6 +244,14 @@ char *codegen_ir_to_string(ir_builder_t *ir, int x64)
     return sb.data; /* caller takes ownership */
 }
 
+/*
+ * Emit the assembly representation of `ir` to the stream `out`.
+ *
+ * Global declarations are written first using the appropriate `.data`
+ * directives. The remaining instructions are lowered via
+ * `codegen_ir_to_string` and printed after an optional `.text` header.
+ * Set `x64` to enable 64-bit output.
+ */
 void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x64)
 {
     if (!out)


### PR DESCRIPTION
## Summary
- document how IR is lowered and where the output goes
- expand comments on `codegen_emit_x86` and `codegen_ir_to_string`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b39c064e88324aa7557a10dc52eb7