### PR TITLE
Add documentation comments for semantic checks and symbol table

### DIFF
--- a/include/semantic.h
+++ b/include/semantic.h
@@ -13,14 +13,20 @@
 #include "symtable.h"
 
 
-/* Type check helpers */
+/* Semantic validation helpers */
+/*
+ * Each function walks the AST and emits IR while checking types.
+ * A non-zero return value indicates success.
+ */
 type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                        ir_builder_t *ir, ir_value_t *out);
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                ir_builder_t *ir, type_kind_t func_ret_type,
                const char *break_label, const char *continue_label);
+/* Validate an entire function definition */
 int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
                ir_builder_t *ir);
+/* Validate a global variable declaration */
 int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir);
 
 #endif /* VC_SEMANTIC_H */

--- a/include/symtable.h
+++ b/include/symtable.h
@@ -29,16 +29,25 @@ typedef struct {
 } symtable_t;
 
 /* Initialize and free a symbol table */
+/*
+ * The table maintains two singly linked lists: one for the current scope and
+ * one for global symbols.  Insertion helpers add new entries to these lists and
+ * lookup helpers search through them.
+ */
 void symtable_init(symtable_t *table);
 void symtable_free(symtable_t *table);
 
 /* Add a symbol to the table. Returns non-zero on success. */
+/* Locals */
 int symtable_add(symtable_t *table, const char *name, type_kind_t type,
                  size_t array_size);
+/* Parameters are stored as locals with an index */
 int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
                        int index);
+/* Functions record return and parameter types */
 int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
                       type_kind_t *param_types, size_t param_count);
+/* Globals live in a separate list */
 int symtable_add_global(symtable_t *table, const char *name, type_kind_t type,
                         size_t array_size);
 

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -127,6 +127,10 @@ static type_kind_t check_binary(expr_t *left, expr_t *right, symtable_t *vars,
     return TYPE_UNKNOWN;
 }
 
+/*
+ * Perform semantic analysis on an expression and emit IR code.
+ * The type of the expression is returned, or TYPE_UNKNOWN on error.
+ */
 type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                        ir_builder_t *ir, ir_value_t *out)
 {
@@ -321,6 +325,10 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
     return TYPE_UNKNOWN;
 }
 
+/*
+ * Validate a single statement.  Loop labels are used for 'break' and
+ * 'continue' targets.  Returns non-zero on success.
+ */
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                ir_builder_t *ir, type_kind_t func_ret_type,
                const char *break_label, const char *continue_label)
@@ -503,6 +511,11 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     return 0;
 }
 
+/*
+ * Check a full function definition.  Parameters are placed in a local symbol
+ * table chained to the list of globals.  IR for the body is generated while
+ * validating statements.
+ */
 int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
                ir_builder_t *ir)
 {
@@ -531,6 +544,10 @@ int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
     return ok;
 }
 
+/*
+ * Validate a global variable declaration and emit the IR needed to
+ * initialize it.  Only constant expressions are permitted for globals.
+ */
 int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
 {
     if (!decl || decl->kind != STMT_VAR_DECL)

--- a/src/symtable.c
+++ b/src/symtable.c
@@ -10,12 +10,14 @@
 #include "symtable.h"
 #include "util.h"
 
+/* Reset a symbol table so that both local and global lists are empty. */
 void symtable_init(symtable_t *table)
 {
     table->head = NULL;
     table->globals = NULL;
 }
 
+/* Free all symbols stored in the table and reset it to an empty state. */
 void symtable_free(symtable_t *table)
 {
     symbol_t *sym = table->head;
@@ -38,6 +40,10 @@ void symtable_free(symtable_t *table)
     table->globals = NULL;
 }
 
+/*
+ * Search the table for a symbol by name.  Local symbols take precedence
+ * over globals.  Returns NULL if the name is not present.
+ */
 symbol_t *symtable_lookup(symtable_t *table, const char *name)
 {
     for (symbol_t *sym = table->head; sym; sym = sym->next) {
@@ -51,6 +57,10 @@ symbol_t *symtable_lookup(symtable_t *table, const char *name)
     return NULL;
 }
 
+/*
+ * Insert a new local variable symbol.  The function fails if a symbol with the
+ * same name already exists in either the local or global list.
+ */
 int symtable_add(symtable_t *table, const char *name, type_kind_t type,
                  size_t array_size)
 {
@@ -74,6 +84,10 @@ int symtable_add(symtable_t *table, const char *name, type_kind_t type,
     return 1;
 }
 
+/*
+ * Insert a function parameter.  Parameters are stored in the local list with
+ * the index field recording the argument position.
+ */
 int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
                        int index)
 {
@@ -97,6 +111,7 @@ int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
     return 1;
 }
 
+/* Insert a global variable into the table. */
 int symtable_add_global(symtable_t *table, const char *name, type_kind_t type,
                         size_t array_size)
 {
@@ -122,6 +137,9 @@ int symtable_add_global(symtable_t *table, const char *name, type_kind_t type,
     return 1;
 }
 
+/*
+ * Insert a function symbol along with its return type and parameter types.
+ */
 int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
                       type_kind_t *param_types, size_t param_count)
 {
@@ -154,6 +172,7 @@ int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
     return 1;
 }
 
+/* Look up a name only in the global list. */
 symbol_t *symtable_lookup_global(symtable_t *table, const char *name)
 {
     for (symbol_t *sym = table->globals; sym; sym = sym->next) {


### PR DESCRIPTION
## Summary
- document how symbols are inserted and looked up
- explain semantic validation helpers

## Testing
- `tests/run.sh` *(fails: undefined reference to `error_set`)*
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b469e36c483249be52c7a400da1a5