### PR TITLE
Document error utilities

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -10,7 +10,17 @@
 
 #include <stddef.h>
 
+/*
+ * Save the given 1-based line and column so that the next call to
+ * error_print() can report where the error occurred.  Passing 0 for
+ * either value indicates an unknown position.
+ */
 void error_set(size_t line, size_t col);
+
+/*
+ * Print an error message to stderr using the position stored by
+ * error_set().
+ */
 void error_print(const char *msg);
 
 #endif /* VC_ERROR_H */

--- a/src/error.c
+++ b/src/error.c
@@ -8,15 +8,26 @@
 #include <stdio.h>
 #include "error.h"
 
+/* Stored source location for the next error message */
 static size_t error_line = 0;
 static size_t error_column = 0;
 
+/*
+ * Remember the given source position for use by error_print().  The
+ * values are 1-based; a line or column of 0 indicates an unknown
+ * position.
+ */
 void error_set(size_t line, size_t col)
 {
     error_line = line;
     error_column = col;
 }
 
+/*
+ * Output "msg" followed by the location previously stored with
+ * error_set().  The message is printed to stderr in a
+ * "line/column" format.
+ */
 void error_print(const char *msg)
 {
     fprintf(stderr, "%s at line %zu, column %zu\n", msg, error_line, error_column);


### PR DESCRIPTION
## Summary
- add detailed comments for error position handling in `error.c`
- document `error_set` and `error_print` in `error.h`

## Testing
- `make`
- `tests/run_tests.sh`
- `cc -Iinclude -Wall -Wextra -std=c99 -o /tmp/unit_tests tests/unit/test_lexer_parser.c src/lexer.c src/parser.c src/parser_expr.c src/parser_stmt.c src/ast.c src/util.c src/vector.c src/error.c && /tmp/unit_tests`

------
https://chatgpt.com/codex/tasks/task_e_685b4b56fc348324b14b2a5faed80c56