### PR TITLE
Add documentation comments and pipeline overview

### DIFF
--- a/include/label.h
+++ b/include/label.h
@@ -8,8 +8,13 @@
 #ifndef VC_LABEL_H
 #define VC_LABEL_H
 
+/* Initialize the label generator. */
 void label_init(void);
+
+/* Get the next unique label identifier. */
 int label_next_id(void);
+
+/* Reset label numbering back to zero. */
 void label_reset(void);
 
 #endif /* VC_LABEL_H */

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -17,9 +17,16 @@ typedef struct {
     size_t cap;
 } strbuf_t;
 
+/* Initialize a new string buffer */
 void strbuf_init(strbuf_t *sb);
+
+/* Append a plain string to the buffer */
 void strbuf_append(strbuf_t *sb, const char *text);
+
+/* Append formatted text using printf-style formatting */
 void strbuf_appendf(strbuf_t *sb, const char *fmt, ...);
+
+/* Release buffer memory */
 void strbuf_free(strbuf_t *sb);
 
 #endif /* VC_STRBUF_H */

--- a/include/util.h
+++ b/include/util.h
@@ -8,7 +8,10 @@
 #ifndef VC_UTIL_H
 #define VC_UTIL_H
 
+/* Duplicate a string using malloc */
 char *vc_strdup(const char *s);
+
+/* Read entire file into a NUL-terminated buffer */
 char *vc_read_file(const char *path);
 
 #endif /* VC_UTIL_H */

--- a/src/label.c
+++ b/src/label.c
@@ -7,18 +7,22 @@
 
 #include "label.h"
 
+/* Next label identifier to issue */
 static int next_label_id = 0;
 
+/* Reset label counter to start at zero */
 void label_init(void)
 {
     next_label_id = 0;
 }
 
+/* Return a fresh label identifier */
 int label_next_id(void)
 {
     return next_label_id++;
 }
 
+/* Clear label state so a new compilation can start */
 void label_reset(void)
 {
     next_label_id = 0;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -12,6 +12,7 @@
 #include "token.h"
 #include "vector.h"
 
+/* Helper to create and append a token to the vector */
 static void append_token(vector_t *vec, token_type_t type, const char *lexeme,
                          size_t len, size_t line, size_t column)
 {
@@ -25,6 +26,7 @@ static void append_token(vector_t *vec, token_type_t type, const char *lexeme,
         exit(1);
 }
 
+/* Skip comments and whitespace, updating position counters */
 static void skip_whitespace(const char *src, size_t *i, size_t *line,
                             size_t *col)
 {
@@ -67,6 +69,7 @@ static void skip_whitespace(const char *src, size_t *i, size_t *line,
     }
 }
 
+/* Read an identifier or keyword starting at src[*i] */
 static void read_identifier(const char *src, size_t *i, size_t *col,
                             vector_t *tokens, size_t line)
 {
@@ -101,6 +104,7 @@ static void read_identifier(const char *src, size_t *i, size_t *col,
     *col += len;
 }
 
+/* Parse a numeric literal */
 static void read_number(const char *src, size_t *i, size_t *col,
                         vector_t *tokens, size_t line)
 {
@@ -112,6 +116,7 @@ static void read_number(const char *src, size_t *i, size_t *col,
     *col += len;
 }
 
+/* Translate escape sequences within character and string literals */
 static int unescape_char(char c)
 {
     switch (c) {
@@ -124,6 +129,7 @@ static int unescape_char(char c)
     }
 }
 
+/* Parse a character constant like '\n' or 'a' */
 static void read_char_const(const char *src, size_t *i, size_t *col,
                             vector_t *tokens, size_t line)
 {
@@ -145,6 +151,7 @@ static void read_char_const(const char *src, size_t *i, size_t *col,
     append_token(tokens, TOK_CHAR, buf, 1, line, column);
 }
 
+/* Parse a double-quoted string literal */
 static void read_string_lit(const char *src, size_t *i, size_t *col,
                             vector_t *tokens, size_t line)
 {
@@ -179,6 +186,7 @@ static void read_string_lit(const char *src, size_t *i, size_t *col,
     free(buf);
 }
 
+/* Convert punctuation characters to tokens */
 static void read_punct(char c, vector_t *tokens, size_t line, size_t column)
 {
     token_type_t type = TOK_UNKNOWN;
@@ -206,6 +214,7 @@ static void read_punct(char c, vector_t *tokens, size_t line, size_t column)
 
 /* Public API */
 
+/* Tokenize the entire source string */
 token_t *lexer_tokenize(const char *src, size_t *out_count)
 {
     vector_t vec;
@@ -249,6 +258,7 @@ token_t *lexer_tokenize(const char *src, size_t *out_count)
     return (token_t *)vec.data;
 }
 
+/* Free an array of tokens produced by lexer_tokenize */
 void lexer_free_tokens(token_t *tokens, size_t count)
 {
     for (size_t i = 0; i < count; i++)

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,13 @@
 /*
  * Entry point of the vc compiler.
  *
+ * This file drives the entire compilation pipeline:
+ *  1. Source code is tokenized by the lexer.
+ *  2. The parser builds an AST from those tokens.
+ *  3. Semantic analysis creates an intermediate representation (IR).
+ *  4. Optimization passes run on the IR.
+ *  5. Code generation emits x86 assembly or an object file.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */

--- a/src/opt.c
+++ b/src/opt.c
@@ -16,13 +16,14 @@ typedef struct var_const {
     struct var_const *next;
 } var_const_t;
 
+/* Reset all entries in a variable constant list */
 static void clear_var_list(var_const_t *head)
 {
     for (var_const_t *v = head; v; v = v->next)
         v->known = 0;
 }
 
-/* Propagate constants through store/load pairs */
+/* Propagate constants from stores to subsequent loads */
 static void propagate_load_consts(ir_builder_t *ir)
 {
     if (!ir)
@@ -127,7 +128,7 @@ static void propagate_load_consts(ir_builder_t *ir)
     }
 }
 
-/* Simple constant folding optimization pass */
+/* Perform simple constant folding */
 static void fold_constants(ir_builder_t *ir)
 {
     if (!ir)
@@ -225,6 +226,7 @@ static void fold_constants(ir_builder_t *ir)
 
 
 /* Instructions that must be preserved even if their result is unused */
+/* Check whether an instruction produces a side effect */
 static int has_side_effect(ir_instr_t *ins)
 {
     switch (ins->op) {
@@ -248,7 +250,7 @@ static int has_side_effect(ir_instr_t *ins)
     }
 }
 
-/* Remove instructions whose results are never used */
+/* Remove instructions whose results are unused */
 static void dead_code_elim(ir_builder_t *ir)
 {
     if (!ir)
@@ -303,6 +305,7 @@ static void dead_code_elim(ir_builder_t *ir)
     free(list);
 }
 
+/* Run enabled optimization passes on the IR */
 void opt_run(ir_builder_t *ir, const opt_config_t *cfg)
 {
     opt_config_t def = {1, 1, 1, 1};

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -11,6 +11,7 @@
 #include <stdarg.h>
 #include "strbuf.h"
 
+/* Initialize a string buffer */
 void strbuf_init(strbuf_t *sb)
 {
     if (!sb)
@@ -22,6 +23,7 @@ void strbuf_init(strbuf_t *sb)
         sb->data[0] = '\0';
 }
 
+/* Ensure the buffer can hold at least extra bytes */
 static void sb_ensure(strbuf_t *sb, size_t extra)
 {
     if (!sb->data || sb->len + extra >= sb->cap) {
@@ -36,6 +38,7 @@ static void sb_ensure(strbuf_t *sb, size_t extra)
     }
 }
 
+/* Append a simple string to the buffer */
 void strbuf_append(strbuf_t *sb, const char *text)
 {
     if (!sb || !text)
@@ -48,6 +51,7 @@ void strbuf_append(strbuf_t *sb, const char *text)
     sb->len += l;
 }
 
+/* Append formatted text using printf-style formatting */
 void strbuf_appendf(strbuf_t *sb, const char *fmt, ...)
 {
     if (!sb || !fmt)
@@ -73,6 +77,7 @@ void strbuf_appendf(strbuf_t *sb, const char *fmt, ...)
     }
 }
 
+/* Free the memory used by a string buffer */
 void strbuf_free(strbuf_t *sb)
 {
     if (!sb)

--- a/src/util.c
+++ b/src/util.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "util.h"
 
+/* Duplicate a string using malloc */
 char *vc_strdup(const char *s)
 {
     size_t len = strlen(s);
@@ -20,6 +21,7 @@ char *vc_strdup(const char *s)
     return out;
 }
 
+/* Read the entire contents of a file into memory */
 char *vc_read_file(const char *path)
 {
     FILE *f = fopen(path, "rb");

--- a/src/vector.c
+++ b/src/vector.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include "vector.h"
 
+/* Initialize vector for elements of the given size */
 void vector_init(vector_t *vec, size_t elem_size)
 {
     if (!vec)
@@ -19,6 +20,7 @@ void vector_init(vector_t *vec, size_t elem_size)
     vec->elem_size = elem_size;
 }
 
+/* Append one element to the vector */
 int vector_push(vector_t *vec, const void *elem)
 {
     if (!vec || !elem)
@@ -36,6 +38,7 @@ int vector_push(vector_t *vec, const void *elem)
     return 1;
 }
 
+/* Release memory held by the vector */
 void vector_free(vector_t *vec)
 {
     if (!vec)


### PR DESCRIPTION
## Summary
- document the compilation pipeline in `main.c`
- add function comments in src/label.c, lexer.c, opt.c, strbuf.c, util.c and vector.c
- document headers for label, strbuf and util
- fix duplicate comments in opt.c

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b4b65a27483249198c9bb79d2ba5a