### PR TITLE
Add goto and label support

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -209,6 +209,7 @@ RETURN v2
 - Arrays
 - Global variables
 - `break` and `continue` statements
+- Labels and `goto`
 
 Examples below show how to compile each feature.
 
@@ -381,6 +382,25 @@ int main() {
 Compile with:
 ```sh
 vc -o switch.s switch_example.c
+```
+
+### Labels and goto
+```c
+/* goto_example.c */
+int main() {
+    int i = 0;
+start:
+    if (i == 3)
+        goto end;
+    i = i + 1;
+    goto start;
+end:
+    return i;
+}
+```
+Compile with:
+```sh
+vc -o goto.s goto_example.c
 ```
 
 ## Command-line Options

--- a/include/ast.h
+++ b/include/ast.h
@@ -123,6 +123,8 @@ typedef enum {
     STMT_SWITCH,
     STMT_BREAK,
     STMT_CONTINUE,
+    STMT_LABEL,
+    STMT_GOTO,
     STMT_BLOCK
 } stmt_kind_t;
 
@@ -173,6 +175,12 @@ struct stmt {
             size_t case_count;
             stmt_t *default_body; /* may be NULL */
         } switch_stmt;
+        struct {
+            char *name;
+        } label;
+        struct {
+            char *name;
+        } goto_stmt;
         struct {
             stmt_t **stmts;
             size_t count;
@@ -240,6 +248,10 @@ stmt_t *ast_make_switch(expr_t *expr, switch_case_t *cases, size_t case_count,
 stmt_t *ast_make_break(size_t line, size_t column);
 /* Simple continue statement used inside loops. */
 stmt_t *ast_make_continue(size_t line, size_t column);
+/* Label definition statement */
+stmt_t *ast_make_label(const char *name, size_t line, size_t column);
+/* goto statement */
+stmt_t *ast_make_goto(const char *name, size_t line, size_t column);
 /* Create a block of statements containing \p count elements. */
 stmt_t *ast_make_block(stmt_t **stmts, size_t count,
                        size_t line, size_t column);

--- a/include/semantic.h
+++ b/include/semantic.h
@@ -21,7 +21,7 @@
 type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                        ir_builder_t *ir, ir_value_t *out);
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-               ir_builder_t *ir, type_kind_t func_ret_type,
+               void *labels, ir_builder_t *ir, type_kind_t func_ret_type,
                const char *break_label, const char *continue_label);
 /* Validate an entire function definition */
 int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,

--- a/include/token.h
+++ b/include/token.h
@@ -28,6 +28,7 @@ typedef enum {
     TOK_KW_FOR,
     TOK_KW_BREAK,
     TOK_KW_CONTINUE,
+    TOK_KW_GOTO,
     TOK_KW_SWITCH,
     TOK_KW_CASE,
     TOK_KW_DEFAULT,
@@ -52,6 +53,7 @@ typedef enum {
     TOK_LBRACKET,
     TOK_RBRACKET,
     TOK_COLON,
+    TOK_LABEL,
     TOK_UNKNOWN
 } token_type_t;
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -329,6 +329,40 @@ stmt_t *ast_make_continue(size_t line, size_t column)
     return stmt;
 }
 
+/* Create a label statement */
+stmt_t *ast_make_label(const char *name, size_t line, size_t column)
+{
+    stmt_t *stmt = malloc(sizeof(*stmt));
+    if (!stmt)
+        return NULL;
+    stmt->kind = STMT_LABEL;
+    stmt->line = line;
+    stmt->column = column;
+    stmt->label.name = vc_strdup(name ? name : "");
+    if (!stmt->label.name) {
+        free(stmt);
+        return NULL;
+    }
+    return stmt;
+}
+
+/* Create a goto statement */
+stmt_t *ast_make_goto(const char *name, size_t line, size_t column)
+{
+    stmt_t *stmt = malloc(sizeof(*stmt));
+    if (!stmt)
+        return NULL;
+    stmt->kind = STMT_GOTO;
+    stmt->line = line;
+    stmt->column = column;
+    stmt->goto_stmt.name = vc_strdup(name ? name : "");
+    if (!stmt->goto_stmt.name) {
+        free(stmt);
+        return NULL;
+    }
+    return stmt;
+}
+
 /* Create a block statement containing \p count child statements. */
 stmt_t *ast_make_block(stmt_t **stmts, size_t count,
                        size_t line, size_t column)
@@ -481,6 +515,12 @@ void ast_free_stmt(stmt_t *stmt)
         }
         free(stmt->switch_stmt.cases);
         ast_free_stmt(stmt->switch_stmt.default_body);
+        break;
+    case STMT_LABEL:
+        free(stmt->label.name);
+        break;
+    case STMT_GOTO:
+        free(stmt->goto_stmt.name);
         break;
     case STMT_BREAK:
     case STMT_CONTINUE:

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -78,6 +78,12 @@ static void read_identifier(const char *src, size_t *i, size_t *col,
         (*i)++;
     size_t len = *i - start;
     token_type_t type = TOK_IDENT;
+    if (src[*i] == ':') {
+        (*i)++; /* consume ':' */
+        append_token(tokens, TOK_LABEL, src + start, len, line, *col);
+        *col += len + 1;
+        return;
+    }
     if (len == 2 && strncmp(src + start, "if", 2) == 0)
         type = TOK_KW_IF;
     else if (len == 4 && strncmp(src + start, "else", 4) == 0)
@@ -92,6 +98,8 @@ static void read_identifier(const char *src, size_t *i, size_t *col,
         type = TOK_KW_BREAK;
     else if (len == 8 && strncmp(src + start, "continue", 8) == 0)
         type = TOK_KW_CONTINUE;
+    else if (len == 4 && strncmp(src + start, "goto", 4) == 0)
+        type = TOK_KW_GOTO;
     else if (len == 6 && strncmp(src + start, "switch", 6) == 0)
         type = TOK_KW_SWITCH;
     else if (len == 4 && strncmp(src + start, "case", 4) == 0)

--- a/src/parser.c
+++ b/src/parser.c
@@ -60,6 +60,7 @@ static const char *token_name(token_type_t type)
     case TOK_KW_FOR: return "\"for\"";
     case TOK_KW_BREAK: return "\"break\"";
     case TOK_KW_CONTINUE: return "\"continue\"";
+    case TOK_KW_GOTO: return "\"goto\"";
     case TOK_KW_SWITCH: return "\"switch\"";
     case TOK_KW_CASE: return "\"case\"";
     case TOK_KW_DEFAULT: return "\"default\"";
@@ -84,6 +85,7 @@ static const char *token_name(token_type_t type)
     case TOK_LBRACKET: return "'['";
     case TOK_RBRACKET: return "']'";
     case TOK_COLON: return "':'";
+    case TOK_LABEL: return "label";
     case TOK_UNKNOWN: return "unknown";
     }
     return "unknown";

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -63,6 +63,11 @@ stmt_t *parser_parse_stmt(parser_t *p)
     if (tok && tok->type == TOK_LBRACE)
         return parse_block(p);
 
+    if (match(p, TOK_LABEL)) {
+        token_t *lbl = &p->tokens[p->pos - 1];
+        return ast_make_label(lbl->lexeme, lbl->line, lbl->column);
+    }
+
     if (match(p, TOK_KW_INT) || match(p, TOK_KW_CHAR)) {
         token_t *kw_tok = &p->tokens[p->pos - 1];
         type_kind_t t = (kw_tok->type == TOK_KW_INT) ? TYPE_INT : TYPE_CHAR;
@@ -139,6 +144,18 @@ stmt_t *parser_parse_stmt(parser_t *p)
         if (!match(p, TOK_SEMI))
             return NULL;
         return ast_make_continue(kw_tok->line, kw_tok->column);
+    }
+
+    if (match(p, TOK_KW_GOTO)) {
+        token_t *kw_tok = &p->tokens[p->pos - 1];
+        token_t *id = peek(p);
+        if (!id || id->type != TOK_IDENT)
+            return NULL;
+        p->pos++;
+        char *name = id->lexeme;
+        if (!match(p, TOK_SEMI))
+            return NULL;
+        return ast_make_goto(name, kw_tok->line, kw_tok->column);
     }
 
     if (match(p, TOK_KW_IF)) {


### PR DESCRIPTION
## Summary
- add `TOK_KW_GOTO` and `TOK_LABEL` token types
- parse labels and `goto` statements into new AST nodes
- track labels during semantic analysis and emit IR branches
- emit unconditional branches for `goto`
- document label and `goto` usage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b50882e108324bf094009721df5d5