### PR TITLE
Add modulo operator

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -100,7 +100,7 @@ The IR uses a straightforward three-address format. The operations defined in
 [`include/ir.h`](../include/ir.h) include:
 
 - `IR_CONST` for integer constants
-- arithmetic ops `IR_ADD`, `IR_SUB`, `IR_MUL`, `IR_DIV`
+ - arithmetic ops `IR_ADD`, `IR_SUB`, `IR_MUL`, `IR_DIV`, `IR_MOD`
 - comparison ops `IR_CMPEQ`, `IR_CMPNE`, `IR_CMPLT`, `IR_CMPGT`, `IR_CMPLE`, `IR_CMPGE`
 - global data directives `IR_GLOB_STRING`, `IR_GLOB_VAR`
 - variable access `IR_LOAD`, `IR_STORE`, `IR_LOAD_PARAM`, `IR_STORE_PARAM`

--- a/include/ast.h
+++ b/include/ast.h
@@ -46,6 +46,7 @@ typedef enum {
     BINOP_SUB,
     BINOP_MUL,
     BINOP_DIV,
+    BINOP_MOD,
     BINOP_EQ,
     BINOP_NEQ,
     BINOP_LOGAND,

--- a/include/ir.h
+++ b/include/ir.h
@@ -15,6 +15,7 @@ typedef enum {
     IR_SUB,
     IR_MUL,
     IR_DIV,
+    IR_MOD,
     IR_PTR_ADD,
     IR_PTR_DIFF,
     IR_CMPEQ,

--- a/include/token.h
+++ b/include/token.h
@@ -51,6 +51,7 @@ typedef enum {
     TOK_AMP,
     TOK_STAR,
     TOK_SLASH,
+    TOK_PERCENT,
     TOK_ASSIGN,
     TOK_EQ,
     TOK_NEQ,

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -153,6 +153,17 @@ static void emit_instr(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64)
             strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, ax,
                        loc_str(buf2, ra, ins->dest, x64));
         break;
+    case IR_MOD:
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
+                   loc_str(buf1, ra, ins->src1, x64), ax);
+        strbuf_appendf(sb, "    %s\n", x64 ? "cqto" : "cltd");
+        strbuf_appendf(sb, "    idiv%s %s\n", sfx,
+                   loc_str(buf1, ra, ins->src2, x64));
+        if (ra && ra->loc[ins->dest] >= 0 &&
+            strcmp(regalloc_reg_name(ra->loc[ins->dest]), x64 ? "%rdx" : "%edx") != 0)
+            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, x64 ? "%rdx" : "%edx",
+                       loc_str(buf2, ra, ins->dest, x64));
+        break;
     case IR_CMPEQ: case IR_CMPNE: case IR_CMPLT: case IR_CMPGT:
     case IR_CMPLE: case IR_CMPGE: {
         const char *cc = "";

--- a/src/ir_dump.c
+++ b/src/ir_dump.c
@@ -19,6 +19,7 @@ static const char *op_name(ir_op_t op)
     case IR_SUB: return "IR_SUB";
     case IR_MUL: return "IR_MUL";
     case IR_DIV: return "IR_DIV";
+    case IR_MOD: return "IR_MOD";
     case IR_PTR_ADD: return "IR_PTR_ADD";
     case IR_PTR_DIFF: return "IR_PTR_DIFF";
     case IR_CMPEQ: return "IR_CMPEQ";

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -223,6 +223,7 @@ static void read_punct(char c, vector_t *tokens, size_t line, size_t column)
     case '&': type = TOK_AMP; break;
     case '*': type = TOK_STAR; break;
     case '/': type = TOK_SLASH; break;
+    case '%': type = TOK_PERCENT; break;
     case '=': type = TOK_ASSIGN; break;
     case '<': type = TOK_LT; break;
     case '>': type = TOK_GT; break;

--- a/src/opt.c
+++ b/src/opt.c
@@ -108,7 +108,7 @@ static void propagate_load_consts(ir_builder_t *ir)
         case IR_BR:
         case IR_BCOND:
         case IR_LABEL:
-        case IR_ADD: case IR_SUB: case IR_MUL: case IR_DIV: case IR_PTR_ADD:
+        case IR_ADD: case IR_SUB: case IR_MUL: case IR_DIV: case IR_MOD: case IR_PTR_ADD:
         case IR_PTR_DIFF:
         case IR_CMPEQ: case IR_CMPNE: case IR_CMPLT:
         case IR_CMPGT: case IR_CMPLE: case IR_CMPGE:
@@ -151,7 +151,7 @@ static void fold_constants(ir_builder_t *ir)
                 values[ins->dest] = ins->imm;
             }
             break;
-        case IR_ADD: case IR_SUB: case IR_MUL: case IR_DIV:
+        case IR_ADD: case IR_SUB: case IR_MUL: case IR_DIV: case IR_MOD:
         case IR_CMPEQ: case IR_CMPNE: case IR_CMPLT:
         case IR_CMPGT: case IR_CMPLE: case IR_CMPGE:
         case IR_LOGAND: case IR_LOGOR:
@@ -165,6 +165,7 @@ static void fold_constants(ir_builder_t *ir)
                 case IR_SUB: result = a - b; break;
                 case IR_MUL: result = a * b; break;
                 case IR_DIV: result = b != 0 ? a / b : 0; break;
+                case IR_MOD: result = b != 0 ? a % b : 0; break;
                 case IR_CMPEQ: result = a == b; break;
                 case IR_CMPNE: result = a != b; break;
                 case IR_CMPLT: result = a < b; break;

--- a/src/parser.c
+++ b/src/parser.c
@@ -83,6 +83,7 @@ static const char *token_name(token_type_t type)
     case TOK_AMP: return "'&'";
     case TOK_STAR: return "'*'";
     case TOK_SLASH: return "'/'";
+    case TOK_PERCENT: return "'%'";
     case TOK_ASSIGN: return "'='";
     case TOK_EQ: return "'=='";
     case TOK_NEQ: return "'!='";

--- a/src/parser_expr.c
+++ b/src/parser_expr.c
@@ -195,6 +195,15 @@ static expr_t *parse_term(parser_t *p)
             }
             left = ast_make_binary(BINOP_DIV, left, right,
                                   op_tok->line, op_tok->column);
+        } else if (match(p, TOK_PERCENT)) {
+            token_t *op_tok = &p->tokens[p->pos - 1];
+            expr_t *right = parse_primary(p);
+            if (!right) {
+                ast_free_expr(left);
+                return NULL;
+            }
+            left = ast_make_binary(BINOP_MOD, left, right,
+                                  op_tok->line, op_tok->column);
         } else {
             break;
         }

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -117,6 +117,7 @@ static int eval_const_expr(expr_t *expr, symtable_t *vars, int *out)
         case BINOP_SUB: if (out) *out = a - b; break;
         case BINOP_MUL: if (out) *out = a * b; break;
         case BINOP_DIV: if (out) *out = b != 0 ? a / b : 0; break;
+        case BINOP_MOD: if (out) *out = b != 0 ? a % b : 0; break;
         case BINOP_EQ:  if (out) *out = (a == b); break;
         case BINOP_NEQ: if (out) *out = (a != b); break;
         case BINOP_LT:  if (out) *out = (a < b); break;
@@ -172,6 +173,7 @@ static type_kind_t check_binary(expr_t *left, expr_t *right, symtable_t *vars,
             case BINOP_SUB: ir_op = IR_SUB; break;
             case BINOP_MUL: ir_op = IR_MUL; break;
             case BINOP_DIV: ir_op = IR_DIV; break;
+            case BINOP_MOD: ir_op = IR_MOD; break;
             case BINOP_EQ:  ir_op = IR_CMPEQ; break;
             case BINOP_NEQ: ir_op = IR_CMPNE; break;
             case BINOP_LT:  ir_op = IR_CMPLT; break;

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -49,6 +49,15 @@ static void test_lexer_comments(void)
     lexer_free_tokens(toks, count);
 }
 
+static void test_lexer_percent(void)
+{
+    const char *src = "a % b;";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    ASSERT(toks[1].type == TOK_PERCENT);
+    lexer_free_tokens(toks, count);
+}
+
 static void test_parser_expr(void)
 {
     const char *src = "1 + 2 * 3";
@@ -180,6 +189,19 @@ static void test_parser_pointer_arith(void)
     lexer_free_tokens(toks, count);
 }
 
+static void test_parser_mod(void)
+{
+    const char *src = "5 % 2";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    expr_t *expr = parser_parse_expr(&p);
+    ASSERT(expr && expr->kind == EXPR_BINARY);
+    ASSERT(expr->binary.op == BINOP_MOD);
+    ast_free_expr(expr);
+    lexer_free_tokens(toks, count);
+}
+
 static void test_parser_global_init(void)
 {
     const char *src = "int y = 1 + 2;";
@@ -288,6 +310,7 @@ int main(void)
 {
     test_lexer_basic();
     test_lexer_comments();
+    test_lexer_percent();
     test_parser_expr();
     test_parser_stmt_return();
     test_parser_stmt_return_void();
@@ -296,6 +319,7 @@ int main(void)
     test_parser_index_expr();
     test_parser_unary_neg();
     test_parser_pointer_arith();
+    test_parser_mod();
     test_parser_global_init();
     test_parser_unary_expr();
     test_parser_logical();


### PR DESCRIPTION
## Summary
- add `%` token and `TOK_PERCENT`
- extend AST with `BINOP_MOD`
- parse modulo in expression parser
- implement semantic checks and IR opcode `IR_MOD`
- emit assembly for modulo
- document IR_MOD and test modulo support

## Testing
- `make`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b6998661883249363dbd31ebdfb79