### PR TITLE
Add minimal preprocessor stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BIN = vc
 
 CORE_SRC = src/main.c src/cli.c src/lexer.c src/ast.c src/parser.c src/symtable.c src/parser_expr.c \
            src/parser_stmt.c src/semantic.c src/error.c src/ir.c src/codegen.c src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c \
-           src/vector.c src/ir_dump.c src/label.c
+           src/vector.c src/ir_dump.c src/label.c src/preproc.c
 
 # Optional optimization sources
 OPT_SRC = src/opt.c
@@ -16,7 +16,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 HDR = include/token.h include/ast.h include/parser.h include/symtable.h include/semantic.h \
     include/ir.h include/ir_dump.h include/opt.h include/codegen.h include/strbuf.h \
-    include/util.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h
+    include/util.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h include/preproc.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man

--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -8,16 +8,21 @@ support for floating-point types and operations.
 
 `vc` processes source code through several stages:
 
-1. **Lexer** – converts the input into a stream of tokens.
-2. **Parser** – builds an abstract syntax tree from the tokens.
-3. **Semantic analyzer** – checks the AST and produces an intermediate representation (IR).
-4. **Optimizer** – performs optional transformations on the IR.
-5. **Register allocator** – assigns machine registers.
-6. **Code generator** – emits target assembly.
+1. **Preprocessor** – handles `#include` directives and expands simple `#define` macros.
+2. **Lexer** – converts the input into a stream of tokens.
+3. **Parser** – builds an abstract syntax tree from the tokens.
+4. **Semantic analyzer** – checks the AST and produces an intermediate representation (IR).
+5. **Optimizer** – performs optional transformations on the IR.
+6. **Register allocator** – assigns machine registers.
+7. **Code generator** – emits target assembly.
 
 The modules described below implement these steps.
 
 ## Modules
+
+### preprocessor
+Expands `#include` directives and simple object-like `#define` macros before lexing.
+Only textual substitution is performed; conditional directives are not supported.
 
 ### lexer
 Translates raw characters into tokens for the parser.
@@ -545,6 +550,20 @@ The compiler supports the following options:
 
 Use `vc -o out.s source.c` to compile a file, or `vc --dump-asm source.c` to
 print the assembly to the terminal.
+
+## Preprocessor Usage
+
+The preprocessor runs automatically before the lexer. It supports `#include "file"`
+to insert the contents of another file and simple object-like `#define` macros:
+
+```c
+#define VAL 3
+#include "header.h"
+int main() { return VAL; }
+```
+
+Macro expansion is purely textual; macros inside strings or comments are not
+recognized and conditional directives are ignored.
 
 ## Compiling a Simple Program
 

--- a/include/preproc.h
+++ b/include/preproc.h
@@ -1,0 +1,18 @@
+/*
+ * Minimal source preprocessor.
+ *
+ * Supports only '#include "file"' and simple object-like '#define NAME value'.
+ * Expansion is naive: macro names are replaced as plain identifiers without
+ * parameter handling. Conditionals and other directives are not implemented.
+ */
+
+#ifndef VC_PREPROC_H
+#define VC_PREPROC_H
+
+/* Preprocess the file at the given path.
+ * The returned string must be freed by the caller.
+ * Returns NULL on failure.
+ */
+char *preproc_run(const char *path);
+
+#endif /* VC_PREPROC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@
 #include "opt.h"
 #include "codegen.h"
 #include "label.h"
+#include "preproc.h"
 
 int main(int argc, char **argv)
 {
@@ -43,9 +44,9 @@ int main(int argc, char **argv)
 
     label_init();
 
-    char *src_text = vc_read_file(source);
+    char *src_text = preproc_run(source);
     if (!src_text) {
-        perror("vc_read_file");
+        perror("preproc_run");
         return 1;
     }
 

--- a/src/preproc.c
+++ b/src/preproc.c
@@ -1,0 +1,154 @@
+/*
+ * Minimal preprocessing implementation.
+ *
+ * Only handles '#include "file"' and object-like '#define'.
+ * Macros are expanded with simple text substitution and no awareness of
+ * string literals or comments. Nested includes are supported but no
+ * include guards are provided.
+ */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc.h"
+#include "util.h"
+#include "vector.h"
+#include "strbuf.h"
+
+/* Stored macro definition */
+typedef struct {
+    char *name;
+    char *value;
+} macro_t;
+
+/* Free memory for a macro */
+static void macro_free(macro_t *m)
+{
+    if (!m) return;
+    free(m->name);
+    free(m->value);
+}
+
+/* Replace identifiers in 'line' with macro values into 'out'.
+ * This does no tokenization and simply matches whole identifiers.
+ */
+static void expand_line(const char *line, vector_t *macros, strbuf_t *out)
+{
+    for (size_t i = 0; line[i];) {
+        int replaced = 0;
+        if (isalpha((unsigned char)line[i]) || line[i] == '_') {
+            size_t j = i + 1;
+            while (isalnum((unsigned char)line[j]) || line[j] == '_')
+                j++;
+            size_t len = j - i;
+            for (size_t k = 0; k < macros->count; k++) {
+                macro_t *m = &((macro_t *)macros->data)[k];
+                if (strlen(m->name) == len && strncmp(m->name, line + i, len) == 0) {
+                    strbuf_append(out, m->value);
+                    i = j;
+                    replaced = 1;
+                    break;
+                }
+            }
+        }
+        if (!replaced) {
+            strbuf_appendf(out, "%c", line[i]);
+            i++;
+        }
+    }
+}
+
+/* Process a single file, writing output to 'out'. */
+static int process_file(const char *path, vector_t *macros, strbuf_t *out)
+{
+    char *text = vc_read_file(path);
+    if (!text)
+        return 0;
+    char *dir = NULL;
+    const char *slash = strrchr(path, '/');
+    if (slash) {
+        size_t len = (size_t)(slash - path) + 1;
+        dir = malloc(len + 1);
+        if (!dir) {
+            free(text);
+            return 0;
+        }
+        memcpy(dir, path, len);
+        dir[len] = '\0';
+    }
+
+    char *line = strtok(text, "\n");
+    while (line) {
+        while (*line == ' ' || *line == '\t')
+            line++;
+        if (strncmp(line, "#include", 8) == 0 && (line[8] == ' ' || line[8] == '\t')) {
+            char *quote = strchr(line, '"');
+            char *end = quote ? strchr(quote + 1, '"') : NULL;
+            if (quote && end) {
+                size_t len = (size_t)(end - quote - 1);
+                char incpath[512];
+                if (dir)
+                    snprintf(incpath, sizeof(incpath), "%s%.*s", dir, (int)len, quote + 1);
+                else
+                    snprintf(incpath, sizeof(incpath), "%.*s", (int)len, quote + 1);
+                if (!process_file(incpath, macros, out)) {
+                    free(text);
+                    free(dir);
+                    return 0;
+                }
+            }
+        } else if (strncmp(line, "#define", 7) == 0 && (line[7] == ' ' || line[7] == '\t')) {
+            char *n = line + 7;
+            while (*n == ' ' || *n == '\t')
+                n++;
+            char *val = n;
+            while (*val && !isspace((unsigned char)*val))
+                val++;
+            if (*val) {
+                *val++ = '\0';
+                while (*val == ' ' || *val == '\t')
+                    val++;
+            } else {
+                val = "";
+            }
+            macro_t m = { vc_strdup(n), vc_strdup(val) };
+            if (!m.name || !m.value || !vector_push(macros, &m)) {
+                macro_free(&m);
+                free(text);
+                free(dir);
+                return 0;
+            }
+        } else {
+            strbuf_t tmp;
+            strbuf_init(&tmp);
+            expand_line(line, macros, &tmp);
+            strbuf_append(&tmp, "\n");
+            strbuf_append(out, tmp.data);
+            strbuf_free(&tmp);
+        }
+        line = strtok(NULL, "\n");
+    }
+    free(text);
+    free(dir);
+    return 1;
+}
+
+/* Entry point: preprocess the file and return a newly allocated buffer. */
+char *preproc_run(const char *path)
+{
+    vector_t macros;
+    vector_init(&macros, sizeof(macro_t));
+    strbuf_t out;
+    strbuf_init(&out);
+    int ok = process_file(path, &macros, &out);
+    for (size_t i = 0; i < macros.count; i++)
+        macro_free(&((macro_t *)macros.data)[i]);
+    vector_free(&macros);
+    char *res = NULL;
+    if (ok)
+        res = vc_strdup(out.data ? out.data : "");
+    strbuf_free(&out);
+    return res;
+}
+


### PR DESCRIPTION
## Summary
- implement a simple preprocessor handling `#include` and object-like `#define`
- run the preprocessor before tokenizing
- compile the new source file in the build
- document preprocessor usage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b702fe2008324b6720bfa5f8df80a