### PR TITLE
Improve memory allocation helpers

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -11,6 +11,12 @@
 /* Duplicate a string using malloc */
 char *vc_strdup(const char *s);
 
+/* Allocate memory or exit on failure */
+void *vc_alloc_or_exit(size_t size);
+
+/* Reallocate memory or exit on failure */
+void *vc_realloc_or_exit(void *ptr, size_t size);
+
 /* Read entire file into a NUL-terminated buffer */
 char *vc_read_file(const char *path);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -11,6 +11,7 @@
 
 #include "token.h"
 #include "vector.h"
+#include "util.h"
 
 typedef struct {
     const char *kw;
@@ -62,9 +63,7 @@ static token_type_t lookup_keyword(const char *str, size_t len)
 static void append_token(vector_t *vec, token_type_t type, const char *lexeme,
                          size_t len, size_t line, size_t column)
 {
-    char *text = malloc(len + 1);
-    if (!text)
-        exit(1);
+    char *text = vc_alloc_or_exit(len + 1);
     memcpy(text, lexeme, len);
     text[len] = '\0';
     token_t tok = { type, text, line, column };

--- a/src/preproc.c
+++ b/src/preproc.c
@@ -69,11 +69,7 @@ static int process_file(const char *path, vector_t *macros, strbuf_t *out)
     const char *slash = strrchr(path, '/');
     if (slash) {
         size_t len = (size_t)(slash - path) + 1;
-        dir = malloc(len + 1);
-        if (!dir) {
-            free(text);
-            return 0;
-        }
+        dir = vc_alloc_or_exit(len + 1);
         memcpy(dir, path, len);
         dir[len] = '\0';
     }

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include "strbuf.h"
+#include "util.h"
 
 /* Initialize a string buffer */
 void strbuf_init(strbuf_t *sb)
@@ -18,9 +19,8 @@ void strbuf_init(strbuf_t *sb)
         return;
     sb->cap = 128;
     sb->len = 0;
-    sb->data = malloc(sb->cap);
-    if (sb->data)
-        sb->data[0] = '\0';
+    sb->data = vc_alloc_or_exit(sb->cap);
+    sb->data[0] = '\0';
 }
 
 /* Ensure the buffer can hold at least extra bytes */
@@ -30,9 +30,7 @@ static void sb_ensure(strbuf_t *sb, size_t extra)
         size_t new_cap = sb->cap ? sb->cap * 2 : 128;
         while (sb->len + extra >= new_cap)
             new_cap *= 2;
-        char *n = realloc(sb->data, new_cap);
-        if (!n)
-            return;
+        char *n = vc_realloc_or_exit(sb->data, new_cap);
         sb->data = n;
         sb->cap = new_cap;
     }
@@ -64,9 +62,7 @@ void strbuf_appendf(strbuf_t *sb, const char *fmt, ...)
     if (n < 0)
         return;
     if ((size_t)n >= sizeof(buf)) {
-        char *tmp = malloc((size_t)n + 1);
-        if (!tmp)
-            return;
+        char *tmp = vc_alloc_or_exit((size_t)n + 1);
         va_start(ap, fmt);
         vsnprintf(tmp, (size_t)n + 1, fmt, ap);
         va_end(ap);

--- a/src/util.c
+++ b/src/util.c
@@ -10,13 +10,33 @@
 #include <string.h>
 #include "util.h"
 
+/* Allocate memory or exit on failure */
+void *vc_alloc_or_exit(size_t size)
+{
+    void *p = malloc(size);
+    if (!p) {
+        fprintf(stderr, "vc: out of memory\n");
+        exit(1);
+    }
+    return p;
+}
+
+/* Reallocate memory or exit on failure */
+void *vc_realloc_or_exit(void *ptr, size_t size)
+{
+    void *p = realloc(ptr, size);
+    if (!p) {
+        fprintf(stderr, "vc: out of memory\n");
+        exit(1);
+    }
+    return p;
+}
+
 /* Duplicate a string using malloc */
 char *vc_strdup(const char *s)
 {
     size_t len = strlen(s);
-    char *out = malloc(len + 1);
-    if (!out)
-        return NULL;
+    char *out = vc_alloc_or_exit(len + 1);
     memcpy(out, s, len + 1);
     return out;
 }
@@ -25,27 +45,29 @@ char *vc_strdup(const char *s)
 char *vc_read_file(const char *path)
 {
     FILE *f = fopen(path, "rb");
-    if (!f)
+    if (!f) {
+        perror(path);
         return NULL;
+    }
     if (fseek(f, 0, SEEK_END) != 0) {
+        perror("fseek");
         fclose(f);
         return NULL;
     }
     long len = ftell(f);
     if (len < 0) {
+        perror("ftell");
         fclose(f);
         return NULL;
     }
     if (fseek(f, 0, SEEK_SET) != 0) {
+        perror("fseek");
         fclose(f);
         return NULL;
     }
-    char *buf = malloc((size_t)len + 1);
-    if (!buf) {
-        fclose(f);
-        return NULL;
-    }
+    char *buf = vc_alloc_or_exit((size_t)len + 1);
     if (fread(buf, 1, (size_t)len, f) != (size_t)len) {
+        perror("fread");
         fclose(f);
         free(buf);
         return NULL;

--- a/src/vector.c
+++ b/src/vector.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "vector.h"
+#include "util.h"
 
 /* Initialize vector for elements of the given size */
 void vector_init(vector_t *vec, size_t elem_size)
@@ -27,9 +28,7 @@ int vector_push(vector_t *vec, const void *elem)
         return 0;
     if (vec->count >= vec->cap) {
         size_t new_cap = vec->cap ? vec->cap * 2 : 16;
-        void *tmp = realloc(vec->data, new_cap * vec->elem_size);
-        if (!tmp)
-            return 0;
+        void *tmp = vc_realloc_or_exit(vec->data, new_cap * vec->elem_size);
         vec->data = tmp;
         vec->cap = new_cap;
     }


### PR DESCRIPTION
## Summary
- add `vc_alloc_or_exit` and `vc_realloc_or_exit` helpers
- use new helpers in `vc_read_file`, `process_file`, and string/vector utilities
- update lexer, strbuf, and vector to rely on new allocation helpers

## Testing
- `make`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c2523c0348324a05a88101c427b4a