### PR TITLE
Use vc_strdup helpers

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -11,6 +11,9 @@
 /* Duplicate a string using malloc */
 char *vc_strdup(const char *s);
 
+/* Duplicate at most 'n' characters of a string */
+char *vc_strndup(const char *s, size_t n);
+
 /* Allocate memory or exit on failure */
 void *vc_alloc_or_exit(size_t size);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -63,9 +63,7 @@ static token_type_t lookup_keyword(const char *str, size_t len)
 static void append_token(vector_t *vec, token_type_t type, const char *lexeme,
                          size_t len, size_t line, size_t column)
 {
-    char *text = vc_alloc_or_exit(len + 1);
-    memcpy(text, lexeme, len);
-    text[len] = '\0';
+    char *text = vc_strndup(lexeme, len);
     token_t tok = { type, text, line, column };
     if (!vector_push(vec, &tok))
         exit(1);

--- a/src/preproc.c
+++ b/src/preproc.c
@@ -69,9 +69,7 @@ static int process_file(const char *path, vector_t *macros, strbuf_t *out)
     const char *slash = strrchr(path, '/');
     if (slash) {
         size_t len = (size_t)(slash - path) + 1;
-        dir = vc_alloc_or_exit(len + 1);
-        memcpy(dir, path, len);
-        dir[len] = '\0';
+        dir = vc_strndup(path, len);
     }
 
     char *line = strtok(text, "\n");
@@ -109,7 +107,7 @@ static int process_file(const char *path, vector_t *macros, strbuf_t *out)
                 val = "";
             }
             macro_t m = { vc_strdup(n), vc_strdup(val) };
-            if (!m.name || !m.value || !vector_push(macros, &m)) {
+            if (!vector_push(macros, &m)) {
                 macro_free(&m);
                 free(text);
                 free(dir);

--- a/src/util.c
+++ b/src/util.c
@@ -41,6 +41,15 @@ char *vc_strdup(const char *s)
     return out;
 }
 
+/* Duplicate at most 'n' characters of a string */
+char *vc_strndup(const char *s, size_t n)
+{
+    char *out = vc_alloc_or_exit(n + 1);
+    memcpy(out, s, n);
+    out[n] = '\0';
+    return out;
+}
+
 /* Read the entire contents of a file into memory */
 char *vc_read_file(const char *path)
 {


### PR DESCRIPTION
## Summary
- add `vc_strndup` for bounded duplication
- use `vc_strndup` in the lexer and preprocessor
- drop redundant error checks for macros

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c42a9090c83248dc57536d8134629