### PR TITLE
Enhance preprocessor

### DIFF
--- a/include/preproc.h
+++ b/include/preproc.h
@@ -9,10 +9,13 @@
 #ifndef VC_PREPROC_H
 #define VC_PREPROC_H
 
-/* Preprocess the file at the given path.
- * The returned string must be freed by the caller.
- * Returns NULL on failure.
+/* Preprocess the file at the given path using optional include search paths.
+ * 'search_paths' is an array of directory strings to search when processing
+ * '#include "file"' directives.  The returned string must be freed by the
+ * caller. Returns NULL on failure.
  */
-char *preproc_run(const char *path);
+char *preproc_run(const char *path,
+                  const char **search_paths,
+                  size_t num_paths);
 
 #endif /* VC_PREPROC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -47,7 +47,7 @@ static int output_stage(ir_builder_t *ir, const char *output,
 static int tokenize_stage(const char *source, char **out_src,
                           token_t **out_toks, size_t *out_count)
 {
-    char *text = preproc_run(source);
+    char *text = preproc_run(source, NULL, 0);
     if (!text) {
         perror("preproc_run");
         return 0;


### PR DESCRIPTION
## Summary
- use getline to process source lines without altering the read buffer
- add optional include search paths to `preproc_run`
- move macro handling to helper functions for clarity
- adjust main for the new preprocessor API

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c42394b24832491016bdbf91f5f3a