### PR TITLE
Add x86-64 fixtures and tests

### DIFF
--- a/tests/fixtures/const_load_x86-64.s
+++ b/tests/fixtures/const_load_x86-64.s
@@ -1,0 +1,10 @@
+main:
+    pushq %rbp
+    movq %rsp, %rbp
+    movq $5, %rax
+    movq %rax, x
+    movq $5, %rax
+    movq %rax, y
+    movq $5, %rax
+    movq %rax, %rax
+    ret

--- a/tests/fixtures/pointer_basic_x86-64.s
+++ b/tests/fixtures/pointer_basic_x86-64.s
@@ -1,0 +1,11 @@
+main:
+    pushq %rbp
+    movq %rsp, %rbp
+    movq $x, %rax
+    movq %rax, p
+    movq $42, %rax
+    movq %rax, x
+    movq p, %rax
+    movq (%rax), %rbx
+    movq %rbx, %rax
+    ret

--- a/tests/fixtures/simple_add_x86-64.s
+++ b/tests/fixtures/simple_add_x86-64.s
@@ -1,0 +1,6 @@
+main:
+    pushq %rbp
+    movq %rsp, %rbp
+    movq $7, %rax
+    movq %rax, %rax
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -30,6 +30,19 @@ for o0asm in "$DIR"/fixtures/*_O0.s; do
     rm -f "$out"
 done
 
+# verify 64-bit code generation for selected fixtures
+for asm64 in "$DIR"/fixtures/*_x86-64.s; do
+    base=$(basename "$asm64" _x86-64.s)
+    cfile="$DIR/fixtures/$base.c"
+    out=$(mktemp)
+    "$BINARY" --x86-64 -o "$out" "$cfile"
+    if ! diff -u "$asm64" "$out"; then
+        echo "Test x86_64_$base failed"
+        fail=1
+    fi
+    rm -f "$out"
+done
+
 # negative test for parse error message
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- add assembly output for 64-bit mode
- update test runner to validate x86-64 code generation

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c471ab7308324bfa3a338745e1b59