### PR TITLE
Improve pointer arithmetic

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -423,6 +423,8 @@ vc -o ptr_arith.s ptr_arith.c
 ```
 Pointer subtraction of two pointers is also supported and returns the
 element distance between them.
+Pointer offsets are scaled by the size of the pointed-to type rather
+than the machine word size.
 
 ### Arrays
 ```c

--- a/include/ast.h
+++ b/include/ast.h
@@ -153,6 +153,7 @@ struct expr {
             int is_type;
             type_kind_t type;
             size_t array_size;
+            size_t elem_size;
             expr_t *expr;
         } sizeof_expr;
     };
@@ -193,6 +194,7 @@ struct stmt {
             char *name;
             type_kind_t type;
             size_t array_size;
+            size_t elem_size;
             int is_static;
             int is_const;
             /* optional initializer expression */
@@ -237,6 +239,7 @@ struct stmt {
             char *name;
             type_kind_t type;
             size_t array_size;
+            size_t elem_size;
         } typedef_decl;
         struct {
             char *tag;
@@ -292,7 +295,7 @@ expr_t *ast_make_member(expr_t *object, const char *member, int via_ptr,
                         size_t line, size_t column);
 /* Create a sizeof expression of a type. */
 expr_t *ast_make_sizeof_type(type_kind_t type, size_t array_size,
-                             size_t line, size_t column);
+                             size_t elem_size, size_t line, size_t column);
 /* Create a sizeof expression of another expression. */
 expr_t *ast_make_sizeof_expr(expr_t *expr, size_t line, size_t column);
 /* Create a function call expression with \p arg_count arguments. */
@@ -305,7 +308,7 @@ stmt_t *ast_make_expr_stmt(expr_t *expr, size_t line, size_t column);
 stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column);
 /* Declare a variable optionally initialized by \p init or \p init_list. */
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
-                          int is_static, int is_const,
+                          size_t elem_size, int is_static, int is_const,
                           expr_t *init, expr_t **init_list, size_t init_count,
                           size_t line, size_t column);
 /* Create an if/else statement. \p else_branch may be NULL. */
@@ -334,7 +337,7 @@ stmt_t *ast_make_label(const char *name, size_t line, size_t column);
 stmt_t *ast_make_goto(const char *name, size_t line, size_t column);
 /* Create a typedef declaration */
 stmt_t *ast_make_typedef(const char *name, type_kind_t type, size_t array_size,
-                         size_t line, size_t column);
+                         size_t elem_size, size_t line, size_t column);
 /* Declare an enum with \p count enumerators. */
 stmt_t *ast_make_enum_decl(const char *tag, enumerator_t *items, size_t count,
                            size_t line, size_t column);
@@ -354,6 +357,7 @@ struct func {
     type_kind_t return_type;
     char **param_names;
     type_kind_t *param_types;
+    size_t *param_elem_sizes;
     size_t param_count;
     stmt_t **body;
     size_t body_count;
@@ -362,7 +366,7 @@ struct func {
 /* Create a function definition node with the provided signature and body. */
 func_t *ast_make_func(const char *name, type_kind_t ret_type,
                       char **param_names, type_kind_t *param_types,
-                      size_t param_count,
+                      size_t *param_elem_sizes, size_t param_count,
                       stmt_t **body, size_t body_count);
 /* Free a function and all statements contained in its body. */
 void ast_free_func(func_t *func);

--- a/include/ir.h
+++ b/include/ir.h
@@ -115,6 +115,12 @@ ir_value_t ir_build_load_ptr(ir_builder_t *b, ir_value_t addr);
 /* Append IR_STORE_PTR that stores `val` through pointer `addr`. */
 void ir_build_store_ptr(ir_builder_t *b, ir_value_t addr, ir_value_t val);
 
+/* Pointer arithmetic helpers */
+ir_value_t ir_build_ptr_add(ir_builder_t *b, ir_value_t ptr, ir_value_t idx,
+                            int elem_size);
+ir_value_t ir_build_ptr_diff(ir_builder_t *b, ir_value_t a, ir_value_t bptr,
+                             int elem_size);
+
 /* Append IR_LOAD_IDX fetching `name[idx]`. */
 ir_value_t ir_build_load_idx(ir_builder_t *b, const char *name, ir_value_t idx);
 

--- a/include/parser_types.h
+++ b/include/parser_types.h
@@ -12,6 +12,7 @@
 
 /* Parse a fundamental type specifier possibly prefixed with 'unsigned'. */
 int parse_basic_type(parser_t *p, type_kind_t *out);
+size_t basic_type_size(type_kind_t t);
 
 #endif /* VC_PARSER_TYPES_H */
 

--- a/include/symtable.h
+++ b/include/symtable.h
@@ -18,6 +18,7 @@ typedef struct symbol {
     type_kind_t type;
     int param_index; /* -1 for locals */
     size_t array_size;
+    size_t elem_size;
     int enum_value;
     int is_enum_const;
     int is_typedef;
@@ -48,25 +49,26 @@ void symtable_free(symtable_t *table);
 /* Add a symbol to the table. Returns non-zero on success. */
 /* Locals */
 int symtable_add(symtable_t *table, const char *name, const char *ir_name,
-                 type_kind_t type, size_t array_size,
+                 type_kind_t type, size_t array_size, size_t elem_size,
                  int is_static, int is_const);
 /* Parameters are stored as locals with an index */
 int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
-                       int index);
+                       size_t elem_size, int index);
 /* Functions record return and parameter types */
 int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
                       type_kind_t *param_types, size_t param_count,
                       int is_prototype);
 /* Globals live in a separate list */
 int symtable_add_global(symtable_t *table, const char *name, const char *ir_name,
-                        type_kind_t type, size_t array_size,
+                        type_kind_t type, size_t array_size, size_t elem_size,
                         int is_static, int is_const);
 int symtable_add_enum(symtable_t *table, const char *name, int value);
 int symtable_add_enum_global(symtable_t *table, const char *name, int value);
 int symtable_add_typedef(symtable_t *table, const char *name, type_kind_t type,
-                         size_t array_size);
+                         size_t array_size, size_t elem_size);
 int symtable_add_typedef_global(symtable_t *table, const char *name,
-                                type_kind_t type, size_t array_size);
+                                type_kind_t type, size_t array_size,
+                                size_t elem_size);
 
 /* Look up a symbol by name. Returns NULL if not found. */
 symbol_t *symtable_lookup(symtable_t *table, const char *name);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -126,7 +126,7 @@ static void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
 
     switch (ins->op) {
     case IR_PTR_ADD: {
-        int scale = x64 ? 8 : 4;
+        int scale = ins->imm;
         strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
                        loc_str(buf1, ra, ins->src2, x64),
                        loc_str(buf2, ra, ins->dest, x64));
@@ -138,7 +138,9 @@ static void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
         break;
     }
     case IR_PTR_DIFF: {
-        int shift = x64 ? 3 : 2;
+        int esz = ins->imm;
+        int shift = 0;
+        while ((esz >>= 1) > 0) shift++;
         strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
                        loc_str(buf1, ra, ins->src1, x64),
                        loc_str(buf2, ra, ins->dest, x64));

--- a/src/ir.c
+++ b/src/ir.c
@@ -185,6 +185,34 @@ void ir_build_store_ptr(ir_builder_t *b, ir_value_t addr, ir_value_t val)
     ins->src2 = val.id;
 }
 
+ir_value_t ir_build_ptr_add(ir_builder_t *b, ir_value_t ptr, ir_value_t idx,
+                            int elem_size)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return (ir_value_t){0};
+    ins->op = IR_PTR_ADD;
+    ins->dest = b->next_value_id++;
+    ins->src1 = ptr.id;
+    ins->src2 = idx.id;
+    ins->imm = elem_size;
+    return (ir_value_t){ins->dest};
+}
+
+ir_value_t ir_build_ptr_diff(ir_builder_t *b, ir_value_t a, ir_value_t bptr,
+                             int elem_size)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return (ir_value_t){0};
+    ins->op = IR_PTR_DIFF;
+    ins->dest = b->next_value_id++;
+    ins->src1 = a.id;
+    ins->src2 = bptr.id;
+    ins->imm = elem_size;
+    return (ir_value_t){ins->dest};
+}
+
 /*
  * Emit IR_LOAD_IDX loading from array element `name[idx]`.
  */

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -61,6 +61,7 @@ static stmt_t *parse_var_decl(parser_t *p)
     type_kind_t t;
     if (!parse_basic_type(p, &t))
         return NULL;
+    size_t elem_size = basic_type_size(t);
     if (match(p, TOK_STAR))
         t = TYPE_PTR;
     token_t *tok = peek(p);
@@ -104,7 +105,7 @@ static stmt_t *parse_var_decl(parser_t *p)
         if (!match(p, TOK_SEMI))
             return NULL;
     }
-    return ast_make_var_decl(name, t, arr_size, is_static, is_const,
+    return ast_make_var_decl(name, t, arr_size, elem_size, is_static, is_const,
                              init, init_list, init_count,
                              kw_tok->line, kw_tok->column);
 }

--- a/src/parser_types.c
+++ b/src/parser_types.c
@@ -41,3 +41,19 @@ int parse_basic_type(parser_t *p, type_kind_t *out)
     return 1;
 }
 
+size_t basic_type_size(type_kind_t t)
+{
+    switch (t) {
+    case TYPE_CHAR: case TYPE_UCHAR: case TYPE_BOOL:
+        return 1;
+    case TYPE_SHORT: case TYPE_USHORT:
+        return 2;
+    case TYPE_INT: case TYPE_UINT: case TYPE_LONG: case TYPE_ULONG:
+        return 4;
+    case TYPE_LLONG: case TYPE_ULLONG:
+        return 8;
+    default:
+        return 4;
+    }
+}
+

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -195,7 +195,10 @@ static int eval_const_expr(expr_t *expr, symtable_t *vars, int *out)
             case TYPE_INT: case TYPE_UINT: case TYPE_LONG: case TYPE_ULONG: sz = 4; break;
             case TYPE_LLONG: case TYPE_ULLONG: sz = 8; break;
             case TYPE_PTR:  sz = 4; break;
-            case TYPE_ARRAY: sz = (int)expr->sizeof_expr.array_size * 4; break;
+            case TYPE_ARRAY:
+                sz = (int)expr->sizeof_expr.array_size *
+                     (int)expr->sizeof_expr.elem_size;
+                break;
             default: sz = 0; break;
             }
             *out = sz;
@@ -224,16 +227,29 @@ static type_kind_t check_binary(expr_t *left, expr_t *right, symtable_t *vars,
                (is_intlike(lt) && rt == TYPE_PTR && op == BINOP_ADD)) {
         ir_value_t ptr = (lt == TYPE_PTR) ? lval : rval;
         ir_value_t idx = (lt == TYPE_PTR) ? rval : lval;
+        size_t esz = 4;
+        expr_t *ptexpr = (lt == TYPE_PTR) ? left : right;
+        if (ptexpr->kind == EXPR_IDENT) {
+            symbol_t *s = symtable_lookup(vars, ptexpr->ident.name);
+            if (s && s->elem_size)
+                esz = s->elem_size;
+        }
         if (op == BINOP_SUB && lt == TYPE_PTR) {
             ir_value_t zero = ir_build_const(ir, 0);
             idx = ir_build_binop(ir, IR_SUB, zero, idx);
         }
         if (out)
-            *out = ir_build_binop(ir, IR_PTR_ADD, ptr, idx);
+            *out = ir_build_ptr_add(ir, ptr, idx, (int)esz);
         return TYPE_PTR;
     } else if (lt == TYPE_PTR && rt == TYPE_PTR && op == BINOP_SUB) {
+        size_t esz = 4;
+        if (left->kind == EXPR_IDENT) {
+            symbol_t *s = symtable_lookup(vars, left->ident.name);
+            if (s && s->elem_size)
+                esz = s->elem_size;
+        }
         if (out)
-            *out = ir_build_binop(ir, IR_PTR_DIFF, lval, rval);
+            *out = ir_build_ptr_diff(ir, lval, rval, (int)esz);
         return TYPE_INT;
     }
     error_set(left->line, left->column);
@@ -536,7 +552,10 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
             case TYPE_INT: case TYPE_UINT: case TYPE_LONG: case TYPE_ULONG: sz = 4; break;
             case TYPE_LLONG: case TYPE_ULLONG: sz = 8; break;
             case TYPE_PTR:  sz = 4; break;
-            case TYPE_ARRAY: sz = (int)expr->sizeof_expr.array_size * 4; break;
+            case TYPE_ARRAY:
+                sz = (int)expr->sizeof_expr.array_size *
+                     (int)expr->sizeof_expr.elem_size;
+                break;
             default: sz = 0; break;
             }
         } else {
@@ -552,7 +571,7 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                 symbol_t *sym = NULL;
                 if (expr->sizeof_expr.expr->kind == EXPR_IDENT)
                     sym = symtable_lookup(vars, expr->sizeof_expr.expr->ident.name);
-                sz = sym ? (int)sym->array_size * 4 : 4;
+                sz = sym ? (int)sym->array_size * (int)sym->elem_size : 4;
             }
         }
         if (out)
@@ -888,7 +907,8 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     case STMT_TYPEDEF: {
         if (!symtable_add_typedef(vars, stmt->typedef_decl.name,
                                   stmt->typedef_decl.type,
-                                  stmt->typedef_decl.array_size)) {
+                                  stmt->typedef_decl.array_size,
+                                  stmt->typedef_decl.elem_size)) {
             error_set(stmt->line, stmt->column);
             return 0;
         }
@@ -903,6 +923,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         if (!symtable_add(vars, stmt->var_decl.name, ir_name,
                           stmt->var_decl.type,
                           stmt->var_decl.array_size,
+                          stmt->var_decl.elem_size,
                           stmt->var_decl.is_static,
                           stmt->var_decl.is_const)) {
             error_set(stmt->line, stmt->column);
@@ -992,7 +1013,9 @@ int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
 
     for (size_t i = 0; i < func->param_count; i++)
         symtable_add_param(&locals, func->param_names[i],
-                           func->param_types[i], (int)i);
+                           func->param_types[i],
+                           func->param_elem_sizes ? func->param_elem_sizes[i] : 4,
+                           (int)i);
 
     ir_build_func_begin(ir, func->name);
 
@@ -1042,7 +1065,8 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
     if (decl->kind == STMT_TYPEDEF) {
         if (!symtable_add_typedef_global(globals, decl->typedef_decl.name,
                                          decl->typedef_decl.type,
-                                         decl->typedef_decl.array_size)) {
+                                         decl->typedef_decl.array_size,
+                                         decl->typedef_decl.elem_size)) {
             error_set(decl->line, decl->column);
             return 0;
         }
@@ -1053,6 +1077,7 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
     if (!symtable_add_global(globals, decl->var_decl.name, decl->var_decl.name,
                              decl->var_decl.type,
                              decl->var_decl.array_size,
+                             decl->var_decl.elem_size,
                              decl->var_decl.is_static,
                              decl->var_decl.is_const)) {
         error_set(decl->line, decl->column);


### PR DESCRIPTION
## Summary
- track element sizes for pointer and array symbols
- scale pointer arithmetic by element size via IR imm field
- update sizeof logic for arrays
- document pointer arithmetic scaling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c4d39d7a88324817a109d5900bb0d