### PR TITLE
Add union declaration AST support

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -177,6 +177,7 @@ typedef enum {
     STMT_GOTO,
     STMT_TYPEDEF,
     STMT_ENUM_DECL,
+    STMT_UNION_DECL,
     STMT_BLOCK
 } stmt_kind_t;
 
@@ -197,6 +198,7 @@ struct stmt {
             type_kind_t type;
             size_t array_size;
             size_t elem_size;
+            char *tag; /* NULL for basic types */
             int is_static;
             int is_const;
             /* optional initializer expression */
@@ -251,6 +253,11 @@ struct stmt {
             size_t count;
         } enum_decl;
         struct {
+            char *tag;
+            union_member_t *members;
+            size_t count;
+        } union_decl;
+        struct {
             stmt_t **stmts;
             size_t count;
         } block;
@@ -270,8 +277,8 @@ struct enumerator {
 struct union_member {
     char *name;
     type_kind_t type;
-    size_t array_size;
     size_t elem_size;
+    size_t offset;
 };
 
 /* Constructors */
@@ -353,6 +360,9 @@ stmt_t *ast_make_typedef(const char *name, type_kind_t type, size_t array_size,
 /* Declare an enum with \p count enumerators. */
 stmt_t *ast_make_enum_decl(const char *tag, enumerator_t *items, size_t count,
                            size_t line, size_t column);
+/* Declare a union with \p count members. */
+stmt_t *ast_make_union_decl(const char *tag, union_member_t *members,
+                           size_t count, size_t line, size_t column);
 /* Create a block of statements containing \p count elements. */
 stmt_t *ast_make_block(stmt_t **stmts, size_t count,
                        size_t line, size_t column);

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -209,7 +209,10 @@ stmt_t *parser_parse_union_decl(parser_t *p)
         }
         if (!match(p, TOK_SEMI))
             goto fail;
-        union_member_t m = { vc_strdup(id->lexeme), mt, arr_size, elem_size };
+        size_t mem_sz = elem_size;
+        if (mt == TYPE_ARRAY)
+            mem_sz *= arr_size;
+        union_member_t m = { vc_strdup(id->lexeme), mt, mem_sz, 0 };
         if (!vector_push(&members_v, &m)) {
             free(m.name);
             goto fail;

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -988,8 +988,6 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
             for (size_t i = 0; i < stmt->var_decl.member_count; i++) {
                 union_member_t *m = &stmt->var_decl.members[i];
                 size_t sz = m->elem_size;
-                if (m->type == TYPE_ARRAY)
-                    sz *= m->array_size;
                 if (sz > max)
                     max = sz;
             }
@@ -1159,8 +1157,6 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
         for (size_t i = 0; i < decl->var_decl.member_count; i++) {
             union_member_t *m = &decl->var_decl.members[i];
             size_t sz = m->elem_size;
-            if (m->type == TYPE_ARRAY)
-                sz *= m->array_size;
             if (sz > max)
                 max = sz;
         }


### PR DESCRIPTION
## Summary
- extend the statement enum with `STMT_UNION_DECL`
- add tag field for struct/union variable declarations
- define `union_member_t` with elem size and offset
- implement `ast_make_union_decl` and update cleanup logic
- adjust parser and semantic handling for new union_member layout

## Testing
- `make`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c5a759b88832492e703acbf530822