### PR TITLE
Add union declaration parsing

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -328,8 +328,8 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column);
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
                           size_t elem_size, int is_static, int is_const,
                           expr_t *init, expr_t **init_list, size_t init_count,
-                          union_member_t *members, size_t member_count,
-                          size_t line, size_t column);
+                          const char *tag, union_member_t *members,
+                          size_t member_count, size_t line, size_t column);
 /* Create an if/else statement. \p else_branch may be NULL. */
 stmt_t *ast_make_if(expr_t *cond, stmt_t *then_branch, stmt_t *else_branch,
                     size_t line, size_t column);

--- a/include/parser.h
+++ b/include/parser.h
@@ -62,6 +62,7 @@ expr_t *parser_parse_expr(parser_t *p);
 expr_t **parser_parse_init_list(parser_t *p, size_t *out_count);
 stmt_t *parser_parse_enum_decl(parser_t *p);
 stmt_t *parser_parse_union_decl(parser_t *p);
+stmt_t *parser_parse_union_var_decl(parser_t *p);
 
 /* Returns non-zero if the parser has reached EOF */
 int parser_is_eof(parser_t *p);

--- a/src/ast.c
+++ b/src/ast.c
@@ -276,8 +276,8 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column)
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
                           size_t elem_size, int is_static, int is_const,
                           expr_t *init, expr_t **init_list, size_t init_count,
-                          union_member_t *members, size_t member_count,
-                          size_t line, size_t column)
+                          const char *tag, union_member_t *members,
+                          size_t member_count, size_t line, size_t column)
 {
     stmt_t *stmt = malloc(sizeof(*stmt));
     if (!stmt)
@@ -293,7 +293,16 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
     stmt->var_decl.type = type;
     stmt->var_decl.array_size = array_size;
     stmt->var_decl.elem_size = elem_size;
-    stmt->var_decl.tag = NULL;
+    if (tag) {
+        stmt->var_decl.tag = vc_strdup(tag);
+        if (!stmt->var_decl.tag) {
+            free(stmt->var_decl.name);
+            free(stmt);
+            return NULL;
+        }
+    } else {
+        stmt->var_decl.tag = NULL;
+    }
     stmt->var_decl.is_static = is_static;
     stmt->var_decl.is_const = is_const;
     stmt->var_decl.init = init;

--- a/src/parser.c
+++ b/src/parser.c
@@ -303,11 +303,21 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         return 0;
 
     if (tok->type == TOK_KW_UNION) {
+        token_t *next = &p->tokens[p->pos + 1];
+        if (next && next->type == TOK_IDENT &&
+            p->pos + 2 < p->count && p->tokens[p->pos + 2].type == TOK_LBRACE) {
+            p->pos = save;
+            if (out_global)
+                *out_global = parser_parse_union_decl(p);
+            else
+                parser_parse_union_decl(p);
+            return out_global ? *out_global != NULL : 1;
+        }
         p->pos = save;
         if (out_global)
-            *out_global = parser_parse_union_decl(p);
+            *out_global = parser_parse_union_var_decl(p);
         else
-            parser_parse_union_decl(p);
+            parser_parse_union_var_decl(p);
         return out_global ? *out_global != NULL : 1;
     }
 
@@ -443,7 +453,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size,
                                            elem_size, is_static, is_const,
                                            NULL, NULL, 0,
-                                           NULL, 0,
+                                           NULL, NULL, 0,
                                            tok->line, tok->column);
         return *out_global != NULL;
     } else if (next_tok && next_tok->type == TOK_ASSIGN) {
@@ -478,7 +488,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size,
                                            elem_size, is_static, is_const,
                                            init, init_list, init_count,
-                                           NULL, 0,
+                                           NULL, NULL, 0,
                                            tok->line, tok->column);
         return *out_global != NULL;
     }

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -20,6 +20,7 @@ static stmt_t *parse_block(parser_t *p);
 static stmt_t *parse_var_decl(parser_t *p);
 stmt_t *parser_parse_enum_decl(parser_t *p);
 stmt_t *parser_parse_union_decl(parser_t *p);
+stmt_t *parser_parse_union_var_decl(parser_t *p);
 stmt_t *parser_parse_stmt(parser_t *p);
 
 /* Parse a "{...}" block recursively collecting inner statements. */
@@ -60,9 +61,22 @@ static stmt_t *parse_var_decl(parser_t *p)
     int is_const = match(p, TOK_KW_CONST);
     token_t *kw_tok = peek(p);
     type_kind_t t;
-    if (!parse_basic_type(p, &t))
-        return NULL;
-    size_t elem_size = basic_type_size(t);
+    char *tag_name = NULL;
+    size_t elem_size = 0;
+    if (match(p, TOK_KW_UNION)) {
+        token_t *tag_tok = peek(p);
+        if (!tag_tok || tag_tok->type != TOK_IDENT)
+            return NULL;
+        p->pos++;
+        tag_name = vc_strdup(tag_tok->lexeme);
+        if (!tag_name)
+            return NULL;
+        t = TYPE_UNION;
+    } else {
+        if (!parse_basic_type(p, &t))
+            return NULL;
+        elem_size = basic_type_size(t);
+    }
     if (match(p, TOK_STAR))
         t = TYPE_PTR;
     token_t *tok = peek(p);
@@ -106,10 +120,13 @@ static stmt_t *parse_var_decl(parser_t *p)
         if (!match(p, TOK_SEMI))
             return NULL;
     }
-    return ast_make_var_decl(name, t, arr_size, elem_size, is_static, is_const,
-                             init, init_list, init_count,
-                             NULL, 0,
-                             kw_tok->line, kw_tok->column);
+    stmt_t *res = ast_make_var_decl(name, t, arr_size, elem_size, is_static,
+                                    is_const, init, init_list, init_count,
+                                    tag_name, NULL, 0,
+                                    kw_tok->line, kw_tok->column);
+    if (!res)
+        free(tag_name);
+    return res;
 }
 
 /* Parse an enum declaration */
@@ -171,8 +188,8 @@ fail:
     return ast_make_enum_decl(tag, items, count, kw->line, kw->column);
 }
 
-/* Parse a union declaration */
-stmt_t *parser_parse_union_decl(parser_t *p)
+/* Parse a union variable with inline member specification */
+stmt_t *parser_parse_union_var_decl(parser_t *p)
 {
     int is_static = match(p, TOK_KW_STATIC);
     int is_const = match(p, TOK_KW_CONST);
@@ -237,9 +254,82 @@ fail:
     }
     union_member_t *members = (union_member_t *)members_v.data;
     size_t count = members_v.count;
-    return ast_make_var_decl(name, TYPE_UNION, 0, 0, is_static, is_const,
-                             NULL, NULL, 0, members, count,
-                             kw->line, kw->column);
+    stmt_t *res = ast_make_var_decl(name, TYPE_UNION, 0, 0, is_static, is_const,
+                                    NULL, NULL, 0, NULL, members, count,
+                                    kw->line, kw->column);
+    if (!res) {
+        for (size_t i = 0; i < count; i++)
+            free(members[i].name);
+        free(members);
+    }
+    return res;
+}
+
+/* Parse a named union type declaration */
+stmt_t *parser_parse_union_decl(parser_t *p)
+{
+    if (!match(p, TOK_KW_UNION))
+        return NULL;
+    token_t *kw = &p->tokens[p->pos - 1];
+    token_t *tok = peek(p);
+    if (!tok || tok->type != TOK_IDENT)
+        return NULL;
+    p->pos++;
+    char *tag = tok->lexeme;
+    if (!match(p, TOK_LBRACE))
+        return NULL;
+
+    vector_t members_v;
+    vector_init(&members_v, sizeof(union_member_t));
+    int ok = 0;
+    while (!match(p, TOK_RBRACE)) {
+        type_kind_t mt;
+        if (!parse_basic_type(p, &mt))
+            goto fail;
+        size_t elem_size = basic_type_size(mt);
+        if (match(p, TOK_STAR))
+            mt = TYPE_PTR;
+        token_t *id = peek(p);
+        if (!id || id->type != TOK_IDENT)
+            goto fail;
+        p->pos++;
+        size_t arr_size = 0;
+        if (match(p, TOK_LBRACKET)) {
+            token_t *num = peek(p);
+            if (!num || num->type != TOK_NUMBER)
+                goto fail;
+            p->pos++;
+            arr_size = strtoul(num->lexeme, NULL, 10);
+            if (!match(p, TOK_RBRACKET))
+                goto fail;
+            mt = TYPE_ARRAY;
+        }
+        if (!match(p, TOK_SEMI))
+            goto fail;
+        size_t mem_sz = elem_size;
+        if (mt == TYPE_ARRAY)
+            mem_sz *= arr_size;
+        union_member_t m = { vc_strdup(id->lexeme), mt, mem_sz, 0 };
+        if (!vector_push(&members_v, &m)) {
+            free(m.name);
+            goto fail;
+        }
+    }
+
+    if (!match(p, TOK_SEMI))
+        goto fail;
+
+    ok = 1;
+fail:
+    if (!ok) {
+        for (size_t i = 0; i < members_v.count; i++)
+            free(((union_member_t *)members_v.data)[i].name);
+        vector_free(&members_v);
+        return NULL;
+    }
+    union_member_t *members = (union_member_t *)members_v.data;
+    size_t count = members_v.count;
+    return ast_make_union_decl(tag, members, count, kw->line, kw->column);
 }
 
 /*
@@ -264,14 +354,28 @@ stmt_t *parser_parse_stmt(parser_t *p)
 
     tok = peek(p);
     size_t save = p->pos;
-    match(p, TOK_KW_STATIC);
-    match(p, TOK_KW_CONST);
-    token_t *t2 = peek(p);
-    if (t2 && t2->type == TOK_KW_UNION) {
+    int has_static = match(p, TOK_KW_STATIC);
+    int has_const = match(p, TOK_KW_CONST);
+    if (match(p, TOK_KW_UNION)) {
+        token_t *next = peek(p);
+        if (next && next->type == TOK_LBRACE) {
+            p->pos = save;
+            return parser_parse_union_var_decl(p);
+        } else if (next && next->type == TOK_IDENT) {
+            p->pos++;
+            token_t *after = peek(p);
+            if (!has_static && !has_const && after && after->type == TOK_LBRACE) {
+                p->pos = save;
+                return parser_parse_union_decl(p);
+            }
+            p->pos = save;
+            return parse_var_decl(p);
+        } else {
+            p->pos = save;
+        }
+    } else {
         p->pos = save;
-        return parser_parse_union_decl(p);
     }
-    p->pos = save;
     if (tok && tok->type == TOK_KW_STATIC)
         return parse_var_decl(p);
     if (tok && tok->type == TOK_KW_CONST)

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -967,6 +967,9 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         }
         return 1;
     }
+    case STMT_UNION_DECL:
+        /* union type declarations are currently ignored */
+        return 1;
     case STMT_TYPEDEF: {
         if (!symtable_add_typedef(vars, stmt->typedef_decl.name,
                                   stmt->typedef_decl.type,
@@ -1138,6 +1141,10 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
             }
             next = val + 1;
         }
+        return 1;
+    }
+    if (decl->kind == STMT_UNION_DECL) {
+        /* union type declarations have no semantic impact */
         return 1;
     }
     if (decl->kind == STMT_TYPEDEF) {


### PR DESCRIPTION
## Summary
- support named union type declarations
- allow inline union variables and tagged union variables in statements
- track union tags in variable declarations
- ignore union declarations during semantic analysis

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c5c3f8af88324a3e3a9c5fc678cdf