### PR TITLE
Enable 64-bit integer IR

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -68,7 +68,9 @@ int y = 5;      /* evaluates 5 and stores to 'y' */
 
 Additional built-in types such as `short`, `long`, `long long` and
 `bool` are recognized.  Each integer type also has an unsigned variant
-using the `unsigned` keyword.
+using the `unsigned` keyword.  The IR now stores immediates in a
+64-bit field so `long long` literals and arithmetic are handled without
+truncation when generating x86-64 code.
 
 Pointers work the same way and may be dereferenced using
 `UNOP_DEREF`:

--- a/include/ir.h
+++ b/include/ir.h
@@ -72,7 +72,7 @@ typedef struct ir_instr {
     int dest;             /* destination value id (-1 if none) */
     int src1;             /* first operand */
     int src2;             /* second operand */
-    int imm;              /* immediate value for constants */
+    long long imm;        /* immediate value for constants and sizes */
     char *name;           /* identifier / label */
     char *data;           /* for string literals */
     struct ir_instr *next;
@@ -92,7 +92,7 @@ void ir_builder_init(ir_builder_t *b);
 void ir_builder_free(ir_builder_t *b);
 
 /* Append IR_CONST producing a new value holding an immediate. */
-ir_value_t ir_build_const(ir_builder_t *b, int value);
+ir_value_t ir_build_const(ir_builder_t *b, long long value);
 
 /* Append IR_LOAD for variable `name`. */
 ir_value_t ir_build_load(ir_builder_t *b, const char *name);
@@ -153,9 +153,10 @@ void ir_build_label(ir_builder_t *b, const char *label);
 
 /* Global data declarations. */
 ir_value_t ir_build_string(ir_builder_t *b, const char *data);
-void ir_build_glob_var(ir_builder_t *b, const char *name, int value, int is_static);
+void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
+                       int is_static);
 void ir_build_glob_array(ir_builder_t *b, const char *name,
-                         const int *values, size_t count, int is_static);
+                         const long long *values, size_t count, int is_static);
 void ir_build_glob_union(ir_builder_t *b, const char *name, int size,
                          int is_static);
 

--- a/man/vc.1
+++ b/man/vc.1
@@ -11,7 +11,7 @@ It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays, pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, floating-point variables, the
-\fBchar\fR type, basic \fBstruct\fR declarations, \fBunion\fR declarations, and the
+\fBchar\fR type, support for 64-bit integer constants, basic \fBstruct\fR declarations, \fBunion\fR declarations, and the
 \fBbreak\fR and \fBcontinue\fR statements.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -47,7 +47,7 @@ static void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
 
     switch (ins->op) {
     case IR_CONST:
-        strbuf_appendf(sb, "    mov%s $%d, %s\n", sfx, ins->imm,
+        strbuf_appendf(sb, "    mov%s $%lld, %s\n", sfx, ins->imm,
                        loc_str(buf1, ra, ins->dest, x64));
         break;
     case IR_LOAD:
@@ -499,15 +499,15 @@ void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x64)
                 fprintf(out, ".local %s\n", ins->name);
             fprintf(out, "%s:\n", ins->name);
             if (ins->op == IR_GLOB_VAR) {
-                fprintf(out, "    %s %d\n", size_directive, ins->imm);
+                fprintf(out, "    %s %lld\n", size_directive, ins->imm);
             } else if (ins->op == IR_GLOB_STRING) {
                 fprintf(out, "    .asciz \"%s\"\n", ins->data);
             } else if (ins->op == IR_GLOB_ARRAY) {
-                int *vals = (int *)ins->data;
-                for (int i = 0; i < ins->imm; i++)
-                    fprintf(out, "    %s %d\n", size_directive, vals[i]);
+                long long *vals = (long long *)ins->data;
+                for (long long i = 0; i < ins->imm; i++)
+                    fprintf(out, "    %s %lld\n", size_directive, vals[i]);
             } else if (ins->op == IR_GLOB_UNION) {
-                fprintf(out, "    .zero %d\n", ins->imm);
+                fprintf(out, "    .zero %lld\n", ins->imm);
             }
         }
     }

--- a/src/ir.c
+++ b/src/ir.c
@@ -60,7 +60,7 @@ static ir_instr_t *append_instr(ir_builder_t *b)
  * Emit IR_CONST. dest gets a fresh id and imm stores the constant
  * value.
  */
-ir_value_t ir_build_const(ir_builder_t *b, int value)
+ir_value_t ir_build_const(ir_builder_t *b, long long value)
 {
     ir_instr_t *ins = append_instr(b);
     if (!ins)
@@ -315,7 +315,7 @@ ir_value_t ir_build_call(ir_builder_t *b, const char *name, size_t arg_count)
     ins->op = IR_CALL;
     ins->dest = b->next_value_id++;
     ins->name = vc_strdup(name ? name : "");
-    ins->imm = (int)arg_count;
+    ins->imm = (long long)arg_count;
     return (ir_value_t){ins->dest};
 }
 
@@ -376,7 +376,8 @@ void ir_build_label(ir_builder_t *b, const char *label)
  * Emit IR_GLOB_VAR declaring global variable `name` with constant
  * initializer `value`.
  */
-void ir_build_glob_var(ir_builder_t *b, const char *name, int value, int is_static)
+void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
+                       int is_static)
 {
     ir_instr_t *ins = append_instr(b);
     if (!ins)
@@ -388,7 +389,7 @@ void ir_build_glob_var(ir_builder_t *b, const char *name, int value, int is_stat
 }
 
 void ir_build_glob_array(ir_builder_t *b, const char *name,
-                         const int *values, size_t count, int is_static)
+                         const long long *values, size_t count, int is_static)
 {
     /* Emit IR_GLOB_ARRAY storing an array of constants. `data` points
      * to a copy of the initializer values. */
@@ -397,10 +398,10 @@ void ir_build_glob_array(ir_builder_t *b, const char *name,
         return;
     ins->op = IR_GLOB_ARRAY;
     ins->name = vc_strdup(name ? name : "");
-    ins->imm = (int)count;
+    ins->imm = (long long)count;
     ins->src1 = is_static;
     if (count) {
-        int *vals = malloc(count * sizeof(int));
+        long long *vals = malloc(count * sizeof(long long));
         if (!vals)
             return;
         for (size_t i = 0; i < count; i++)

--- a/src/ir_dump.c
+++ b/src/ir_dump.c
@@ -78,14 +78,14 @@ char *ir_to_string(ir_builder_t *ir)
     strbuf_init(&sb);
     for (ir_instr_t *ins = ir->head; ins; ins = ins->next) {
         if (ins->op == IR_GLOB_ARRAY) {
-            strbuf_appendf(&sb, "%s name=%s count=%d\n", op_name(ins->op),
+            strbuf_appendf(&sb, "%s name=%s count=%lld\n", op_name(ins->op),
                            ins->name ? ins->name : "", ins->imm);
         } else if (ins->op == IR_GLOB_UNION) {
-            strbuf_appendf(&sb, "%s name=%s size=%d\n", op_name(ins->op),
+            strbuf_appendf(&sb, "%s name=%s size=%lld\n", op_name(ins->op),
                            ins->name ? ins->name : "", ins->imm);
         } else {
             strbuf_appendf(&sb,
-                           "%s dest=%d src1=%d src2=%d imm=%d name=%s data=%s\n",
+                           "%s dest=%d src1=%d src2=%d imm=%lld name=%s data=%s\n",
                            op_name(ins->op), ins->dest, ins->src1, ins->src2,
                            ins->imm, ins->name ? ins->name : "",
                            ins->data ? ins->data : "");

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -13,6 +13,7 @@
 #include "util.h"
 #include "label.h"
 #include "error.h"
+#include <limits.h>
 
 typedef struct label_entry {
     char *name;
@@ -135,22 +136,22 @@ static void symtable_pop_scope(symtable_t *table, symbol_t *old_head)
 
 
 /* Evaluate a constant expression at compile time. Returns non-zero on success. */
-static int eval_const_expr(expr_t *expr, symtable_t *vars, int *out)
+static int eval_const_expr(expr_t *expr, symtable_t *vars, long long *out)
 {
     if (!expr)
         return 0;
     switch (expr->kind) {
     case EXPR_NUMBER:
         if (out)
-            *out = (int)strtol(expr->number.value, NULL, 10);
+            *out = strtoll(expr->number.value, NULL, 10);
         return 1;
     case EXPR_CHAR:
         if (out)
-            *out = (int)expr->ch.value;
+            *out = (long long)expr->ch.value;
         return 1;
     case EXPR_UNARY:
         if (expr->unary.op == UNOP_NEG) {
-            int val;
+            long long val;
             if (eval_const_expr(expr->unary.operand, vars, &val)) {
                 if (out)
                     *out = -val;
@@ -159,7 +160,7 @@ static int eval_const_expr(expr_t *expr, symtable_t *vars, int *out)
         }
         return 0;
     case EXPR_BINARY: {
-        int a, b;
+        long long a, b;
         if (!eval_const_expr(expr->binary.left, vars, &a) ||
             !eval_const_expr(expr->binary.right, vars, &b))
             return 0;
@@ -186,7 +187,7 @@ static int eval_const_expr(expr_t *expr, symtable_t *vars, int *out)
         return 1;
     }
     case EXPR_COND: {
-        int cval;
+        long long cval;
         if (!eval_const_expr(expr->cond.cond, vars, &cval))
             return 0;
         if (cval)
@@ -257,6 +258,9 @@ static type_kind_t check_binary(expr_t *left, expr_t *right, symtable_t *vars,
             ir_op_t ir_op = binop_to_ir[op];
             *out = ir_build_binop(ir, ir_op, lval, rval);
         }
+        if (lt == TYPE_LLONG || lt == TYPE_ULLONG ||
+            rt == TYPE_LLONG || rt == TYPE_ULLONG)
+            return TYPE_LLONG;
         return TYPE_INT;
     } else if ((lt == TYPE_PTR && is_intlike(rt) &&
                 (op == BINOP_ADD || op == BINOP_SUB)) ||
@@ -331,7 +335,7 @@ static type_kind_t check_unary_expr(expr_t *expr, symtable_t *vars,
                 ir_value_t zero = ir_build_const(ir, 0);
                 *out = ir_build_binop(ir, IR_SUB, zero, val);
             }
-            return TYPE_INT;
+            return vt == TYPE_LLONG || vt == TYPE_ULLONG ? TYPE_LLONG : TYPE_INT;
         } else if (is_floatlike(vt)) {
             if (out) {
                 ir_value_t zero = ir_build_const(ir, 0);
@@ -454,10 +458,14 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
     if (!expr)
         return TYPE_UNKNOWN;
     switch (expr->kind) {
-    case EXPR_NUMBER:
+    case EXPR_NUMBER: {
+        long long val = strtoll(expr->number.value, NULL, 10);
         if (out)
-            *out = ir_build_const(ir, (int)strtol(expr->number.value, NULL, 10));
+            *out = ir_build_const(ir, val);
+        if (val > INT_MAX || val < INT_MIN)
+            return TYPE_LLONG;
         return TYPE_INT;
+    }
     case EXPR_STRING:
         if (out)
             *out = ir_build_string(ir, expr->string.value);
@@ -522,6 +530,9 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
         }
         if (out)
             *out = ir_build_load(ir, tmp);
+        if (tt == TYPE_LLONG || tt == TYPE_ULLONG ||
+            ft == TYPE_LLONG || ft == TYPE_ULLONG)
+            return TYPE_LLONG;
         return TYPE_INT;
     }
     case EXPR_ASSIGN: {
@@ -565,7 +576,7 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
             error_set(expr->index.index->line, expr->index.index->column);
             return TYPE_UNKNOWN;
         }
-        int cval;
+        long long cval;
         if (sym->array_size && eval_const_expr(expr->index.index, vars, &cval)) {
             if (cval < 0 || (size_t)cval >= sym->array_size) {
                 error_set(expr->index.index->line, expr->index.index->column);
@@ -599,7 +610,7 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
             error_set(expr->assign_index.value->line, expr->assign_index.value->column);
             return TYPE_UNKNOWN;
         }
-        int cval;
+        long long cval;
         if (sym->array_size && eval_const_expr(expr->assign_index.index, vars, &cval)) {
             if (cval < 0 || (size_t)cval >= sym->array_size) {
                 error_set(expr->assign_index.index->line, expr->assign_index.index->column);
@@ -888,7 +899,7 @@ static int check_switch_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         char lbl[32];
         snprintf(lbl, sizeof(lbl), "L%d_case%zu", id, i);
         case_labels[i] = vc_strdup(lbl);
-        int cval;
+        long long cval;
         if (!eval_const_expr(stmt->switch_stmt.cases[i].expr, vars, &cval)) {
             for (size_t j = 0; j <= i; j++) free(case_labels[j]);
             free(case_labels);
@@ -1017,18 +1028,18 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         int next = 0;
         for (size_t i = 0; i < stmt->enum_decl.count; i++) {
             enumerator_t *e = &stmt->enum_decl.items[i];
-            int val = next;
+            long long val = next;
             if (e->value) {
                 if (!eval_const_expr(e->value, vars, &val)) {
                     error_set(e->value->line, e->value->column);
                     return 0;
                 }
             }
-            if (!symtable_add_enum(vars, e->name, val)) {
+            if (!symtable_add_enum(vars, e->name, (int)val)) {
                 error_set(stmt->line, stmt->column);
                 return 0;
             }
-            next = val + 1;
+            next = (int)val + 1;
         }
         return 1;
     }
@@ -1094,7 +1105,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         }
         if (stmt->var_decl.init) {
             if (stmt->var_decl.is_static) {
-                int cval;
+                long long cval;
                 if (!eval_const_expr(stmt->var_decl.init, vars, &cval)) {
                     error_set(stmt->var_decl.init->line, stmt->var_decl.init->column);
                     return 0;
@@ -1121,7 +1132,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                 error_set(stmt->line, stmt->column);
                 return 0;
             }
-            int *vals = calloc(stmt->var_decl.array_size, sizeof(int));
+            long long *vals = calloc(stmt->var_decl.array_size, sizeof(long long));
             if (!vals) return 0;
             for (size_t i = 0; i < stmt->var_decl.init_count; i++) {
                 if (!eval_const_expr(stmt->var_decl.init_list[i], vars, &vals[i])) {
@@ -1214,18 +1225,18 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
         int next = 0;
         for (size_t i = 0; i < decl->enum_decl.count; i++) {
             enumerator_t *e = &decl->enum_decl.items[i];
-            int val = next;
+            long long val = next;
             if (e->value) {
                 if (!eval_const_expr(e->value, globals, &val)) {
                     error_set(e->value->line, e->value->column);
                     return 0;
                 }
             }
-            if (!symtable_add_enum_global(globals, e->name, val)) {
+            if (!symtable_add_enum_global(globals, e->name, (int)val)) {
                 error_set(decl->line, decl->column);
                 return 0;
             }
-            next = val + 1;
+            next = (int)val + 1;
         }
         return 1;
     }
@@ -1285,7 +1296,7 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
     }
     if (decl->var_decl.type == TYPE_ARRAY) {
         size_t count = decl->var_decl.array_size;
-        int *vals = calloc(count, sizeof(int));
+        long long *vals = calloc(count, sizeof(long long));
         if (!vals)
             return 0;
         size_t init_count = decl->var_decl.init_count;
@@ -1306,7 +1317,7 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
                            decl->var_decl.is_static);
         free(vals);
     } else {
-        int value = 0;
+        long long value = 0;
         if (decl->var_decl.init) {
             if (!eval_const_expr(decl->var_decl.init, globals, &value)) {
                 error_set(decl->var_decl.init->line, decl->var_decl.init->column);

--- a/tests/fixtures/ll_arith.c
+++ b/tests/fixtures/ll_arith.c
@@ -1,0 +1,9 @@
+int main() {
+    long long a;
+    a = 5000000000;
+    long long b;
+    b = 7;
+    int r;
+    r = a + b;
+    return r;
+}

--- a/tests/fixtures/ll_arith.s
+++ b/tests/fixtures/ll_arith.s
@@ -1,0 +1,12 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $5000000000, %eax
+    movl %eax, a
+    movl $7, %eax
+    movl %eax, b
+    movl $705032711, %eax
+    movl %eax, r
+    movl r, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/ll_arith_x86-64.s
+++ b/tests/fixtures/ll_arith_x86-64.s
@@ -1,0 +1,12 @@
+main:
+    pushq %rbp
+    movq %rsp, %rbp
+    movq $5000000000, %rax
+    movq %rax, a
+    movq $7, %rax
+    movq %rax, b
+    movq $705032711, %rax
+    movq %rax, r
+    movq r, %rax
+    movq %rax, %rax
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,6 +6,9 @@ BINARY="$DIR/../vc"
 fail=0
 for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
+    case "$base" in
+        *_x86-64) continue;;
+    esac
     expect="$DIR/fixtures/$base.s"
     out=$(mktemp)
     echo "Running fixture $base"


### PR DESCRIPTION
## Summary
- widen `imm` field in IR to 64 bits
- emit 64-bit immediates in x86 code generation
- handle long long constants in semantic analysis
- document 64-bit support
- add regression test for long long arithmetic

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c6ac7c3fc8324afddd1d2feedf16a