### PR TITLE
Add preprocess option

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -694,6 +694,7 @@ The compiler supports the following options:
 - `--link` – build an executable by assembling and linking with `cc`.
 - `--dump-asm` – print the generated assembly to stdout instead of creating a file.
 - `--dump-ir` – print the IR to stdout before code generation.
+- `-E`, `--preprocess` – print the preprocessed source to stdout and exit.
 - `-I`, `--include <dir>` – add directory to the `#include` search path.
 - `-O<N>` – set optimization level (0 disables all passes).
 

--- a/include/cli.h
+++ b/include/cli.h
@@ -20,6 +20,7 @@ typedef struct {
     int link;           /* build executable */
     int dump_asm;       /* dump assembly to stdout */
     int dump_ir;        /* dump IR to stdout */
+    int preprocess;     /* print preprocessed source */
     vector_t include_dirs; /* additional include directories */
     const char *source; /* input source file */
 } cli_options_t;

--- a/man/vc.1
+++ b/man/vc.1
@@ -60,6 +60,9 @@ Print generated assembly to stdout rather than creating a file.
 .TP
 .B --dump-ir
 Print IR to stdout before generating assembly.
+.TP
+.BR -E "," \fB--preprocess\fR
+Print the preprocessed source to stdout and exit.
 .SH EXAMPLES
 Compile a source file to \fIout.s\fR:
 .PP

--- a/src/cli.c
+++ b/src/cli.c
@@ -31,6 +31,7 @@ static void print_usage(const char *prog)
     printf("      --x86-64         Generate 64-bit x86 assembly\n");
     printf("      --dump-asm       Print assembly to stdout and exit\n");
     printf("      --dump-ir        Print IR to stdout and exit\n");
+    printf("  -E, --preprocess     Print preprocessed source and exit\n");
 }
 
 int cli_parse_args(int argc, char **argv, cli_options_t *opts)
@@ -47,6 +48,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"dump-asm", no_argument,     0, 4},
         {"no-cprop", no_argument,     0, 5},
         {"dump-ir", no_argument,      0, 6},
+        {"preprocess", no_argument,  0, 'E'},
         {"link", no_argument,        0, 7},
         {0, 0, 0, 0}
     };
@@ -61,11 +63,12 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
     opts->link = 0;
     opts->dump_asm = 0;
     opts->dump_ir = 0;
+    opts->preprocess = 0;
     vector_init(&opts->include_dirs, sizeof(char *));
     opts->source = NULL;
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hvo:O:cI:", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hvo:O:cEI:", long_opts, NULL)) != -1) {
         switch (opt) {
         case 'h':
             print_usage(argv[0]);
@@ -115,6 +118,9 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         case 6:
             opts->dump_ir = 1;
             break;
+        case 'E':
+            opts->preprocess = 1;
+            break;
         case 7:
             opts->link = 1;
             break;
@@ -130,7 +136,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         return 1;
     }
 
-    if (!opts->output && !opts->dump_asm && !opts->dump_ir) {
+    if (!opts->output && !opts->dump_asm && !opts->dump_ir && !opts->preprocess) {
         fprintf(stderr, "Error: no output path specified.\n");
         print_usage(argv[0]);
         return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -237,6 +237,17 @@ int main(int argc, char **argv)
     int dump_ir = cli.dump_ir;
     int link = cli.link;
 
+    if (cli.preprocess) {
+        char *text = preproc_run(source, &cli.include_dirs);
+        if (!text) {
+            perror("preproc_run");
+            return 1;
+        }
+        printf("%s", text);
+        free(text);
+        return 0;
+    }
+
     label_init();
 
     char *src_text = NULL;


### PR DESCRIPTION
## Summary
- add `preprocess` field in CLI options
- support `-E`/`--preprocess` in option parser and usage text
- print preprocessed output when requested
- document the new option in documentation and man page

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c7f92d0b48324a952b385427d041d