### PR TITLE
Add struct parsing support

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -63,6 +63,8 @@ expr_t **parser_parse_init_list(parser_t *p, size_t *out_count);
 stmt_t *parser_parse_enum_decl(parser_t *p);
 stmt_t *parser_parse_union_decl(parser_t *p);
 stmt_t *parser_parse_union_var_decl(parser_t *p);
+stmt_t *parser_parse_struct_decl(parser_t *p);
+stmt_t *parser_parse_struct_var_decl(parser_t *p);
 
 /* Returns non-zero if the parser has reached EOF */
 int parser_is_eof(parser_t *p);

--- a/src/parser.c
+++ b/src/parser.c
@@ -318,6 +318,25 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
     if (!tok)
         return 0;
 
+    if (tok->type == TOK_KW_STRUCT) {
+        token_t *next = &p->tokens[p->pos + 1];
+        if (next && next->type == TOK_IDENT &&
+            p->pos + 2 < p->count && p->tokens[p->pos + 2].type == TOK_LBRACE) {
+            p->pos = save;
+            if (out_global)
+                *out_global = parser_parse_struct_decl(p);
+            else
+                parser_parse_struct_decl(p);
+            return out_global ? *out_global != NULL : 1;
+        }
+        p->pos = save;
+        if (out_global)
+            *out_global = parser_parse_struct_var_decl(p);
+        else
+            parser_parse_struct_var_decl(p);
+        return out_global ? *out_global != NULL : 1;
+    }
+
     if (tok->type == TOK_KW_UNION) {
         token_t *next = &p->tokens[p->pos + 1];
         if (next && next->type == TOK_IDENT &&

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -22,6 +22,8 @@ stmt_t *parser_parse_enum_decl(parser_t *p);
 stmt_t *parser_parse_union_decl(parser_t *p);
 stmt_t *parser_parse_union_var_decl(parser_t *p);
 stmt_t *parser_parse_stmt(parser_t *p);
+stmt_t *parser_parse_struct_decl(parser_t *p);
+stmt_t *parser_parse_struct_var_decl(parser_t *p);
 
 /* Parse a "{...}" block recursively collecting inner statements. */
 static stmt_t *parse_block(parser_t *p)
@@ -339,6 +341,152 @@ fail:
     return ast_make_union_decl(tag, members, count, kw->line, kw->column);
 }
 
+/* Parse a struct variable with inline member specification */
+stmt_t *parser_parse_struct_var_decl(parser_t *p)
+{
+    int is_static = match(p, TOK_KW_STATIC);
+    int is_const = match(p, TOK_KW_CONST);
+    int is_volatile = match(p, TOK_KW_VOLATILE);
+    if (!match(p, TOK_KW_STRUCT))
+        return NULL;
+    token_t *kw = &p->tokens[p->pos - 1];
+    if (!match(p, TOK_LBRACE))
+        return NULL;
+
+    vector_t members_v;
+    vector_init(&members_v, sizeof(struct_member_t));
+    int ok = 0;
+    while (!match(p, TOK_RBRACE)) {
+        type_kind_t mt;
+        if (!parse_basic_type(p, &mt))
+            goto fail;
+        size_t elem_size = basic_type_size(mt);
+        if (match(p, TOK_STAR))
+            mt = TYPE_PTR;
+        token_t *id = peek(p);
+        if (!id || id->type != TOK_IDENT)
+            goto fail;
+        p->pos++;
+        size_t arr_size = 0;
+        if (match(p, TOK_LBRACKET)) {
+            token_t *num = peek(p);
+            if (!num || num->type != TOK_NUMBER)
+                goto fail;
+            p->pos++;
+            arr_size = strtoul(num->lexeme, NULL, 10);
+            if (!match(p, TOK_RBRACKET))
+                goto fail;
+            mt = TYPE_ARRAY;
+        }
+        if (!match(p, TOK_SEMI))
+            goto fail;
+        size_t mem_sz = elem_size;
+        if (mt == TYPE_ARRAY)
+            mem_sz *= arr_size;
+        struct_member_t m = { vc_strdup(id->lexeme), mt, mem_sz, 0 };
+        if (!vector_push(&members_v, &m)) {
+            free(m.name);
+            goto fail;
+        }
+    }
+
+    token_t *name_tok = peek(p);
+    if (!name_tok || name_tok->type != TOK_IDENT)
+        goto fail;
+    p->pos++;
+    char *name = name_tok->lexeme;
+    if (!match(p, TOK_SEMI))
+        goto fail;
+
+    ok = 1;
+fail:
+    if (!ok) {
+        for (size_t i = 0; i < members_v.count; i++)
+            free(((struct_member_t *)members_v.data)[i].name);
+        vector_free(&members_v);
+        return NULL;
+    }
+    struct_member_t *members = (struct_member_t *)members_v.data;
+    size_t count = members_v.count;
+    stmt_t *res = ast_make_var_decl(name, TYPE_STRUCT, 0, 0, is_static, is_const,
+                                    is_volatile, 0, NULL, NULL, 0, NULL,
+                                    (union_member_t *)members, count,
+                                    kw->line, kw->column);
+    if (!res) {
+        for (size_t i = 0; i < count; i++)
+            free(members[i].name);
+        free(members);
+    }
+    return res;
+}
+
+/* Parse a named struct type declaration */
+stmt_t *parser_parse_struct_decl(parser_t *p)
+{
+    if (!match(p, TOK_KW_STRUCT))
+        return NULL;
+    token_t *kw = &p->tokens[p->pos - 1];
+    token_t *tok = peek(p);
+    if (!tok || tok->type != TOK_IDENT)
+        return NULL;
+    p->pos++;
+    char *tag = tok->lexeme;
+    if (!match(p, TOK_LBRACE))
+        return NULL;
+
+    vector_t members_v;
+    vector_init(&members_v, sizeof(struct_member_t));
+    int ok = 0;
+    while (!match(p, TOK_RBRACE)) {
+        type_kind_t mt;
+        if (!parse_basic_type(p, &mt))
+            goto fail;
+        size_t elem_size = basic_type_size(mt);
+        if (match(p, TOK_STAR))
+            mt = TYPE_PTR;
+        token_t *id = peek(p);
+        if (!id || id->type != TOK_IDENT)
+            goto fail;
+        p->pos++;
+        size_t arr_size = 0;
+        if (match(p, TOK_LBRACKET)) {
+            token_t *num = peek(p);
+            if (!num || num->type != TOK_NUMBER)
+                goto fail;
+            p->pos++;
+            arr_size = strtoul(num->lexeme, NULL, 10);
+            if (!match(p, TOK_RBRACKET))
+                goto fail;
+            mt = TYPE_ARRAY;
+        }
+        if (!match(p, TOK_SEMI))
+            goto fail;
+        size_t mem_sz = elem_size;
+        if (mt == TYPE_ARRAY)
+            mem_sz *= arr_size;
+        struct_member_t m = { vc_strdup(id->lexeme), mt, mem_sz, 0 };
+        if (!vector_push(&members_v, &m)) {
+            free(m.name);
+            goto fail;
+        }
+    }
+
+    if (!match(p, TOK_SEMI))
+        goto fail;
+
+    ok = 1;
+fail:
+    if (!ok) {
+        for (size_t i = 0; i < members_v.count; i++)
+            free(((struct_member_t *)members_v.data)[i].name);
+        vector_free(&members_v);
+        return NULL;
+    }
+    struct_member_t *members = (struct_member_t *)members_v.data;
+    size_t count = members_v.count;
+    return ast_make_struct_decl(tag, members, count, kw->line, kw->column);
+}
+
 /*
  * Parse a single statement at the current position.  This function
  * delegates to the specific helpers for declarations, control flow
@@ -364,7 +512,24 @@ stmt_t *parser_parse_stmt(parser_t *p)
     int has_static = match(p, TOK_KW_STATIC);
     int has_const = match(p, TOK_KW_CONST);
     int has_vol = match(p, TOK_KW_VOLATILE);
-    if (match(p, TOK_KW_UNION)) {
+    if (match(p, TOK_KW_STRUCT)) {
+        token_t *next = peek(p);
+        if (next && next->type == TOK_LBRACE) {
+            p->pos = save;
+            return parser_parse_struct_var_decl(p);
+        } else if (next && next->type == TOK_IDENT) {
+            p->pos++;
+            token_t *after = peek(p);
+            if (!has_static && !has_const && !has_vol && after && after->type == TOK_LBRACE) {
+                p->pos = save;
+                return parser_parse_struct_decl(p);
+            }
+            p->pos = save;
+            return parse_var_decl(p);
+        } else {
+            p->pos = save;
+        }
+    } else if (match(p, TOK_KW_UNION)) {
         token_t *next = peek(p);
         if (next && next->type == TOK_LBRACE) {
             p->pos = save;


### PR DESCRIPTION
## Summary
- extend parser to support struct declarations and struct variable declarations with inline member lists
- handle `struct` tokens at top-level and statement level
- expose new struct parser helpers in the public header

## Testing
- `make -s`
- `make -s test`

------
https://chatgpt.com/codex/tasks/task_e_685c879a84b48324ba6535ea5c62c932