### PR TITLE
Implement struct layout handling

### DIFF
--- a/src/semantic.c
+++ b/src/semantic.c
@@ -100,7 +100,8 @@ static size_t layout_union_members(union_member_t *members, size_t count)
     return max;
 }
 
-/* Compute byte offsets for struct members sequentially and return total size. */
+/* Compute byte offsets for struct members sequentially and return the
+ * total size of the struct. */
 static size_t layout_struct_members(struct_member_t *members, size_t count)
 {
     size_t off = 0;
@@ -668,7 +669,7 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                 return TYPE_UNKNOWN;
             }
             obj_sym = symtable_lookup(vars, expr->assign_member.object->ident.name);
-            if (!obj_sym || obj_sym->type != TYPE_UNION) {
+            if (!obj_sym || (obj_sym->type != TYPE_UNION && obj_sym->type != TYPE_STRUCT)) {
                 error_set(expr->assign_member.object->line,
                           expr->assign_member.object->column);
                 return TYPE_UNKNOWN;
@@ -676,38 +677,51 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
             base_addr = ir_build_addr(ir, obj_sym->ir_name);
         }
 
-        if (!obj_sym || obj_sym->type != TYPE_UNION || obj_sym->member_count == 0) {
+        if (!obj_sym ||
+            ((obj_sym->type == TYPE_UNION && obj_sym->member_count == 0) ||
+             (obj_sym->type == TYPE_STRUCT && obj_sym->struct_member_count == 0))) {
             error_set(expr->line, expr->column);
             return TYPE_UNKNOWN;
         }
-
-        union_member_t *member = NULL;
-        for (size_t i = 0; i < obj_sym->member_count; i++) {
-            if (strcmp(obj_sym->members[i].name, expr->assign_member.member) == 0) {
-                member = &obj_sym->members[i];
-                break;
+        type_kind_t mtype = TYPE_UNKNOWN;
+        size_t moff = 0;
+        if (obj_sym->type == TYPE_UNION) {
+            for (size_t i = 0; i < obj_sym->member_count; i++) {
+                if (strcmp(obj_sym->members[i].name, expr->assign_member.member) == 0) {
+                    mtype = obj_sym->members[i].type;
+                    moff = obj_sym->members[i].offset;
+                    break;
+                }
+            }
+        } else {
+            for (size_t i = 0; i < obj_sym->struct_member_count; i++) {
+                if (strcmp(obj_sym->struct_members[i].name, expr->assign_member.member) == 0) {
+                    mtype = obj_sym->struct_members[i].type;
+                    moff = obj_sym->struct_members[i].offset;
+                    break;
+                }
             }
         }
-        if (!member) {
+        if (mtype == TYPE_UNKNOWN) {
             error_set(expr->line, expr->column);
             return TYPE_UNKNOWN;
         }
 
         ir_value_t val;
         type_kind_t vt = check_expr(expr->assign_member.value, vars, funcs, ir, &val);
-        if (!(((is_intlike(member->type) && is_intlike(vt)) ||
-               (is_floatlike(member->type) && (is_floatlike(vt) || is_intlike(vt)))) ||
-              vt == member->type)) {
+        if (!(((is_intlike(mtype) && is_intlike(vt)) ||
+               (is_floatlike(mtype) && (is_floatlike(vt) || is_intlike(vt)))) ||
+              vt == mtype)) {
             error_set(expr->assign_member.value->line, expr->assign_member.value->column);
             return TYPE_UNKNOWN;
         }
 
-        ir_value_t idx = ir_build_const(ir, (int)member->offset);
+        ir_value_t idx = ir_build_const(ir, (int)moff);
         ir_value_t addr = ir_build_ptr_add(ir, base_addr, idx, 1);
         ir_build_store_ptr(ir, addr, val);
         if (out)
             *out = val;
-        return member->type;
+        return mtype;
     }
     case EXPR_MEMBER: {
         if (!expr->member.object)
@@ -731,7 +745,7 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                 return TYPE_UNKNOWN;
             }
             obj_sym = symtable_lookup(vars, expr->member.object->ident.name);
-            if (!obj_sym || obj_sym->type != TYPE_UNION) {
+            if (!obj_sym || (obj_sym->type != TYPE_UNION && obj_sym->type != TYPE_STRUCT)) {
                 error_set(expr->member.object->line,
                           expr->member.object->column);
                 return TYPE_UNKNOWN;
@@ -739,29 +753,41 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
             base_addr = ir_build_addr(ir, obj_sym->ir_name);
         }
 
-        if (!obj_sym || obj_sym->type != TYPE_UNION || obj_sym->member_count == 0) {
+        if (!obj_sym ||
+            ((obj_sym->type == TYPE_UNION && obj_sym->member_count == 0) ||
+             (obj_sym->type == TYPE_STRUCT && obj_sym->struct_member_count == 0))) {
             error_set(expr->line, expr->column);
             return TYPE_UNKNOWN;
         }
-
-        union_member_t *member = NULL;
-        for (size_t i = 0; i < obj_sym->member_count; i++) {
-            if (strcmp(obj_sym->members[i].name, expr->member.member) == 0) {
-                member = &obj_sym->members[i];
-                break;
+        type_kind_t mtype = TYPE_UNKNOWN;
+        size_t moff = 0;
+        if (obj_sym->type == TYPE_UNION) {
+            for (size_t i = 0; i < obj_sym->member_count; i++) {
+                if (strcmp(obj_sym->members[i].name, expr->member.member) == 0) {
+                    mtype = obj_sym->members[i].type;
+                    moff = obj_sym->members[i].offset;
+                    break;
+                }
+            }
+        } else {
+            for (size_t i = 0; i < obj_sym->struct_member_count; i++) {
+                if (strcmp(obj_sym->struct_members[i].name, expr->member.member) == 0) {
+                    mtype = obj_sym->struct_members[i].type;
+                    moff = obj_sym->struct_members[i].offset;
+                    break;
+                }
             }
         }
-        if (!member) {
+        if (mtype == TYPE_UNKNOWN) {
             error_set(expr->line, expr->column);
             return TYPE_UNKNOWN;
         }
-
         if (out) {
-            ir_value_t idx = ir_build_const(ir, (int)member->offset);
+            ir_value_t idx = ir_build_const(ir, (int)moff);
             ir_value_t addr = ir_build_ptr_add(ir, base_addr, idx, 1);
             *out = ir_build_load_ptr(ir, addr);
         }
-        return member->type;
+        return mtype;
     }
     case EXPR_SIZEOF: {
         int sz = 0;
@@ -775,6 +801,9 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
             case TYPE_ARRAY:
                 sz = (int)expr->sizeof_expr.array_size *
                      (int)expr->sizeof_expr.elem_size;
+                break;
+            case TYPE_STRUCT:
+                sz = (int)expr->sizeof_expr.elem_size;
                 break;
             default: sz = 0; break;
             }
@@ -797,6 +826,11 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                 if (expr->sizeof_expr.expr->kind == EXPR_IDENT)
                     sym = symtable_lookup(vars, expr->sizeof_expr.expr->ident.name);
                 sz = sym ? (int)sym->total_size : 0;
+            } else if (t == TYPE_STRUCT) {
+                symbol_t *sym = NULL;
+                if (expr->sizeof_expr.expr->kind == EXPR_IDENT)
+                    sym = symtable_lookup(vars, expr->sizeof_expr.expr->ident.name);
+                sz = sym ? (int)sym->struct_total_size : 0;
             }
         }
         if (out)
@@ -1133,13 +1167,15 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     case STMT_STRUCT_DECL: {
         size_t total = layout_struct_members(stmt->struct_decl.members,
                                              stmt->struct_decl.count);
-        (void)total;
         if (!symtable_add_struct(vars, stmt->struct_decl.tag,
                                  stmt->struct_decl.members,
                                  stmt->struct_decl.count)) {
             error_set(stmt->line, stmt->column);
             return 0;
         }
+        symbol_t *stype = symtable_lookup_struct(vars, stmt->struct_decl.tag);
+        if (stype)
+            stype->struct_total_size = total;
         return 1;
     }
     case STMT_UNION_DECL: {
@@ -1175,6 +1211,13 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                                              stmt->var_decl.member_count);
             stmt->var_decl.elem_size = max;
         }
+        if (stmt->var_decl.type == TYPE_STRUCT) {
+            size_t total = layout_struct_members(
+                (struct_member_t *)stmt->var_decl.members,
+                stmt->var_decl.member_count);
+            if (stmt->var_decl.member_count || stmt->var_decl.tag)
+                stmt->var_decl.elem_size = total;
+        }
         if (!symtable_add(vars, stmt->var_decl.name, ir_name,
                           stmt->var_decl.type,
                           stmt->var_decl.array_size,
@@ -1201,6 +1244,24 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                     sym->members[i].type = m->type;
                     sym->members[i].elem_size = m->elem_size;
                     sym->members[i].offset = m->offset;
+                }
+            }
+        }
+        if (stmt->var_decl.type == TYPE_STRUCT) {
+            sym->struct_total_size = stmt->var_decl.elem_size;
+            if (stmt->var_decl.member_count) {
+                sym->struct_members = malloc(stmt->var_decl.member_count *
+                                             sizeof(*sym->struct_members));
+                if (!sym->struct_members)
+                    return 0;
+                sym->struct_member_count = stmt->var_decl.member_count;
+                for (size_t i = 0; i < sym->struct_member_count; i++) {
+                    struct_member_t *m =
+                        (struct_member_t *)&stmt->var_decl.members[i];
+                    sym->struct_members[i].name = vc_strdup(m->name);
+                    sym->struct_members[i].type = m->type;
+                    sym->struct_members[i].elem_size = m->elem_size;
+                    sym->struct_members[i].offset = m->offset;
                 }
             }
         }
@@ -1349,14 +1410,18 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
         return 1;
     }
     if (decl->kind == STMT_STRUCT_DECL) {
-        layout_struct_members(decl->struct_decl.members,
-                             decl->struct_decl.count);
+        size_t total = layout_struct_members(decl->struct_decl.members,
+                                             decl->struct_decl.count);
         if (!symtable_add_struct_global(globals, decl->struct_decl.tag,
                                         decl->struct_decl.members,
                                         decl->struct_decl.count)) {
             error_set(decl->line, decl->column);
             return 0;
         }
+        symbol_t *stype =
+            symtable_lookup_struct(globals, decl->struct_decl.tag);
+        if (stype)
+            stype->struct_total_size = total;
         return 1;
     }
     if (decl->kind == STMT_UNION_DECL) {
@@ -1386,6 +1451,13 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
                                           decl->var_decl.member_count);
         decl->var_decl.elem_size = max;
     }
+    if (decl->var_decl.type == TYPE_STRUCT) {
+        size_t total = layout_struct_members(
+            (struct_member_t *)decl->var_decl.members,
+            decl->var_decl.member_count);
+        if (decl->var_decl.member_count || decl->var_decl.tag)
+            decl->var_decl.elem_size = total;
+    }
     if (!symtable_add_global(globals, decl->var_decl.name, decl->var_decl.name,
                              decl->var_decl.type,
                              decl->var_decl.array_size,
@@ -1412,6 +1484,24 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
                 gsym->members[i].type = m->type;
                 gsym->members[i].elem_size = m->elem_size;
                 gsym->members[i].offset = m->offset;
+            }
+        }
+    }
+    if (decl->var_decl.type == TYPE_STRUCT) {
+        gsym->struct_total_size = decl->var_decl.elem_size;
+        if (decl->var_decl.member_count) {
+            gsym->struct_members = malloc(decl->var_decl.member_count *
+                                          sizeof(*gsym->struct_members));
+            if (!gsym->struct_members)
+                return 0;
+            gsym->struct_member_count = decl->var_decl.member_count;
+            for (size_t i = 0; i < gsym->struct_member_count; i++) {
+                struct_member_t *m =
+                    (struct_member_t *)&decl->var_decl.members[i];
+                gsym->struct_members[i].name = vc_strdup(m->name);
+                gsym->struct_members[i].type = m->type;
+                gsym->struct_members[i].elem_size = m->elem_size;
+                gsym->struct_members[i].offset = m->offset;
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `layout_struct_members` helper
- store computed struct sizes for struct declarations and variables
- validate struct member access and assignment
- support `sizeof` on struct objects

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c8915ecf08324a595679e44d43324