### PR TITLE
Add struct assignment fixture

### DIFF
--- a/tests/fixtures/struct_assign.c
+++ b/tests/fixtures/struct_assign.c
@@ -1,0 +1,6 @@
+struct { int x; int y; } p;
+int main() {
+    p.x = 5;
+    p.y = 10;
+    return p.x + p.y;
+}

--- a/tests/fixtures/struct_assign.s
+++ b/tests/fixtures/struct_assign.s
@@ -1,0 +1,37 @@
+.data
+p:
+    .zero 8
+.text
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $p, %eax
+    movl $5, %ebx
+    movl $0, %ecx
+    movl %ecx, %edx
+    imull $1, %edx
+    addl %eax, %edx
+    movl %ebx, (%edx)
+    movl $p, %ebx
+    movl $10, %edx
+    movl $4, %ecx
+    movl %ecx, %eax
+    imull $1, %eax
+    addl %ebx, %eax
+    movl %edx, (%eax)
+    movl $p, %edx
+    movl $0, %eax
+    movl %eax, %ecx
+    imull $1, %ecx
+    addl %edx, %ecx
+    movl (%ecx), %eax
+    movl $p, %ecx
+    movl $4, %edx
+    movl %edx, %ebx
+    imull $1, %ebx
+    addl %ecx, %ebx
+    movl (%ebx), %edx
+    movl %eax, %ebx
+    addl %edx, %ebx
+    movl %ebx, %eax
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,9 +8,24 @@ for cfile in $(ls "$DIR"/fixtures/*.c | sort); do
     base=$(basename "$cfile" .c)
 
     case "$base" in
-        *_x86-64) continue;;
+        *_x86-64|struct_*) continue;;
     esac
     [ "$base" = "include_search" ] && continue
+    expect="$DIR/fixtures/$base.s"
+    out=$(mktemp)
+    echo "Running fixture $base"
+    "$BINARY" -o "$out" "$cfile"
+    if ! diff -u "$expect" "$out"; then
+        echo "Test $base failed"
+        fail=1
+    fi
+    rm -f "$out"
+done
+
+# run struct fixtures separately to ensure struct member access and assignment
+for cfile in "$DIR"/fixtures/struct_*.c; do
+    [ -e "$cfile" ] || continue
+    base=$(basename "$cfile" .c)
     expect="$DIR/fixtures/$base.s"
     out=$(mktemp)
     echo "Running fixture $base"


### PR DESCRIPTION
## Summary
- add struct_assign test fixture for struct member access
- compile fixture to get expected assembly
- ensure run_tests.sh processes struct fixtures separately

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ca0e6a7208324914b24287dfb808b