### PR TITLE
Add --std option

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -687,6 +687,7 @@ The compiler supports the following options:
 - `--link` – build an executable by assembling and linking with `cc`.
 - `--dump-asm` – print the generated assembly to stdout instead of creating a file.
 - `--dump-ir` – print the IR to stdout before code generation.
+- `--std=<c99|gnu99>` – select the language standard (default is `c99`).
 - `-E`, `--preprocess` – print the preprocessed source to stdout and exit.
 - `-I`, `--include <dir>` – add directory to the `#include` search path.
 - `-O<N>` – set optimization level (0 disables all passes).

--- a/include/cli.h
+++ b/include/cli.h
@@ -11,6 +11,11 @@
 #include "opt.h"
 #include "vector.h"
 
+typedef enum {
+    STD_C99 = 0,
+    STD_GNU99
+} c_std_t;
+
 /* Command line options parsed from argv */
 typedef struct {
     char *output;       /* output file path */
@@ -21,6 +26,7 @@ typedef struct {
     int dump_asm;       /* dump assembly to stdout */
     int dump_ir;        /* dump IR to stdout */
     int preprocess;     /* print preprocessed source */
+    c_std_t std;        /* language standard */
     vector_t include_dirs; /* additional include directories */
     const char *source; /* input source file */
 } cli_options_t;

--- a/man/vc.1
+++ b/man/vc.1
@@ -62,6 +62,9 @@ Print generated assembly to stdout rather than creating a file.
 .B --dump-ir
 Print IR to stdout before generating assembly.
 .TP
+.BR --std=\fIstd\fR
+Select the language standard. Valid values are \fIc99\fR (default) or \fIgnu99\fR.
+.TP
 .BR -E "," \fB--preprocess\fR
 Print the preprocessed source to stdout and exit.
 .SH EXAMPLES

--- a/src/cli.c
+++ b/src/cli.c
@@ -21,6 +21,7 @@ static void print_usage(const char *prog)
     printf("  -o, --output <file>  Output path\n");
     printf("  -O<N>               Optimization level (0-3)\n");
     printf("  -I, --include <dir> Add directory to include search path\n");
+    printf("      --std=<std>      Language standard (c99 or gnu99)\n");
     printf("  -h, --help           Display this help and exit\n");
     printf("  -v, --version        Print version information and exit\n");
     printf("  -c, --compile        Assemble to an object file\n");
@@ -50,6 +51,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"dump-ir", no_argument,      0, 6},
         {"preprocess", no_argument,  0, 'E'},
         {"link", no_argument,        0, 7},
+        {"std", required_argument,   0, 8},
         {0, 0, 0, 0}
     };
 
@@ -64,6 +66,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
     opts->dump_asm = 0;
     opts->dump_ir = 0;
     opts->preprocess = 0;
+    opts->std = STD_C99;
     vector_init(&opts->include_dirs, sizeof(char *));
     opts->source = NULL;
 
@@ -123,6 +126,16 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
             break;
         case 7:
             opts->link = 1;
+            break;
+        case 8:
+            if (strcmp(optarg, "c99") == 0)
+                opts->std = STD_C99;
+            else if (strcmp(optarg, "gnu99") == 0)
+                opts->std = STD_GNU99;
+            else {
+                fprintf(stderr, "Unknown standard '%s'\n", optarg);
+                return 1;
+            }
             break;
         default:
             print_usage(argv[0]);

--- a/src/main.c
+++ b/src/main.c
@@ -233,6 +233,7 @@ int main(int argc, char **argv)
     char *output = cli.output;
     opt_config_t opt_cfg = cli.opt_cfg;
     int use_x86_64 = cli.use_x86_64;
+    c_std_t std = cli.std;
     int dump_asm = cli.dump_asm;
     int dump_ir = cli.dump_ir;
     int link = cli.link;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -167,6 +167,26 @@ if ! od -An -t x1 "$exe_out" | head -n 1 | grep -q "7f 45 4c 46"; then
 fi
 rm -f "$exe_out"
 
+# test --std option
+std_out=$(mktemp)
+"$BINARY" --std=gnu99 -o "$std_out" "$DIR/fixtures/simple_add.c"
+if ! diff -u "$DIR/fixtures/simple_add.s" "$std_out" > /dev/null; then
+    echo "Test std_gnu99 failed"
+    fail=1
+fi
+rm -f "$std_out"
+
+err=$(mktemp)
+set +e
+"$BINARY" --std=c23 -o "$std_out" "$DIR/fixtures/simple_add.c" 2> "$err"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Unknown standard" "$err"; then
+    echo "Test invalid_std failed"
+    fail=1
+fi
+rm -f "$std_out" "$err"
+
 if [ $fail -eq 0 ]; then
     echo "All tests passed"
 else


### PR DESCRIPTION
## Summary
- add `--std=<c99|gnu99>` option to CLI
- track chosen standard in `cli_options_t`
- document the new command-line option
- test the option works and invalid value is rejected

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ca9acb0008324abf96135051e9948