### PR TITLE
Add variable length array support

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -498,6 +498,21 @@ Compile with:
 vc -o array_init.s array_init.c
 ```
 
+Variable length arrays may use any runtime expression between the brackets:
+
+```c
+/* vla.c */
+int main(int n) {
+    int buf[n + 2];
+    buf[0] = 1;
+    return buf[n];
+}
+```
+Compile with:
+```sh
+vc -o vla.s vla.c
+```
+
 ### sizeof
 `sizeof` returns the number of bytes for a type or expression without
 evaluating the expression.

--- a/include/ast.h
+++ b/include/ast.h
@@ -208,6 +208,7 @@ struct stmt {
             char *name;
             type_kind_t type;
             size_t array_size;
+            expr_t *size_expr;
             size_t elem_size;
             char *tag; /* NULL for basic types */
             int is_static;
@@ -354,8 +355,8 @@ stmt_t *ast_make_expr_stmt(expr_t *expr, size_t line, size_t column);
 stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column);
 /* Declare a variable optionally initialized by \p init or \p init_list. */
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
-                          size_t elem_size, int is_static, int is_const,
-                          int is_volatile, int is_restrict,
+                          expr_t *size_expr, size_t elem_size, int is_static,
+                          int is_const, int is_volatile, int is_restrict,
                           expr_t *init, expr_t **init_list, size_t init_count,
                           const char *tag, union_member_t *members,
                           size_t member_count, size_t line, size_t column);

--- a/include/ir.h
+++ b/include/ir.h
@@ -53,6 +53,7 @@ typedef enum {
     IR_STORE_PTR,
     IR_LOAD_IDX,
     IR_STORE_IDX,
+    IR_ALLOCA,
     IR_ARG,
     IR_RETURN,
     IR_CALL,
@@ -143,6 +144,9 @@ void ir_build_store_idx(ir_builder_t *b, const char *name, ir_value_t idx,
                         ir_value_t val);
 void ir_build_store_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx,
                             ir_value_t val);
+
+/* Allocate `size` bytes on the stack and return the address. */
+ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size);
 
 /* Append IR_RETURN with return value `val`. */
 void ir_build_return(ir_builder_t *b, ir_value_t val);

--- a/man/vc.1
+++ b/man/vc.1
@@ -10,7 +10,7 @@ is a lightweight ANSI C compiler with experimental C99 support.
 It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
-Supported constructs include arrays, pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, floating-point variables including \fBlong double\fR, the
+Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants, complete \fBstruct\fR and \fBunion\fR declarations, the
 \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements.
 .PP

--- a/src/ast.c
+++ b/src/ast.c
@@ -295,7 +295,7 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column)
 
 /* Create a variable declaration statement. */
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
-                          size_t elem_size, int is_static, int is_const,
+                          expr_t *size_expr, size_t elem_size, int is_static, int is_const,
                           int is_volatile, int is_restrict,
                           expr_t *init, expr_t **init_list, size_t init_count,
                           const char *tag, union_member_t *members,
@@ -314,6 +314,7 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
     }
     stmt->var_decl.type = type;
     stmt->var_decl.array_size = array_size;
+    stmt->var_decl.size_expr = size_expr;
     stmt->var_decl.elem_size = elem_size;
     if (tag) {
         stmt->var_decl.tag = vc_strdup(tag);
@@ -705,6 +706,7 @@ void ast_free_stmt(stmt_t *stmt)
         break;
     case STMT_VAR_DECL:
         free(stmt->var_decl.name);
+        ast_free_expr(stmt->var_decl.size_expr);
         ast_free_expr(stmt->var_decl.init);
         for (size_t i = 0; i < stmt->var_decl.init_count; i++)
             ast_free_expr(stmt->var_decl.init_list[i]);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -441,6 +441,17 @@ static void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
     case IR_LABEL:
         strbuf_appendf(sb, "%s:\n", ins->name);
         break;
+    case IR_ALLOCA: {
+        const char *sfx = x64 ? "q" : "l";
+        const char *sp = x64 ? "%rsp" : "%esp";
+        char buf1[32];
+        char buf2[32];
+        strbuf_appendf(sb, "    sub%s %s, %s\n", sfx,
+                       loc_str(buf1, ra, ins->src1, x64), sp);
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, sp,
+                       loc_str(buf2, ra, ins->dest, x64));
+        break;
+    }
     default:
         break;
     }

--- a/src/ir.c
+++ b/src/ir.c
@@ -293,6 +293,17 @@ void ir_build_store_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx,
     ins->is_volatile = 1;
 }
 
+ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return (ir_value_t){0};
+    ins->op = IR_ALLOCA;
+    ins->dest = b->next_value_id++;
+    ins->src1 = size.id;
+    return (ir_value_t){ins->dest};
+}
+
 /*
  * Emit a binary arithmetic or comparison instruction. Operands are in
  * src1 and src2 and a new destination value id is returned.


### PR DESCRIPTION
## Summary
- allow full expressions inside array brackets
- extend AST var_decl with `size_expr`
- handle new IR_ALLOCA op in codegen
- document VLAs and mention in man page

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685caba3ba18832494eba5f45700aca8