### PR TITLE
Add hex and octal literal support

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -284,6 +284,7 @@ RETURN v2
 - Object-like and multi-parameter `#define` macros with recursive expansion
 - Conditional preprocessing directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else`, `#endif`)
 - 64-bit integer literals and arithmetic when using `long long`
+- Hexadecimal (`0x`) and octal (leading `0`) integer literals
 
 Examples below show how to compile each feature.
 
@@ -369,6 +370,19 @@ Compile with:
 ```sh
 vc -o ll_const.s ll_const.c
 vc --x86-64 -o ll_const_x86-64.s ll_const.c
+```
+
+### Numeric constants
+
+Integer literals may be written in decimal, hexadecimal or octal form.
+Numbers beginning with `0x` or `0X` are parsed as hexadecimal. Numbers
+starting with `0` but not `0x`/`0X` are treated as octal. All other
+numbers are interpreted as decimal.
+
+```c
+int a = 0x2a;  /* 42 in hex */
+int b = 0755;  /* octal */
+int c = 10;    /* decimal */
 ```
 
 ### Function calls

--- a/man/vc.1
+++ b/man/vc.1
@@ -11,7 +11,7 @@ It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, floating-point variables including \fBlong double\fR, the
-\fBchar\fR type, support for 64-bit integer constants, complete \fBstruct\fR and \fBunion\fR declarations, the
+\fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, complete \fBstruct\fR and \fBunion\fR declarations, the
 \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -139,8 +139,20 @@ static void read_number(const char *src, size_t *i, size_t *col,
                         vector_t *tokens, size_t line)
 {
     size_t start = *i;
-    while (isdigit((unsigned char)src[*i]))
+
+    if (src[*i] == '0' && (src[*i + 1] == 'x' || src[*i + 1] == 'X')) {
+        (*i) += 2; /* consume 0x */
+        while (isxdigit((unsigned char)src[*i]))
+            (*i)++;
+    } else if (src[*i] == '0') {
         (*i)++;
+        while (src[*i] >= '0' && src[*i] <= '7')
+            (*i)++;
+    } else {
+        while (isdigit((unsigned char)src[*i]))
+            (*i)++;
+    }
+
     size_t len = *i - start;
     append_token(tokens, TOK_NUMBER, src + start, len, line, *col);
     *col += len;

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -155,7 +155,7 @@ static int eval_const_expr(expr_t *expr, symtable_t *vars, long long *out)
     switch (expr->kind) {
     case EXPR_NUMBER:
         if (out)
-            *out = strtoll(expr->number.value, NULL, 10);
+            *out = strtoll(expr->number.value, NULL, 0);
         return 1;
     case EXPR_CHAR:
         if (out)
@@ -480,7 +480,7 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
         return TYPE_UNKNOWN;
     switch (expr->kind) {
     case EXPR_NUMBER: {
-        long long val = strtoll(expr->number.value, NULL, 10);
+        long long val = strtoll(expr->number.value, NULL, 0);
         if (out)
             *out = ir_build_const(ir, val);
         if (val > INT_MAX || val < INT_MIN)


### PR DESCRIPTION
## Summary
- extend `read_number` to parse `0x`/`0X` hex and leading `0` octal literals
- parse integer literals with base detection in semantic analysis
- document numeric literal formats
- mention hex and octal literals in manual

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cae996c448324b1a20beda9dc8c4c