### PR TITLE
Add extern declaration support

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -278,6 +278,7 @@ RETURN v2
 - Floating-point types (`float`, `double`, `long double`)
 - `sizeof` operator
 - Global variables
+- `extern` declarations for globals and function prototypes
 - `break` and `continue` statements
 - Labels and `goto`
 - `struct` and `union` objects with member assignments

--- a/include/ast.h
+++ b/include/ast.h
@@ -212,6 +212,7 @@ struct stmt {
             size_t elem_size;
             char *tag; /* NULL for basic types */
             int is_static;
+            int is_extern;
             int is_const;
             int is_volatile;
             int is_restrict;
@@ -356,7 +357,7 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column);
 /* Declare a variable optionally initialized by \p init or \p init_list. */
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
                           expr_t *size_expr, size_t elem_size, int is_static,
-                          int is_const, int is_volatile, int is_restrict,
+                          int is_extern, int is_const, int is_volatile, int is_restrict,
                           expr_t *init, expr_t **init_list, size_t init_count,
                           const char *tag, union_member_t *members,
                           size_t member_count, size_t line, size_t column);

--- a/include/token.h
+++ b/include/token.h
@@ -31,6 +31,7 @@ typedef enum {
     TOK_KW_UNION,
     TOK_KW_TYPEDEF,
     TOK_KW_STATIC,
+    TOK_KW_EXTERN,
     TOK_KW_CONST,
     TOK_KW_VOLATILE,
     TOK_KW_RESTRICT,

--- a/man/vc.1
+++ b/man/vc.1
@@ -10,7 +10,7 @@ is a lightweight ANSI C compiler with experimental C99 support.
 It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
-Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, floating-point variables including \fBlong double\fR, the
+Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, complete \fBstruct\fR and \fBunion\fR declarations, the
 \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements.
 .PP

--- a/src/ast.c
+++ b/src/ast.c
@@ -295,8 +295,8 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column)
 
 /* Create a variable declaration statement. */
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
-                          expr_t *size_expr, size_t elem_size, int is_static, int is_const,
-                          int is_volatile, int is_restrict,
+                          expr_t *size_expr, size_t elem_size, int is_static, int is_extern,
+                          int is_const, int is_volatile, int is_restrict,
                           expr_t *init, expr_t **init_list, size_t init_count,
                           const char *tag, union_member_t *members,
                           size_t member_count, size_t line, size_t column)
@@ -327,6 +327,7 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
         stmt->var_decl.tag = NULL;
     }
     stmt->var_decl.is_static = is_static;
+    stmt->var_decl.is_extern = is_extern;
     stmt->var_decl.is_const = is_const;
     stmt->var_decl.is_volatile = is_volatile;
     stmt->var_decl.is_restrict = is_restrict;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -45,6 +45,7 @@ static const keyword_t keyword_table[] = {
     { "union",    TOK_KW_UNION },
     { "typedef",  TOK_KW_TYPEDEF },
     { "static",   TOK_KW_STATIC },
+    { "extern",   TOK_KW_EXTERN },
     { "const",    TOK_KW_CONST },
     { "volatile", TOK_KW_VOLATILE },
     { "restrict", TOK_KW_RESTRICT },

--- a/src/parser.c
+++ b/src/parser.c
@@ -64,6 +64,7 @@ static const char *token_name(token_type_t type)
     case TOK_KW_UNION: return "\"union\"";
     case TOK_KW_TYPEDEF: return "\"typedef\"";
     case TOK_KW_STATIC: return "\"static\"";
+    case TOK_KW_EXTERN: return "\"extern\"";
     case TOK_KW_CONST: return "\"const\"";
     case TOK_KW_VOLATILE: return "\"volatile\"";
     case TOK_KW_RESTRICT: return "\"restrict\"";
@@ -311,6 +312,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
     if (out_global) *out_global = NULL;
 
     size_t save = p->pos;
+    int is_extern = match(p, TOK_KW_EXTERN);
     int is_static = match(p, TOK_KW_STATIC);
     int is_const = match(p, TOK_KW_CONST);
     int is_volatile = match(p, TOK_KW_VOLATILE);
@@ -489,8 +491,8 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         p->pos++; /* consume ';' */
         if (out_global)
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_const,
-                                           is_volatile, is_restrict,
+                                           elem_size, is_static, is_extern,
+                                           is_const, is_volatile, is_restrict,
                                            NULL, NULL, 0,
                                            NULL, NULL, 0,
                                            tok->line, tok->column);
@@ -525,8 +527,8 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         }
         if (out_global)
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_const,
-                                           is_volatile, is_restrict,
+                                           elem_size, is_static, is_extern,
+                                           is_const, is_volatile, is_restrict,
                                            init, init_list, init_count,
                                            NULL, NULL, 0,
                                            tok->line, tok->column);

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -59,6 +59,7 @@ static stmt_t *parse_block(parser_t *p)
 /* Parse a variable declaration starting after a type keyword already matched */
 static stmt_t *parse_var_decl(parser_t *p)
 {
+    int is_extern = match(p, TOK_KW_EXTERN);
     int is_static = match(p, TOK_KW_STATIC);
     int is_const = match(p, TOK_KW_CONST);
     int is_volatile = match(p, TOK_KW_VOLATILE);
@@ -130,7 +131,7 @@ static stmt_t *parse_var_decl(parser_t *p)
             return NULL;
     }
     stmt_t *res = ast_make_var_decl(name, t, arr_size, size_expr, elem_size, is_static,
-                                    is_const, is_volatile, is_restrict, init, init_list,
+                                    is_extern, is_const, is_volatile, is_restrict, init, init_list,
                                     init_count,
                                     tag_name, NULL, 0,
                                     kw_tok->line, kw_tok->column);
@@ -201,6 +202,7 @@ fail:
 /* Parse a union variable with inline member specification */
 stmt_t *parser_parse_union_var_decl(parser_t *p)
 {
+    int is_extern = match(p, TOK_KW_EXTERN);
     int is_static = match(p, TOK_KW_STATIC);
     int is_const = match(p, TOK_KW_CONST);
     int is_volatile = match(p, TOK_KW_VOLATILE);
@@ -265,8 +267,8 @@ fail:
     }
     union_member_t *members = (union_member_t *)members_v.data;
     size_t count = members_v.count;
-    stmt_t *res = ast_make_var_decl(name, TYPE_UNION, 0, NULL, 0, is_static, is_const,
-                                    is_volatile, 0, NULL, NULL, 0, NULL, members,
+    stmt_t *res = ast_make_var_decl(name, TYPE_UNION, 0, NULL, 0, is_static, is_extern,
+                                    is_const, is_volatile, 0, NULL, NULL, 0, NULL, members,
                                     count,
                                     kw->line, kw->column);
     if (!res) {
@@ -347,6 +349,7 @@ fail:
 /* Parse a struct variable with inline member specification */
 stmt_t *parser_parse_struct_var_decl(parser_t *p)
 {
+    int is_extern = match(p, TOK_KW_EXTERN);
     int is_static = match(p, TOK_KW_STATIC);
     int is_const = match(p, TOK_KW_CONST);
     int is_volatile = match(p, TOK_KW_VOLATILE);
@@ -411,8 +414,8 @@ fail:
     }
     struct_member_t *members = (struct_member_t *)members_v.data;
     size_t count = members_v.count;
-    stmt_t *res = ast_make_var_decl(name, TYPE_STRUCT, 0, NULL, 0, is_static, is_const,
-                                    is_volatile, 0, NULL, NULL, 0, NULL,
+    stmt_t *res = ast_make_var_decl(name, TYPE_STRUCT, 0, NULL, 0, is_static, is_extern,
+                                    is_const, is_volatile, 0, NULL, NULL, 0, NULL,
                                     (union_member_t *)members, count,
                                     kw->line, kw->column);
     if (!res) {

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -1511,6 +1511,9 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
             }
         }
     }
+    if (decl->var_decl.is_extern)
+        return 1;
+
     if (decl->var_decl.type == TYPE_ARRAY) {
         size_t count = decl->var_decl.array_size;
         long long *vals = calloc(count, sizeof(long long));


### PR DESCRIPTION
## Summary
- recognize `extern` keyword in lexer
- parse extern global variables and function prototypes
- track extern flag in AST and skip emitting storage
- document extern support
- mention extern in man page

## Testing
- `make`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685cafd8e8cc8324b31c611940d9b1cd