### PR TITLE
Add inline function support

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -2,7 +2,8 @@
 
 This document describes the compilation pipeline, the role of each module
 and the language features currently supported. Recent updates add basic
-support for floating-point types and operations.
+support for floating-point types and operations, along with preliminary
+handling of inline function definitions.
 
 ## Pipeline Overview
 
@@ -138,6 +139,12 @@ must match the previously declared signature.
 
 Any mismatch results in `error_print` reporting the source
 location of the failure.
+
+Function definitions may also be marked with the `inline` specifier. Inline
+functions are currently treated like regular functions. The compiler does not
+enforce the one-definition rule so multiple identical inline definitions are
+accepted. When combined with `static`, the `static` keyword must appear before
+`inline`.
 
 ### ir
 Defines the IR structures used throughout the rest of the compiler.

--- a/include/token.h
+++ b/include/token.h
@@ -34,6 +34,7 @@ typedef enum {
     TOK_KW_CONST,
     TOK_KW_VOLATILE,
     TOK_KW_RESTRICT,
+    TOK_KW_INLINE,
     TOK_KW_RETURN,
     TOK_KW_IF,
     TOK_KW_ELSE,

--- a/man/vc.1
+++ b/man/vc.1
@@ -11,7 +11,7 @@ It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, floating-point variables including \fBlong double\fR, the
-\fBchar\fR type, support for 64-bit integer constants, complete \fBstruct\fR and \fBunion\fR declarations, the
+\fBchar\fR type, support for 64-bit integer constants, complete \fBstruct\fR and \fBunion\fR declarations, inline function definitions, the
 \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -48,6 +48,7 @@ static const keyword_t keyword_table[] = {
     { "const",    TOK_KW_CONST },
     { "volatile", TOK_KW_VOLATILE },
     { "restrict", TOK_KW_RESTRICT },
+    { "inline",   TOK_KW_INLINE },
     { "return",   TOK_KW_RETURN }
 };
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -67,6 +67,7 @@ static const char *token_name(token_type_t type)
     case TOK_KW_CONST: return "\"const\"";
     case TOK_KW_VOLATILE: return "\"volatile\"";
     case TOK_KW_RESTRICT: return "\"restrict\"";
+    case TOK_KW_INLINE: return "\"inline\"";
     case TOK_KW_RETURN: return "\"return\"";
     case TOK_KW_IF: return "\"if\"";
     case TOK_KW_ELSE: return "\"else\"";
@@ -312,8 +313,10 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
 
     size_t save = p->pos;
     int is_static = match(p, TOK_KW_STATIC);
+    match(p, TOK_KW_INLINE);
     int is_const = match(p, TOK_KW_CONST);
     int is_volatile = match(p, TOK_KW_VOLATILE);
+    size_t spec_pos = p->pos;
     token_t *tok = peek(p);
     if (!tok)
         return 0;
@@ -455,7 +458,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
             return 1;
         } else if (after && after->type == TOK_LBRACE) {
             vector_free(&param_types_v);
-            p->pos = save;
+            p->pos = spec_pos;
             if (out_func)
                 *out_func = parser_parse_func(p);
             return *out_func != NULL;
@@ -533,7 +536,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         return *out_global != NULL;
     }
 
-    p->pos = save;
+    p->pos = spec_pos;
     if (out_func)
         *out_func = parser_parse_func(p);
     return *out_func != NULL;

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -60,6 +60,7 @@ static stmt_t *parse_block(parser_t *p)
 static stmt_t *parse_var_decl(parser_t *p)
 {
     int is_static = match(p, TOK_KW_STATIC);
+    match(p, TOK_KW_INLINE);
     int is_const = match(p, TOK_KW_CONST);
     int is_volatile = match(p, TOK_KW_VOLATILE);
     token_t *kw_tok = peek(p);

--- a/tests/fixtures/inline_func.c
+++ b/tests/fixtures/inline_func.c
@@ -1,0 +1,2 @@
+inline int add(int a, int b) { return a + b; }
+int main() { return add(2, 3); }

--- a/tests/fixtures/inline_func.s
+++ b/tests/fixtures/inline_func.s
@@ -1,0 +1,21 @@
+add:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %eax
+    movl 12(%ebp), %ebx
+    movl %eax, %ecx
+    addl %ebx, %ecx
+    movl %ecx, %eax
+    ret
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $2, %ecx
+    movl $3, %ebx
+    pushl %ebx
+    pushl %ecx
+    call add
+    addl $8, %esp
+    movl %eax, %ecx
+    movl %ecx, %eax
+    ret


### PR DESCRIPTION
## Summary
- lex and parse `inline` keyword
- handle inline specifier when parsing functions
- document inline functions and limitations
- mention inline functions in man page
- add a test case for inline function

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685caeb117508324bafd78d0a27ffe6f