### PR TITLE
Add fixtures and docs for new features

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -768,13 +768,20 @@ followed by the standard system locations such as `/usr/include`. It also suppor
 object-like `#define` macros and parameterized
 macros such as `#define NAME(a, b)`; macro bodies are expanded recursively.
 Macros may be removed with `#undef NAME`.
-
 ```c
 #define VAL 3
 #define ADD(a, b) ((a) + (b))
 #define DOUBLE(x) ADD(x, x)
 #include "header.h"
 int main() { return DOUBLE(VAL); }
+```
+
+Macros may be removed with `#undef` and redefined later:
+
+```c
+#define TEMP 1
+#undef TEMP
+#define TEMP 2
 ```
 
 Conditional blocks may be controlled using the `defined` operator or

--- a/man/vc.1
+++ b/man/vc.1
@@ -12,7 +12,7 @@ optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
-\fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements.
+\fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, as well as labels and \fBgoto\fR.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like
 and parameterized macros defined with \fB#define\fR. Macro bodies may be

--- a/tests/fixtures/enum_example.c
+++ b/tests/fixtures/enum_example.c
@@ -1,0 +1,8 @@
+enum Colors {
+    RED,
+    GREEN = 3,
+    BLUE
+};
+int main() {
+    return GREEN;
+}

--- a/tests/fixtures/enum_example.s
+++ b/tests/fixtures/enum_example.s
@@ -1,0 +1,6 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $3, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/goto_example.c
+++ b/tests/fixtures/goto_example.c
@@ -1,0 +1,10 @@
+int main() {
+    int i = 0;
+start:
+    if (i == 3)
+        goto end;
+    i = i + 1;
+    goto start;
+end:
+    return i;
+}

--- a/tests/fixtures/goto_example.s
+++ b/tests/fixtures/goto_example.s
@@ -1,0 +1,18 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $0, %eax
+    movl %eax, i
+Luser0:
+    movl $0, %eax
+    cmpl $0, %eax
+    je L1_end
+    jmp Luser2
+L1_end:
+    movl $1, %eax
+    movl %eax, i
+    jmp Luser0
+Luser2:
+    movl i, %eax
+    movl %eax, %eax
+    ret

--- a/tests/fixtures/struct_example.c
+++ b/tests/fixtures/struct_example.c
@@ -1,0 +1,6 @@
+struct { int x; int y; } p;
+int main() {
+    p.x = 1;
+    p.y = 2;
+    return p.x + p.y;
+}

--- a/tests/fixtures/struct_example.s
+++ b/tests/fixtures/struct_example.s
@@ -1,0 +1,37 @@
+.data
+p:
+    .zero 8
+.text
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $p, %eax
+    movl $1, %ebx
+    movl $0, %ecx
+    movl %ecx, %edx
+    imull $1, %edx
+    addl %eax, %edx
+    movl %ebx, (%edx)
+    movl $p, %ebx
+    movl $2, %edx
+    movl $4, %ecx
+    movl %ecx, %eax
+    imull $1, %eax
+    addl %ebx, %eax
+    movl %edx, (%eax)
+    movl $p, %edx
+    movl $0, %eax
+    movl %eax, %ecx
+    imull $1, %ecx
+    addl %edx, %ecx
+    movl (%ecx), %eax
+    movl $p, %ecx
+    movl $4, %edx
+    movl %edx, %ebx
+    imull $1, %ebx
+    addl %ecx, %ebx
+    movl (%ebx), %edx
+    movl %eax, %ebx
+    addl %edx, %ebx
+    movl %ebx, %eax
+    ret


### PR DESCRIPTION
## Summary
- document `#undef` usage in docs
- mention labels and `goto` in the manual
- add fixtures for enum declarations, structs and goto

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d60ed23148324b98c36874a1a8ebd