### PR TITLE
Add documentation for switch statements

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -286,6 +286,7 @@ RETURN v2
 - Increment and decrement operators (`++`, `--`)
 - Logical operators `&&`, `||` and `!`
 - Conditional operator (`?:`)
+- `switch` statements with `case` and `default`
 - Bitwise operators (`&`, `|`, `^`, `<<`, `>>` and compound forms)
 - Floating-point types (`float`, `double`, `long double`)
 - `sizeof` operator
@@ -602,6 +603,26 @@ int main() {
 Compile with:
 ```sh
 vc -o for_decl.s for_decl.c
+```
+
+### Switch statements
+```c
+/* switch.c */
+int main() {
+    int x = 1;
+    switch (x) {
+    case 0:
+        return 5;
+    case 1:
+        return 10;
+    default:
+        return -1;
+    }
+}
+```
+Compile with:
+```sh
+vc -o switch.s switch.c
 ```
 
 ### Logical operators

--- a/man/vc.1
+++ b/man/vc.1
@@ -12,7 +12,7 @@ optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
-\fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, as well as labels and \fBgoto\fR.
+\fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like
 and parameterized macros defined with \fB#define\fR. Macro bodies may be


### PR DESCRIPTION
## Summary
- mention `switch`, `case` and `default` as supported constructs in man page
- document `switch` usage with a new example in `vcdoc.md`

## Testing
- `make`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d662527888324a30d9a0b01b60746