### PR TITLE
Add string literal pointer support

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -300,6 +300,7 @@ RETURN v2
 - Conditional preprocessing directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else`, `#endif`)
 - 64-bit integer literals and arithmetic when using `long long`
 - Hexadecimal (`0x`) and octal (leading `0`) integer literals
+- String literals which evaluate to a `char *`
 
 Examples below show how to compile each feature.
 
@@ -458,6 +459,13 @@ int main() {
 Compile with:
 ```sh
 vc -o ptr.s ptr.c
+```
+
+String literals evaluate to the address of their storage and may be
+assigned to `char *` variables:
+
+```c
+char *msg = "hi";
 ```
 
 #### Pointer arithmetic

--- a/man/vc.1
+++ b/man/vc.1
@@ -11,7 +11,7 @@ It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
-\fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
+\fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
 \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -491,7 +491,7 @@ type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
     case EXPR_STRING:
         if (out)
             *out = ir_build_string(ir, expr->string.value);
-        return TYPE_INT;
+        return TYPE_PTR;
     case EXPR_CHAR:
         if (out)
             *out = ir_build_const(ir, (int)expr->ch.value);

--- a/tests/fixtures/string_usage.c
+++ b/tests/fixtures/string_usage.c
@@ -1,0 +1,5 @@
+int main() {
+    char *p;
+    p = "hi";
+    return *p;
+}

--- a/tests/fixtures/string_usage.s
+++ b/tests/fixtures/string_usage.s
@@ -1,0 +1,13 @@
+.data
+Lstr1:
+    .asciz "hi"
+.text
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $Lstr1, %eax
+    movl %eax, p
+    movl p, %eax
+    movl (%eax), %ebx
+    movl %ebx, %eax
+    ret


### PR DESCRIPTION
## Summary
- allow EXPR_STRING to yield a pointer type
- describe string literal pointers in documentation and manual
- add fixture showing assignment of a string literal to `char *`

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d6b60964c832492e1e03ab8b2b899