### PR TITLE
Support array size inference from initializers

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -530,6 +530,16 @@ int main() {
     return nums[0];
 }
 ```
+If the size between the brackets is omitted, it is inferred from the number of
+initializer elements:
+
+```c
+/* array_infer_size.c */
+int main() {
+    int nums[] = {1, 2, 3};
+    return nums[1];
+}
+```
 Compile with:
 ```sh
 vc -o array_init.s array_init.c

--- a/man/vc.1
+++ b/man/vc.1
@@ -10,7 +10,7 @@ is a lightweight ANSI C compiler with experimental C99 support.
 It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
-Supported constructs include arrays (with variable length support), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
+Supported constructs include arrays (with variable length support and size inference from initializer lists), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
 \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
 .PP

--- a/src/parser.c
+++ b/src/parser.c
@@ -486,15 +486,19 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
     expr_t *size_expr = NULL;
     if (next_tok && next_tok->type == TOK_LBRACKET) {
         p->pos++; /* '[' */
-        size_expr = parser_parse_expr(p);
-        if (!size_expr || !match(p, TOK_RBRACKET)) {
-            ast_free_expr(size_expr);
-            p->pos = save;
-            return 0;
+        if (match(p, TOK_RBRACKET)) {
+            t = TYPE_ARRAY;
+        } else {
+            size_expr = parser_parse_expr(p);
+            if (!size_expr || !match(p, TOK_RBRACKET)) {
+                ast_free_expr(size_expr);
+                p->pos = save;
+                return 0;
+            }
+            if (size_expr->kind == EXPR_NUMBER)
+                arr_size = strtoul(size_expr->number.value, NULL, 10);
+            t = TYPE_ARRAY;
         }
-        if (size_expr->kind == EXPR_NUMBER)
-            arr_size = strtoul(size_expr->number.value, NULL, 10);
-        t = TYPE_ARRAY;
         next_tok = peek(p);
     }
 

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -96,15 +96,19 @@ static stmt_t *parse_var_decl(parser_t *p)
     expr_t *size_expr = NULL;
     if (match(p, TOK_LBRACKET)) {
         size_t save = p->pos;
-        size_expr = parser_parse_expr(p);
-        if (!size_expr || !match(p, TOK_RBRACKET)) {
-            ast_free_expr(size_expr);
-            p->pos = save;
-            return NULL;
+        if (match(p, TOK_RBRACKET)) {
+            t = TYPE_ARRAY;
+        } else {
+            size_expr = parser_parse_expr(p);
+            if (!size_expr || !match(p, TOK_RBRACKET)) {
+                ast_free_expr(size_expr);
+                p->pos = save;
+                return NULL;
+            }
+            if (size_expr->kind == EXPR_NUMBER)
+                arr_size = strtoul(size_expr->number.value, NULL, 10);
+            t = TYPE_ARRAY;
         }
-        if (size_expr->kind == EXPR_NUMBER)
-            arr_size = strtoul(size_expr->number.value, NULL, 10);
-        t = TYPE_ARRAY;
     }
     expr_t *init = NULL;
     expr_t **init_list = NULL;

--- a/tests/fixtures/array_infer_size.c
+++ b/tests/fixtures/array_infer_size.c
@@ -1,0 +1,4 @@
+int main() {
+    int nums[] = {1, 2, 3};
+    return nums[1];
+}

--- a/tests/fixtures/array_infer_size.s
+++ b/tests/fixtures/array_infer_size.s
@@ -1,0 +1,16 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $0, %eax
+    movl $1, %ebx
+    movl %ebx, nums(,%eax,4)
+    movl $1, %ebx
+    movl $2, %eax
+    movl %eax, nums(,%ebx,4)
+    movl $2, %eax
+    movl $3, %ebx
+    movl %ebx, nums(,%eax,4)
+    movl $1, %ebx
+    movl nums(,%ebx,4), %eax
+    movl %eax, %eax
+    ret


### PR DESCRIPTION
## Summary
- allow `int a[] = {1,2,3};` by parsing empty brackets
- infer array size from initializer count during semantic checks
- document inferred array size feature
- test fixture for unsized initializer list

## Testing
- `make -j4`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d6d7a7cc483248750a7522b82e93c