### PR TITLE
Add designator examples

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -560,6 +560,20 @@ Compile with:
 vc -o vla.s vla.c
 ```
 
+Designated initializers can specify the index for each element:
+
+```c
+/* array_designate.c */
+int main() {
+    int nums[5] = { [2] = 4, [4] = 9 };
+    return nums[2] + nums[4];
+}
+```
+Compile with:
+```sh
+vc -o array_designate.s array_designate.c
+```
+
 ### sizeof
 `sizeof` returns the number of bytes for a type or expression without
 evaluating the expression.
@@ -721,6 +735,20 @@ int main() {
 Compile with:
 ```sh
 vc -o struct_ptr.s struct_ptr.c
+```
+
+### Struct designators
+```c
+/* struct_designate.c */
+struct Point { int x; int y; };
+int main() {
+    struct Point p = { .y = 5, .x = 1 };
+    return p.y - p.x;
+}
+```
+Compile with:
+```sh
+vc -o struct_designate.s struct_designate.c
 ```
 ### Union declarations
 ```c

--- a/man/vc.1
+++ b/man/vc.1
@@ -10,7 +10,7 @@ is a lightweight ANSI C compiler with experimental C99 support.
 It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
-Supported constructs include arrays (with variable length support and size inference from initializer lists), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
+Supported constructs include arrays (with variable length support, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
 \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
 .PP


### PR DESCRIPTION
## Summary
- document array `[index]` designators
- show `.member` designator usage for structs
- mention designators in supported constructs list

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685d7a782944832482fd6602e0e58544