### PR TITLE
Enforce const initializer

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -88,6 +88,7 @@ constant initializers.
 
 The `const` qualifier marks a variable as read-only after initialization.
 Any attempt to assign to a `const` object results in a semantic error.
+Declaring a `const` variable without an initializer is also a semantic error.
 
 The `volatile` qualifier tells the compiler that a variable's value may change
 unexpectedly.  Reads and writes to a `volatile` object are always emitted and

--- a/man/vc.1
+++ b/man/vc.1
@@ -12,7 +12,7 @@ optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
-\fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
+\fBconst\fR (which requires an initializer), \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like
 and parameterized macros defined with \fB#define\fR. Macro bodies may be

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -1227,6 +1227,11 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
             if (stmt->var_decl.member_count || stmt->var_decl.tag)
                 stmt->var_decl.elem_size = total;
         }
+        if (stmt->var_decl.is_const && !stmt->var_decl.init &&
+            !stmt->var_decl.init_list) {
+            error_set(stmt->line, stmt->column);
+            return 0;
+        }
         if (!symtable_add(vars, stmt->var_decl.name, ir_name,
                           stmt->var_decl.type,
                           stmt->var_decl.array_size,

--- a/tests/fixtures/const_init.c
+++ b/tests/fixtures/const_init.c
@@ -1,0 +1,4 @@
+int main() {
+    const int x = 5;
+    return x;
+}

--- a/tests/fixtures/const_init.s
+++ b/tests/fixtures/const_init.s
@@ -1,0 +1,11 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $5, %eax
+    movl %eax, x
+    movl $5, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/invalid/const_no_init.c
+++ b/tests/invalid/const_no_init.c
@@ -1,0 +1,4 @@
+int main() {
+    const int x;
+    return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -131,6 +131,19 @@ if [ $ret -eq 0 ] || ! grep -q "Semantic error" "$err"; then
 fi
 rm -f "$out" "$err"
 
+# negative test for const variable without initializer
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "$out" "$DIR/invalid/const_no_init.c" 2> "$err"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Semantic error" "$err"; then
+    echo "Test const_no_init failed"
+    fail=1
+fi
+rm -f "$out" "$err"
+
 # test --dump-asm option
 dump_out=$(mktemp)
 "$BINARY" --dump-asm "$DIR/fixtures/simple_add.c" > "$dump_out"


### PR DESCRIPTION
## Summary
- require initializers for const variables during semantic checks
- document the new requirement
- mention const requirement in the man page
- add regression tests

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d7c8b9f108324b3faad83a5431f8e