### PR TITLE
Implement # and ## macro operators

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -839,7 +839,8 @@ then any paths listed in the `VCPATH` environment variable (colon separated),
 followed by the standard system locations such as `/usr/include`. It also supports
 object-like `#define` macros and parameterized
 macros such as `#define NAME(a, b)`; macro bodies are expanded recursively.
-Macros may be removed with `#undef NAME`.
+The `#` operator stringizes a parameter and `##` concatenates two tokens during
+expansion. Macros may be removed with `#undef NAME`.
 
 Use the `-E`/`--preprocess` option to run just the preprocessor and print the
 expanded source to the terminal.

--- a/man/vc.1
+++ b/man/vc.1
@@ -16,7 +16,8 @@ Supported constructs include arrays (with variable length support, size inferenc
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like
 and parameterized macros defined with \fB#define\fR. Macro bodies may be
-expanded recursively and macros may be removed with \fB#undef\fR.
+expanded recursively. The \fB#\fR operator stringizes a parameter and
+\fB##\fR concatenates two tokens. Macros may be removed with \fB#undef\fR.
 Conditional
 directives (\fB#if\fR, \fB#ifdef\fR, \fB#ifndef\fR, \fB#elif\fR, \fB#else\fR
 and \fB#endif\fR) are supported using expression evaluation with the

--- a/tests/fixtures/macro_concat.c
+++ b/tests/fixtures/macro_concat.c
@@ -1,0 +1,3 @@
+#define JOIN(a,b) a##b
+int foobar = 5;
+int main() { return JOIN(foo,bar); }

--- a/tests/fixtures/macro_concat.s
+++ b/tests/fixtures/macro_concat.s
@@ -1,0 +1,13 @@
+.data
+foobar:
+    .long 5
+.text
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl foobar, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/macro_stringize.c
+++ b/tests/fixtures/macro_stringize.c
@@ -1,0 +1,6 @@
+#define TO_STR(x) #x
+int main() {
+    char *s;
+    s = TO_STR(hello);
+    return 0;
+}

--- a/tests/fixtures/macro_stringize.s
+++ b/tests/fixtures/macro_stringize.s
@@ -1,0 +1,15 @@
+.data
+Lstr1:
+    .asciz "hello"
+.text
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $Lstr1, %eax
+    movl %eax, s
+    movl $0, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- support stringizing (#) and token pasting (##) in macro expansion
- add fixtures for new preprocessor features
- document new macro operators in docs and man page

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d7e7a78a08324ac72147c0c5174a1