### PR TITLE
Add register qualifier support

### DIFF
--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -99,6 +99,10 @@ promises that the pointer is the sole reference to its pointed-to object
 for the lifetime of the pointer.  This lets the optimizer assume no aliasing
 between `restrict` qualified pointers.
 
+The `register` qualifier is accepted for compatibility.  The qualifier is
+recorded in symbol tables but has no effect on code generation.  Objects
+declared with `register` behave the same as ordinary locals or globals.
+
 Structures and unions are declared with the `struct` or `union` keyword.
 Members are accessed using `.` for objects or `->` when working through a pointer.
 For structures each member has its own storage in the order declared.

--- a/include/ast.h
+++ b/include/ast.h
@@ -221,6 +221,7 @@ struct stmt {
             size_t elem_size;
             char *tag; /* NULL for basic types */
             int is_static;
+            int is_register;
             int is_extern;
             int is_const;
             int is_volatile;
@@ -366,7 +367,7 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column);
 /* Declare a variable optionally initialized by \p init or \p init_list. */
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
                           expr_t *size_expr, size_t elem_size, int is_static,
-                          int is_extern, int is_const, int is_volatile, int is_restrict,
+                          int is_register, int is_extern, int is_const, int is_volatile, int is_restrict,
                           expr_t *init, init_entry_t *init_list, size_t init_count,
                           const char *tag, union_member_t *members,
                           size_t member_count, size_t line, size_t column);

--- a/include/symtable.h
+++ b/include/symtable.h
@@ -30,6 +30,7 @@ typedef struct symbol {
     size_t struct_member_count;
     size_t struct_total_size;
     int is_static;
+    int is_register;
     int is_const;
     int is_volatile;
     int is_restrict;
@@ -58,7 +59,7 @@ void symtable_free(symtable_t *table);
 /* Locals */
 int symtable_add(symtable_t *table, const char *name, const char *ir_name,
                  type_kind_t type, size_t array_size, size_t elem_size,
-                 int is_static, int is_const, int is_volatile,
+                 int is_static, int is_register, int is_const, int is_volatile,
                  int is_restrict);
 /* Parameters are stored as locals with an index */
 int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
@@ -70,7 +71,7 @@ int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
 /* Globals live in a separate list */
 int symtable_add_global(symtable_t *table, const char *name, const char *ir_name,
                         type_kind_t type, size_t array_size, size_t elem_size,
-                        int is_static, int is_const, int is_volatile,
+                        int is_static, int is_register, int is_const, int is_volatile,
                         int is_restrict);
 int symtable_add_enum(symtable_t *table, const char *name, int value);
 int symtable_add_enum_global(symtable_t *table, const char *name, int value);

--- a/include/token.h
+++ b/include/token.h
@@ -35,6 +35,7 @@ typedef enum {
     TOK_KW_CONST,
     TOK_KW_VOLATILE,
     TOK_KW_RESTRICT,
+    TOK_KW_REGISTER,
     TOK_KW_INLINE,
     TOK_KW_RETURN,
     TOK_KW_IF,

--- a/man/vc.1
+++ b/man/vc.1
@@ -12,7 +12,7 @@ optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
-\fBconst\fR (which requires an initializer), \fBvolatile\fR and \fBrestrict\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
+\fBconst\fR (which requires an initializer), \fBvolatile\fR and \fBrestrict\fR and \fBregister\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, as well as labels and \fBgoto\fR.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like
 and parameterized macros defined with \fB#define\fR. Macro bodies may be

--- a/src/ast.c
+++ b/src/ast.c
@@ -295,8 +295,8 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column)
 
 /* Create a variable declaration statement. */
 stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
-                          expr_t *size_expr, size_t elem_size, int is_static, int is_extern,
-                          int is_const, int is_volatile, int is_restrict,
+                          expr_t *size_expr, size_t elem_size, int is_static, int is_register,
+                          int is_extern, int is_const, int is_volatile, int is_restrict,
                           expr_t *init, init_entry_t *init_list, size_t init_count,
                           const char *tag, union_member_t *members,
                           size_t member_count, size_t line, size_t column)
@@ -327,6 +327,7 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
         stmt->var_decl.tag = NULL;
     }
     stmt->var_decl.is_static = is_static;
+    stmt->var_decl.is_register = is_register;
     stmt->var_decl.is_extern = is_extern;
     stmt->var_decl.is_const = is_const;
     stmt->var_decl.is_volatile = is_volatile;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -49,6 +49,7 @@ static const keyword_t keyword_table[] = {
     { "const",    TOK_KW_CONST },
     { "volatile", TOK_KW_VOLATILE },
     { "restrict", TOK_KW_RESTRICT },
+    { "register", TOK_KW_REGISTER },
     { "inline",   TOK_KW_INLINE },
     { "return",   TOK_KW_RETURN }
 };

--- a/src/parser.c
+++ b/src/parser.c
@@ -68,6 +68,7 @@ static const char *token_name(token_type_t type)
     case TOK_KW_CONST: return "\"const\"";
     case TOK_KW_VOLATILE: return "\"volatile\"";
     case TOK_KW_RESTRICT: return "\"restrict\"";
+    case TOK_KW_REGISTER: return "\"register\"";
     case TOK_KW_INLINE: return "\"inline\"";
     case TOK_KW_RETURN: return "\"return\"";
     case TOK_KW_IF: return "\"if\"";
@@ -315,6 +316,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
     size_t save = p->pos;
     int is_extern = match(p, TOK_KW_EXTERN);
     int is_static = match(p, TOK_KW_STATIC);
+    int is_register = match(p, TOK_KW_REGISTER);
     match(p, TOK_KW_INLINE);
     int is_const = match(p, TOK_KW_CONST);
     int is_volatile = match(p, TOK_KW_VOLATILE);
@@ -510,7 +512,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         p->pos++; /* consume ';' */
         if (out_global)
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_extern,
+                                           elem_size, is_static, is_register, is_extern,
                                            is_const, is_volatile, is_restrict,
                                            NULL, NULL, 0,
                                            NULL, NULL, 0,
@@ -549,7 +551,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         }
         if (out_global)
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_extern,
+                                           elem_size, is_static, is_register, is_extern,
                                            is_const, is_volatile, is_restrict,
                                            init, init_list, init_count,
                                            NULL, NULL, 0,

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -1237,6 +1237,7 @@ int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                           stmt->var_decl.array_size,
                           stmt->var_decl.elem_size,
                           stmt->var_decl.is_static,
+                          stmt->var_decl.is_register,
                           stmt->var_decl.is_const,
                           stmt->var_decl.is_volatile,
                           stmt->var_decl.is_restrict)) {
@@ -1565,6 +1566,7 @@ int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir)
                              decl->var_decl.array_size,
                              decl->var_decl.elem_size,
                              decl->var_decl.is_static,
+                             decl->var_decl.is_register,
                              decl->var_decl.is_const,
                              decl->var_decl.is_volatile,
                              decl->var_decl.is_restrict)) {

--- a/src/symtable.c
+++ b/src/symtable.c
@@ -45,6 +45,7 @@ static symbol_t *symtable_create_symbol(const char *name, const char *ir_name)
     sym->struct_member_count = 0;
     sym->struct_total_size = 0;
     sym->is_restrict = 0;
+    sym->is_register = 0;
     return sym;
 }
 
@@ -113,7 +114,7 @@ symbol_t *symtable_lookup(symtable_t *table, const char *name)
  */
 int symtable_add(symtable_t *table, const char *name, const char *ir_name,
                  type_kind_t type, size_t array_size, size_t elem_size,
-                 int is_static, int is_const, int is_volatile,
+                 int is_static, int is_register, int is_const, int is_volatile,
                  int is_restrict)
 {
     if (symtable_lookup(table, name))
@@ -125,6 +126,7 @@ int symtable_add(symtable_t *table, const char *name, const char *ir_name,
     sym->array_size = array_size;
     sym->elem_size = elem_size;
     sym->is_static = is_static;
+    sym->is_register = is_register;
     sym->is_const = is_const;
     sym->is_volatile = is_volatile;
     sym->is_restrict = is_restrict;
@@ -157,7 +159,7 @@ int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
 /* Insert a global variable into the table. */
 int symtable_add_global(symtable_t *table, const char *name, const char *ir_name,
                         type_kind_t type, size_t array_size, size_t elem_size,
-                        int is_static, int is_const, int is_volatile,
+                        int is_static, int is_register, int is_const, int is_volatile,
                         int is_restrict)
 {
     for (symbol_t *sym = table->globals; sym; sym = sym->next) {
@@ -171,6 +173,7 @@ int symtable_add_global(symtable_t *table, const char *name, const char *ir_name
     sym->array_size = array_size;
     sym->elem_size = elem_size;
     sym->is_static = is_static;
+    sym->is_register = is_register;
     sym->is_const = is_const;
     sym->is_volatile = is_volatile;
     sym->is_restrict = is_restrict;

--- a/tests/fixtures/register_local.c
+++ b/tests/fixtures/register_local.c
@@ -1,0 +1,4 @@
+int main() {
+    register int x = 5;
+    return x;
+}

--- a/tests/fixtures/register_local.s
+++ b/tests/fixtures/register_local.s
@@ -1,0 +1,11 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $5, %eax
+    movl %eax, x
+    movl $5, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- support the `register` storage class
- allow parsing `register` for variables
- record the qualifier in symbol tables
- document `register` support
- include fixture for `register` variables

## Testing
- `make`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d7e99459483248d5465f0f84f17a1