### PR TITLE
Refactor constant expression helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BIN = vc
 
 CORE_SRC = src/main.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser.c src/symtable.c src/parser_expr.c src/parser_init.c \
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
-           src/semantic_expr.c src/semantic_stmt.c src/semantic_global.c src/error.c src/ir.c \
+           src/semantic_expr.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir.c \
            src/codegen.c src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
 
@@ -17,7 +17,7 @@ OPT_SRC = src/opt.c
 EXTRA_SRC ?=
 # Final source list
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
-HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/semantic_expr.h include/semantic_stmt.h include/semantic_global.h \
+HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_stmt.h include/semantic_global.h \
     include/ir.h include/ir_dump.h include/opt.h include/codegen.h include/strbuf.h \
     include/util.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h

--- a/include/consteval.h
+++ b/include/consteval.h
@@ -1,0 +1,18 @@
+/*
+ * Constant expression evaluation helpers.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_CONSTEVAL_H
+#define VC_CONSTEVAL_H
+
+#include "ast.h"
+#include "symtable.h"
+
+int is_intlike(type_kind_t t);
+int is_floatlike(type_kind_t t);
+int eval_const_expr(expr_t *expr, symtable_t *vars, long long *out);
+
+#endif /* VC_CONSTEVAL_H */

--- a/include/semantic.h
+++ b/include/semantic.h
@@ -8,6 +8,7 @@
 #ifndef VC_SEMANTIC_H
 #define VC_SEMANTIC_H
 
+#include "consteval.h"
 #include "semantic_expr.h"
 #include "semantic_stmt.h"
 #include "semantic_global.h"

--- a/include/semantic_expr.h
+++ b/include/semantic_expr.h
@@ -12,9 +12,6 @@
 #include "ir.h"
 #include "symtable.h"
 
-int is_intlike(type_kind_t t);
-int is_floatlike(type_kind_t t);
-int eval_const_expr(expr_t *expr, symtable_t *vars, long long *out);
 type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,
                        ir_builder_t *ir, ir_value_t *out);
 

--- a/src/consteval.c
+++ b/src/consteval.c
@@ -1,0 +1,128 @@
+/*
+ * Constant expression evaluation implementation.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include "consteval.h"
+#include "symtable.h"
+
+int is_intlike(type_kind_t t)
+{
+    switch (t) {
+    case TYPE_INT: case TYPE_UINT:
+    case TYPE_CHAR: case TYPE_UCHAR:
+    case TYPE_SHORT: case TYPE_USHORT:
+    case TYPE_LONG: case TYPE_ULONG:
+    case TYPE_LLONG: case TYPE_ULLONG:
+    case TYPE_BOOL:
+    case TYPE_ENUM:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+int is_floatlike(type_kind_t t)
+{
+    return t == TYPE_FLOAT || t == TYPE_DOUBLE || t == TYPE_LDOUBLE;
+}
+
+int eval_const_expr(expr_t *expr, symtable_t *vars, long long *out)
+{
+    if (!expr)
+        return 0;
+    switch (expr->kind) {
+    case EXPR_NUMBER:
+        if (out)
+            *out = strtoll(expr->number.value, NULL, 0);
+        return 1;
+    case EXPR_CHAR:
+        if (out)
+            *out = (long long)expr->ch.value;
+        return 1;
+    case EXPR_UNARY:
+        if (expr->unary.op == UNOP_NEG) {
+            long long val;
+            if (eval_const_expr(expr->unary.operand, vars, &val)) {
+                if (out)
+                    *out = -val;
+                return 1;
+            }
+        }
+        return 0;
+    case EXPR_BINARY: {
+        long long a, b;
+        if (!eval_const_expr(expr->binary.left, vars, &a) ||
+            !eval_const_expr(expr->binary.right, vars, &b))
+            return 0;
+        switch (expr->binary.op) {
+        case BINOP_ADD: if (out) *out = a + b; break;
+        case BINOP_SUB: if (out) *out = a - b; break;
+        case BINOP_MUL: if (out) *out = a * b; break;
+        case BINOP_DIV: if (out) *out = b != 0 ? a / b : 0; break;
+        case BINOP_MOD: if (out) *out = b != 0 ? a % b : 0; break;
+        case BINOP_SHL: if (out) *out = a << b; break;
+        case BINOP_SHR: if (out) *out = a >> b; break;
+        case BINOP_BITAND: if (out) *out = a & b; break;
+        case BINOP_BITXOR: if (out) *out = a ^ b; break;
+        case BINOP_BITOR: if (out) *out = a | b; break;
+        case BINOP_EQ:  if (out) *out = (a == b); break;
+        case BINOP_NEQ: if (out) *out = (a != b); break;
+        case BINOP_LT:  if (out) *out = (a < b); break;
+        case BINOP_GT:  if (out) *out = (a > b); break;
+        case BINOP_LE:  if (out) *out = (a <= b); break;
+        case BINOP_GE:  if (out) *out = (a >= b); break;
+        default:
+            return 0;
+        }
+        return 1;
+    }
+    case EXPR_COND: {
+        long long cval;
+        if (!eval_const_expr(expr->cond.cond, vars, &cval))
+            return 0;
+        if (cval)
+            return eval_const_expr(expr->cond.then_expr, vars, out);
+        else
+            return eval_const_expr(expr->cond.else_expr, vars, out);
+    }
+    case EXPR_IDENT: {
+        symbol_t *sym = vars ? symtable_lookup(vars, expr->ident.name) : NULL;
+        if (sym && sym->is_enum_const) {
+            if (out)
+                *out = sym->enum_value;
+            return 1;
+        }
+        return 0;
+    }
+    case EXPR_SIZEOF:
+        if (!expr->sizeof_expr.is_type)
+            return 0;
+        if (out) {
+            int sz = 0;
+            switch (expr->sizeof_expr.type) {
+            case TYPE_CHAR: case TYPE_UCHAR: case TYPE_BOOL: sz = 1; break;
+            case TYPE_SHORT: case TYPE_USHORT: sz = 2; break;
+            case TYPE_INT: case TYPE_UINT: case TYPE_LONG: case TYPE_ULONG: sz = 4; break;
+            case TYPE_LLONG: case TYPE_ULLONG: sz = 8; break;
+            case TYPE_PTR:  sz = 4; break;
+            case TYPE_ARRAY:
+                sz = (int)expr->sizeof_expr.array_size *
+                     (int)expr->sizeof_expr.elem_size;
+                break;
+            case TYPE_UNION:
+                sz = (int)expr->sizeof_expr.elem_size;
+                break;
+            default: sz = 0; break;
+            }
+            *out = sz;
+        }
+        return 1;
+    default:
+        return 0;
+    }
+}
+

--- a/src/semantic_expr.c
+++ b/src/semantic_expr.c
@@ -9,33 +9,12 @@
 #include <string.h>
 #include <stdio.h>
 #include "semantic_expr.h"
+#include "consteval.h"
 #include "symtable.h"
 #include "util.h"
 #include "label.h"
 #include "error.h"
 #include <limits.h>
-
-int is_intlike(type_kind_t t)
-{
-    switch (t) {
-    case TYPE_INT: case TYPE_UINT:
-    case TYPE_CHAR: case TYPE_UCHAR:
-    case TYPE_SHORT: case TYPE_USHORT:
-    case TYPE_LONG: case TYPE_ULONG:
-    case TYPE_LLONG: case TYPE_ULLONG:
-    case TYPE_BOOL:
-    case TYPE_ENUM:
-        return 1;
-    default:
-        return 0;
-    }
-}
-
-int is_floatlike(type_kind_t t)
-{
-    return t == TYPE_FLOAT || t == TYPE_DOUBLE || t == TYPE_LDOUBLE;
-}
-
 
 /* Mapping from BINOP_* to corresponding IR op.  Logical ops are
  * handled separately and use IR_CMPEQ here just as a placeholder. */
@@ -62,102 +41,6 @@ static const ir_op_t binop_to_ir[] = {
 
 
 
-/* Evaluate a constant expression at compile time. Returns non-zero on success. */
-int eval_const_expr(expr_t *expr, symtable_t *vars, long long *out)
-{
-    if (!expr)
-        return 0;
-    switch (expr->kind) {
-    case EXPR_NUMBER:
-        if (out)
-            *out = strtoll(expr->number.value, NULL, 0);
-        return 1;
-    case EXPR_CHAR:
-        if (out)
-            *out = (long long)expr->ch.value;
-        return 1;
-    case EXPR_UNARY:
-        if (expr->unary.op == UNOP_NEG) {
-            long long val;
-            if (eval_const_expr(expr->unary.operand, vars, &val)) {
-                if (out)
-                    *out = -val;
-                return 1;
-            }
-        }
-        return 0;
-    case EXPR_BINARY: {
-        long long a, b;
-        if (!eval_const_expr(expr->binary.left, vars, &a) ||
-            !eval_const_expr(expr->binary.right, vars, &b))
-            return 0;
-        switch (expr->binary.op) {
-        case BINOP_ADD: if (out) *out = a + b; break;
-        case BINOP_SUB: if (out) *out = a - b; break;
-        case BINOP_MUL: if (out) *out = a * b; break;
-        case BINOP_DIV: if (out) *out = b != 0 ? a / b : 0; break;
-        case BINOP_MOD: if (out) *out = b != 0 ? a % b : 0; break;
-        case BINOP_SHL: if (out) *out = a << b; break;
-        case BINOP_SHR: if (out) *out = a >> b; break;
-        case BINOP_BITAND: if (out) *out = a & b; break;
-        case BINOP_BITXOR: if (out) *out = a ^ b; break;
-        case BINOP_BITOR: if (out) *out = a | b; break;
-        case BINOP_EQ:  if (out) *out = (a == b); break;
-        case BINOP_NEQ: if (out) *out = (a != b); break;
-        case BINOP_LT:  if (out) *out = (a < b); break;
-        case BINOP_GT:  if (out) *out = (a > b); break;
-        case BINOP_LE:  if (out) *out = (a <= b); break;
-        case BINOP_GE:  if (out) *out = (a >= b); break;
-        default:
-            return 0;
-        }
-        return 1;
-    }
-    case EXPR_COND: {
-        long long cval;
-        if (!eval_const_expr(expr->cond.cond, vars, &cval))
-            return 0;
-        if (cval)
-            return eval_const_expr(expr->cond.then_expr, vars, out);
-        else
-            return eval_const_expr(expr->cond.else_expr, vars, out);
-    }
-    case EXPR_IDENT: {
-        symbol_t *sym = vars ? symtable_lookup(vars, expr->ident.name) : NULL;
-        if (sym && sym->is_enum_const) {
-            if (out)
-                *out = sym->enum_value;
-            return 1;
-        }
-        return 0;
-    }
-    case EXPR_SIZEOF:
-        if (!expr->sizeof_expr.is_type)
-            return 0;
-        if (out) {
-            int sz = 0;
-            switch (expr->sizeof_expr.type) {
-            case TYPE_CHAR: case TYPE_UCHAR: case TYPE_BOOL: sz = 1; break;
-            case TYPE_SHORT: case TYPE_USHORT: sz = 2; break;
-            case TYPE_INT: case TYPE_UINT: case TYPE_LONG: case TYPE_ULONG: sz = 4; break;
-            case TYPE_LLONG: case TYPE_ULLONG: sz = 8; break;
-            case TYPE_PTR:  sz = 4; break;
-            case TYPE_ARRAY:
-                sz = (int)expr->sizeof_expr.array_size *
-                     (int)expr->sizeof_expr.elem_size;
-                break;
-            case TYPE_UNION:
-                sz = (int)expr->sizeof_expr.elem_size;
-                break;
-            default: sz = 0; break;
-            }
-            *out = sz;
-        }
-        return 1;
-    default:
-        return 0;
-    }
-}
 
 type_kind_t check_binary(expr_t *left, expr_t *right, symtable_t *vars,
                                 symtable_t *funcs, ir_builder_t *ir,

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include "semantic_global.h"
 #include "semantic_stmt.h"
+#include "consteval.h"
 #include "semantic_expr.h"
 #include "symtable.h"
 #include "util.h"

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "semantic_stmt.h"
+#include "consteval.h"
 #include "semantic_expr.h"
 #include "semantic_global.h"
 #include "symtable.h"


### PR DESCRIPTION
## Summary
- add new `consteval` module for constant expression helpers
- move `eval_const_expr` and integer/float helpers into `consteval`
- include `consteval.h` where needed
- adjust Makefile for new files

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685d96357f3483249d88da41069b8aa3