### PR TITLE
Refactor parser to use helpers

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -303,117 +303,137 @@ func_t *parser_parse_func(parser_t *p)
     return fn;
 }
 
-/*
- * Parse either a global variable declaration or a full function
- * definition.  Exactly one of "out_func" or "out_global" is set on
- * success.  The function returns 1 when a valid top-level construct was
- * consumed and 0 otherwise.
- */
-int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
-                          func_t **out_func, stmt_t **out_global)
+/* Helper to parse enum declarations at global scope */
+static int parse_enum_global(parser_t *p, size_t start_pos, stmt_t **out)
 {
-    if (out_func) *out_func = NULL;
-    if (out_global) *out_global = NULL;
-
-    size_t save = p->pos;
-    int is_extern = match(p, TOK_KW_EXTERN);
-    int is_static = match(p, TOK_KW_STATIC);
-    int is_register = match(p, TOK_KW_REGISTER);
-    match(p, TOK_KW_INLINE);
-    int is_const = match(p, TOK_KW_CONST);
-    int is_volatile = match(p, TOK_KW_VOLATILE);
-    size_t spec_pos = p->pos;
     token_t *tok = peek(p);
-    if (!tok)
+    if (!tok || tok->type != TOK_KW_ENUM)
         return 0;
 
-    if (tok->type == TOK_KW_STRUCT) {
-        token_t *next = &p->tokens[p->pos + 1];
-        if (next && next->type == TOK_IDENT &&
-            p->pos + 2 < p->count && p->tokens[p->pos + 2].type == TOK_LBRACE) {
-            p->pos = save;
-            if (out_global)
-                *out_global = parser_parse_struct_decl(p);
+    token_t *next = &p->tokens[p->pos + 1];
+    if (next && next->type == TOK_LBRACE) {
+        p->pos = start_pos;
+        match(p, TOK_KW_ENUM);
+        if (out)
+            *out = parser_parse_enum_decl(p);
+        else
+            parser_parse_enum_decl(p);
+        return 1;
+    }
+    if (next && next->type == TOK_IDENT &&
+        p->pos + 2 < p->count && p->tokens[p->pos + 2].type == TOK_LBRACE) {
+        p->pos = start_pos;
+        match(p, TOK_KW_ENUM);
+        if (out)
+            *out = parser_parse_enum_decl(p);
+        else
+            parser_parse_enum_decl(p);
+        return 1;
+    }
+
+    p->pos = start_pos;
+    return 0;
+}
+
+/* Helper to parse struct or union declarations/variables at global scope */
+static int parse_struct_or_union_global(parser_t *p, size_t start_pos,
+                                        stmt_t **out)
+{
+    token_t *tok = peek(p);
+    if (!tok || (tok->type != TOK_KW_STRUCT && tok->type != TOK_KW_UNION))
+        return 0;
+
+    token_type_t kw = tok->type;
+    token_t *next = &p->tokens[p->pos + 1];
+    if (next && next->type == TOK_IDENT &&
+        p->pos + 2 < p->count && p->tokens[p->pos + 2].type == TOK_LBRACE) {
+        p->pos = start_pos;
+        if (kw == TOK_KW_STRUCT) {
+            if (out)
+                *out = parser_parse_struct_decl(p);
             else
                 parser_parse_struct_decl(p);
-            return out_global ? *out_global != NULL : 1;
-        }
-        p->pos = save;
-        if (out_global)
-            *out_global = parser_parse_struct_var_decl(p);
-        else
-            parser_parse_struct_var_decl(p);
-        return out_global ? *out_global != NULL : 1;
-    }
-
-    if (tok->type == TOK_KW_UNION) {
-        token_t *next = &p->tokens[p->pos + 1];
-        if (next && next->type == TOK_IDENT &&
-            p->pos + 2 < p->count && p->tokens[p->pos + 2].type == TOK_LBRACE) {
-            p->pos = save;
-            if (out_global)
-                *out_global = parser_parse_union_decl(p);
+        } else {
+            if (out)
+                *out = parser_parse_union_decl(p);
             else
                 parser_parse_union_decl(p);
-            return out_global ? *out_global != NULL : 1;
         }
-        p->pos = save;
-        if (out_global)
-            *out_global = parser_parse_union_var_decl(p);
+        return 1;
+    }
+
+    p->pos = start_pos;
+    if (kw == TOK_KW_STRUCT) {
+        if (out)
+            *out = parser_parse_struct_var_decl(p);
+        else
+            parser_parse_struct_var_decl(p);
+    } else {
+        if (out)
+            *out = parser_parse_union_var_decl(p);
         else
             parser_parse_union_var_decl(p);
-        return out_global ? *out_global != NULL : 1;
+    }
+    return 1;
+}
+
+/* Helper to parse typedef declarations */
+static int parse_typedef_decl(parser_t *p, size_t start_pos, stmt_t **out)
+{
+    token_t *tok = peek(p);
+    if (!tok || tok->type != TOK_KW_TYPEDEF)
+        return 0;
+
+    p->pos++; /* consume 'typedef' */
+    type_kind_t tt;
+    if (!parse_basic_type(p, &tt)) {
+        p->pos = start_pos;
+        return 0;
+    }
+    size_t elem_sz = basic_type_size(tt);
+    if (match(p, TOK_STAR))
+        tt = TYPE_PTR;
+
+    token_t *name_tok = peek(p);
+    if (!name_tok || name_tok->type != TOK_IDENT) {
+        p->pos = start_pos;
+        return 0;
+    }
+    p->pos++;
+    size_t arr_size = 0;
+    if (match(p, TOK_LBRACKET)) {
+        token_t *num = peek(p);
+        if (!num || num->type != TOK_NUMBER) {
+            p->pos = start_pos;
+            return 0;
+        }
+        p->pos++;
+        arr_size = strtoul(num->lexeme, NULL, 10);
+        if (!match(p, TOK_RBRACKET)) {
+            p->pos = start_pos;
+            return 0;
+        }
+        tt = TYPE_ARRAY;
+    }
+    if (!match(p, TOK_SEMI)) {
+        p->pos = start_pos;
+        return 0;
     }
 
-    if (tok->type == TOK_KW_ENUM) {
-        token_t *next = &p->tokens[p->pos + 1];
-        if (next && next->type == TOK_LBRACE) {
-            p->pos = save;
-            match(p, TOK_KW_ENUM);
-            if (out_global)
-                *out_global = parser_parse_enum_decl(p);
-            else
-                parser_parse_enum_decl(p);
-            return out_global ? *out_global != NULL : 1;
-        }
-        if (next && next->type == TOK_IDENT && p->pos + 2 < p->count &&
-            p->tokens[p->pos + 2].type == TOK_LBRACE) {
-            p->pos = save;
-            match(p, TOK_KW_ENUM);
-            if (out_global)
-                *out_global = parser_parse_enum_decl(p);
-            else
-                parser_parse_enum_decl(p);
-            return out_global ? *out_global != NULL : 1;
-        }
-        p->pos = save;
-    }
+    if (out)
+        *out = ast_make_typedef(name_tok->lexeme, tt, arr_size, elem_sz,
+                                tok->line, tok->column);
+    return 1;
+}
 
-    if (tok->type == TOK_KW_TYPEDEF) {
-        p->pos++;
-        type_kind_t tt;
-        if (!parse_basic_type(p, &tt)) { p->pos = save; return 0; }
-        size_t elem_sz = basic_type_size(tt);
-        if (match(p, TOK_STAR))
-            tt = TYPE_PTR;
-        token_t *name_tok = peek(p);
-        if (!name_tok || name_tok->type != TOK_IDENT) { p->pos = save; return 0; }
-        p->pos++;
-        size_t arr_size = 0;
-        if (match(p, TOK_LBRACKET)) {
-            token_t *num = peek(p);
-            if (!num || num->type != TOK_NUMBER) { p->pos = save; return 0; }
-            p->pos++;
-            arr_size = strtoul(num->lexeme, NULL, 10);
-            if (!match(p, TOK_RBRACKET)) { p->pos = save; return 0; }
-            tt = TYPE_ARRAY;
-        }
-        if (!match(p, TOK_SEMI)) { p->pos = save; return 0; }
-        if (out_global)
-            *out_global = ast_make_typedef(name_tok->lexeme, tt, arr_size,
-                                          elem_sz, tok->line, tok->column);
-        return *out_global != NULL;
-    }
+/* Helper to parse a function definition or variable declaration */
+static int parse_function_or_var(parser_t *p, symtable_t *funcs,
+                                 int is_extern, int is_static, int is_register,
+                                 int is_const, int is_volatile,
+                                 size_t spec_pos, size_t line, size_t column,
+                                 func_t **out_func, stmt_t **out_global)
+{
+    size_t save = spec_pos;
 
     type_kind_t t;
     if (!parse_basic_type(p, &t))
@@ -435,7 +455,6 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
     size_t arr_size = 0;
     token_t *next_tok = peek(p);
     if (next_tok && next_tok->type == TOK_LPAREN) {
-        /* lookahead for prototype or definition */
         p->pos++; /* '(' */
         vector_t param_types_v;
         vector_init(&param_types_v, sizeof(type_kind_t));
@@ -466,6 +485,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
                 return 0;
             }
         }
+
         token_t *after = peek(p);
         if (after && after->type == TOK_SEMI) {
             p->pos++; /* ';' */
@@ -479,7 +499,7 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
             p->pos = spec_pos;
             if (out_func)
                 *out_func = parser_parse_func(p);
-            return *out_func != NULL;
+            return out_func ? *out_func != NULL : 0;
         } else {
             vector_free(&param_types_v);
             p->pos = save;
@@ -514,12 +534,12 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         p->pos++; /* consume ';' */
         if (out_global)
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_register, is_extern,
-                                           is_const, is_volatile, is_restrict,
+                                           elem_size, is_static, is_register,
+                                           is_extern, is_const, is_volatile,
+                                           is_restrict, NULL, NULL, 0,
                                            NULL, NULL, 0,
-                                           NULL, NULL, 0,
-                                           tok->line, tok->column);
-        return *out_global != NULL;
+                                           line, column);
+        return 1;
     } else if (next_tok && next_tok->type == TOK_ASSIGN) {
         if (t == TYPE_VOID) {
             p->pos = save;
@@ -553,16 +573,60 @@ int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
         }
         if (out_global)
             *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_register, is_extern,
-                                           is_const, is_volatile, is_restrict,
-                                           init, init_list, init_count,
-                                           NULL, NULL, 0,
-                                           tok->line, tok->column);
-        return *out_global != NULL;
+                                           elem_size, is_static, is_register,
+                                           is_extern, is_const, is_volatile,
+                                           is_restrict, init, init_list,
+                                           init_count, NULL, NULL, 0,
+                                           line, column);
+        return 1;
     }
 
     p->pos = spec_pos;
     if (out_func)
         *out_func = parser_parse_func(p);
-    return *out_func != NULL;
+    return out_func ? *out_func != NULL : 0;
+}
+
+/*
+ * Parse either a global variable declaration or a full function
+ * definition.  Exactly one of "out_func" or "out_global" is set on
+ * success.  The function returns 1 when a valid top-level construct was
+ * consumed and 0 otherwise.
+ */
+int parser_parse_toplevel(parser_t *p, symtable_t *funcs,
+                          func_t **out_func, stmt_t **out_global)
+{
+    if (out_func) *out_func = NULL;
+    if (out_global) *out_global = NULL;
+
+    size_t start = p->pos;
+    int is_extern = match(p, TOK_KW_EXTERN);
+    int is_static = match(p, TOK_KW_STATIC);
+    int is_register = match(p, TOK_KW_REGISTER);
+    match(p, TOK_KW_INLINE);
+    int is_const = match(p, TOK_KW_CONST);
+    int is_volatile = match(p, TOK_KW_VOLATILE);
+    size_t spec_pos = p->pos;
+    token_t *tok = peek(p);
+    if (!tok)
+        return 0;
+
+    if (tok->type == TOK_KW_STRUCT || tok->type == TOK_KW_UNION) {
+        return parse_struct_or_union_global(p, start, out_global);
+    }
+
+    if (tok->type == TOK_KW_ENUM) {
+        if (parse_enum_global(p, start, out_global))
+            return 1;
+        tok = peek(p); /* restored by helper */
+    }
+
+    if (tok->type == TOK_KW_TYPEDEF)
+        return parse_typedef_decl(p, start, out_global);
+
+    p->pos = spec_pos;
+    return parse_function_or_var(p, funcs, is_extern, is_static, is_register,
+                                 is_const, is_volatile, spec_pos,
+                                 tok->line, tok->column,
+                                 out_func, out_global);
 }


### PR DESCRIPTION
## Summary
- add helper functions to handle enum, struct/union, typedef and general
  toplevel parsing logic
- shrink `parser_parse_toplevel` by calling the helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685da082e5548324aad2d7de1ea5938f