### PR TITLE
Refactor semantic checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BIN = vc
 CORE_SRC = src/main.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_init.c \
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
-           src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir.c \
+           src/semantic_loops.c src/semantic_switch.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir.c \
            src/codegen.c src/codegen_mem.c src/codegen_arith.c src/codegen_branch.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
@@ -19,7 +19,7 @@ OPT_SRC = src/opt.c src/opt_constprop.c src/opt_fold.c src/opt_dce.c
 EXTRA_SRC ?=
 # Final source list
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
-HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_stmt.h include/semantic_global.h \
+HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_global.h \
     include/ir.h include/ir_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h

--- a/include/semantic.h
+++ b/include/semantic.h
@@ -11,6 +11,8 @@
 #include "consteval.h"
 #include "semantic_expr.h"
 #include "semantic_stmt.h"
+#include "semantic_loops.h"
+#include "semantic_switch.h"
 #include "semantic_global.h"
 
 #endif /* VC_SEMANTIC_H */

--- a/include/semantic_loops.h
+++ b/include/semantic_loops.h
@@ -1,0 +1,26 @@
+/*
+ * Loop statement semantic helpers.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_SEMANTIC_LOOPS_H
+#define VC_SEMANTIC_LOOPS_H
+
+#include "ast.h"
+#include "ir.h"
+#include "symtable.h"
+#include "semantic_switch.h"
+
+int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                     label_table_t *labels, ir_builder_t *ir,
+                     type_kind_t func_ret_type);
+int check_do_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                        label_table_t *labels, ir_builder_t *ir,
+                        type_kind_t func_ret_type);
+int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                   label_table_t *labels, ir_builder_t *ir,
+                   type_kind_t func_ret_type);
+
+#endif /* VC_SEMANTIC_LOOPS_H */

--- a/include/semantic_stmt.h
+++ b/include/semantic_stmt.h
@@ -12,21 +12,6 @@
 #include "ir.h"
 #include "symtable.h"
 
-typedef struct label_entry {
-    char *name;
-    char *ir_name;
-    struct label_entry *next;
-} label_entry_t;
-
-typedef struct {
-    label_entry_t *head;
-} label_table_t;
-
-void label_table_init(label_table_t *t);
-void label_table_free(label_table_t *t);
-const char *label_table_get(label_table_t *t, const char *name);
-const char *label_table_get_or_add(label_table_t *t, const char *name);
-
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                void *labels, ir_builder_t *ir, type_kind_t func_ret_type,
                const char *break_label, const char *continue_label);

--- a/include/semantic_switch.h
+++ b/include/semantic_switch.h
@@ -1,0 +1,35 @@
+/*
+ * Switch statement and label table helpers.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_SEMANTIC_SWITCH_H
+#define VC_SEMANTIC_SWITCH_H
+
+#include "ast.h"
+#include "ir.h"
+#include "symtable.h"
+#include "util.h"
+
+typedef struct label_entry {
+    char *name;
+    char *ir_name;
+    struct label_entry *next;
+} label_entry_t;
+
+typedef struct {
+    label_entry_t *head;
+} label_table_t;
+
+void label_table_init(label_table_t *t);
+void label_table_free(label_table_t *t);
+const char *label_table_get(label_table_t *t, const char *name);
+const char *label_table_get_or_add(label_table_t *t, const char *name);
+
+int check_switch_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                      label_table_t *labels, ir_builder_t *ir,
+                      type_kind_t func_ret_type);
+
+#endif /* VC_SEMANTIC_SWITCH_H */

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include "semantic_global.h"
 #include "semantic_stmt.h"
+#include "semantic_switch.h"
 #include "consteval.h"
 #include "semantic_expr.h"
 #include "symtable.h"

--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -1,0 +1,106 @@
+/* Loop statement semantic helpers */
+
+#include "semantic_loops.h"
+#include "semantic_expr.h"
+#include "label.h"
+
+/* Forward declaration from semantic_stmt.c */
+extern int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                      void *labels, ir_builder_t *ir, type_kind_t func_ret_type,
+                      const char *break_label, const char *continue_label);
+extern void symtable_pop_scope(symtable_t *table, symbol_t *old_head);
+
+int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                     label_table_t *labels, ir_builder_t *ir,
+                     type_kind_t func_ret_type)
+{
+    ir_value_t cond_val;
+    char start_label[32];
+    char end_label[32];
+    int id = label_next_id();
+    label_format_suffix("L", id, "_start", start_label);
+    label_format_suffix("L", id, "_end", end_label);
+    ir_build_label(ir, start_label);
+    if (check_expr(stmt->while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
+        return 0;
+    ir_build_bcond(ir, cond_val, end_label);
+    if (!check_stmt(stmt->while_stmt.body, vars, funcs, labels, ir,
+                    func_ret_type, end_label, start_label))
+        return 0;
+    ir_build_br(ir, start_label);
+    ir_build_label(ir, end_label);
+    return 1;
+}
+
+int check_do_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                        label_table_t *labels, ir_builder_t *ir,
+                        type_kind_t func_ret_type)
+{
+    ir_value_t cond_val;
+    char start_label[32];
+    char cond_label[32];
+    char end_label[32];
+    int id = label_next_id();
+    label_format_suffix("L", id, "_start", start_label);
+    label_format_suffix("L", id, "_cond", cond_label);
+    label_format_suffix("L", id, "_end", end_label);
+    ir_build_label(ir, start_label);
+    if (!check_stmt(stmt->do_while_stmt.body, vars, funcs, labels, ir,
+                    func_ret_type, end_label, cond_label))
+        return 0;
+    ir_build_label(ir, cond_label);
+    if (check_expr(stmt->do_while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
+        return 0;
+    ir_build_bcond(ir, cond_val, end_label);
+    ir_build_br(ir, start_label);
+    ir_build_label(ir, end_label);
+    return 1;
+}
+
+int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                   label_table_t *labels, ir_builder_t *ir,
+                   type_kind_t func_ret_type)
+{
+    ir_value_t cond_val;
+    char start_label[32];
+    char end_label[32];
+    int id = label_next_id();
+    label_format_suffix("L", id, "_start", start_label);
+    label_format_suffix("L", id, "_end", end_label);
+    symbol_t *old_head = vars->head;
+    if (stmt->for_stmt.init_decl) {
+        if (!check_stmt(stmt->for_stmt.init_decl, vars, funcs, labels, ir,
+                        func_ret_type, NULL, NULL)) {
+            symtable_pop_scope(vars, old_head);
+            return 0;
+        }
+    } else {
+        if (check_expr(stmt->for_stmt.init, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+            symtable_pop_scope(vars, old_head);
+            return 0; /* reuse cond_val for init but ignore value */
+        }
+    }
+    ir_build_label(ir, start_label);
+    if (check_expr(stmt->for_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+        symtable_pop_scope(vars, old_head);
+        return 0;
+    }
+    ir_build_bcond(ir, cond_val, end_label);
+    char cont_label[32];
+    label_format_suffix("L", id, "_cont", cont_label);
+    if (!check_stmt(stmt->for_stmt.body, vars, funcs, labels, ir,
+                    func_ret_type, end_label, cont_label)) {
+        symtable_pop_scope(vars, old_head);
+        return 0;
+    }
+    ir_build_label(ir, cont_label);
+    if (check_expr(stmt->for_stmt.incr, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+        symtable_pop_scope(vars, old_head);
+        return 0;
+    }
+    ir_build_br(ir, start_label);
+    ir_build_label(ir, end_label);
+    symtable_pop_scope(vars, old_head);
+    return 1;
+}
+

--- a/src/semantic_switch.c
+++ b/src/semantic_switch.c
@@ -1,0 +1,120 @@
+/* Switch statement and label table helpers */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "semantic_switch.h"
+#include "consteval.h"
+#include "semantic_expr.h"
+#include "util.h"
+#include "label.h"
+#include "error.h"
+
+/* Forward declaration from semantic_stmt.c */
+extern int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                      void *labels, ir_builder_t *ir, type_kind_t func_ret_type,
+                      const char *break_label, const char *continue_label);
+
+void label_table_init(label_table_t *t) { t->head = NULL; }
+
+void label_table_free(label_table_t *t)
+{
+    label_entry_t *e = t->head;
+    while (e) {
+        label_entry_t *n = e->next;
+        free(e->name);
+        free(e->ir_name);
+        free(e);
+        e = n;
+    }
+    t->head = NULL;
+}
+
+const char *label_table_get(label_table_t *t, const char *name)
+{
+    for (label_entry_t *e = t->head; e; e = e->next) {
+        if (strcmp(e->name, name) == 0)
+            return e->ir_name;
+    }
+    return NULL;
+}
+
+const char *label_table_get_or_add(label_table_t *t, const char *name)
+{
+    const char *ir = label_table_get(t, name);
+    if (ir)
+        return ir;
+    label_entry_t *e = malloc(sizeof(*e));
+    if (!e)
+        return NULL;
+    e->name = vc_strdup(name);
+    char buf[32];
+    e->ir_name = vc_strdup(label_format("Luser", label_next_id(), buf));
+    e->next = t->head;
+    t->head = e;
+    return e->ir_name;
+}
+
+int check_switch_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                      label_table_t *labels, ir_builder_t *ir,
+                      type_kind_t func_ret_type)
+{
+    ir_value_t expr_val;
+    if (check_expr(stmt->switch_stmt.expr, vars, funcs, ir, &expr_val) == TYPE_UNKNOWN)
+        return 0;
+    char end_label[32];
+    char default_label[32];
+    int id = label_next_id();
+    label_format_suffix("L", id, "_end", end_label);
+    label_format_suffix("L", id, "_default", default_label);
+    char **case_labels = calloc(stmt->switch_stmt.case_count, sizeof(char *));
+    if (!case_labels)
+        return 0;
+    for (size_t i = 0; i < stmt->switch_stmt.case_count; i++) {
+        char lbl[32];
+        snprintf(lbl, sizeof(lbl), "L%d_case%zu", id, i);
+        case_labels[i] = vc_strdup(lbl);
+        long long cval;
+        if (!eval_const_expr(stmt->switch_stmt.cases[i].expr, vars, &cval)) {
+            for (size_t j = 0; j <= i; j++) free(case_labels[j]);
+            free(case_labels);
+            error_set(stmt->switch_stmt.cases[i].expr->line,
+                      stmt->switch_stmt.cases[i].expr->column);
+            return 0;
+        }
+        ir_value_t const_val = ir_build_const(ir, cval);
+        ir_value_t cmp = ir_build_binop(ir, IR_CMPEQ, expr_val, const_val);
+        ir_build_bcond(ir, cmp, case_labels[i]);
+    }
+    if (stmt->switch_stmt.default_body)
+        ir_build_br(ir, default_label);
+    else
+        ir_build_br(ir, end_label);
+    for (size_t i = 0; i < stmt->switch_stmt.case_count; i++) {
+        ir_build_label(ir, case_labels[i]);
+        if (!check_stmt(stmt->switch_stmt.cases[i].body, vars, funcs, labels, ir,
+                        func_ret_type, end_label, NULL)) {
+            for (size_t j = 0; j < stmt->switch_stmt.case_count; j++)
+                free(case_labels[j]);
+            free(case_labels);
+            return 0;
+        }
+        ir_build_br(ir, end_label);
+    }
+    if (stmt->switch_stmt.default_body) {
+        ir_build_label(ir, default_label);
+        if (!check_stmt(stmt->switch_stmt.default_body, vars, funcs, labels, ir,
+                        func_ret_type, end_label, NULL)) {
+            for (size_t j = 0; j < stmt->switch_stmt.case_count; j++)
+                free(case_labels[j]);
+            free(case_labels);
+            return 0;
+        }
+    }
+    ir_build_label(ir, end_label);
+    for (size_t j = 0; j < stmt->switch_stmt.case_count; j++)
+        free(case_labels[j]);
+    free(case_labels);
+    return 1;
+}
+


### PR DESCRIPTION
## Summary
- move loop validation helpers into `semantic_loops.c`
- move switch and label table logic into `semantic_switch.c`
- update `check_stmt` to include new headers
- add new headers to build system

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685daa25f6b883248444772a0c3b9805