### PR TITLE
Split IR builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BIN = vc
 CORE_SRC = src/main.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_init.c \
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
-           src/semantic_loops.c src/semantic_switch.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir.c \
+           src/semantic_loops.c src/semantic_switch.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_arith.c src/codegen_branch.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
@@ -20,7 +20,7 @@ EXTRA_SRC ?=
 # Final source list
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_global.h \
-    include/ir.h include/ir_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
+    include/ir_core.h include/ir_global.h include/ir_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h
 PREFIX ?= /usr/local

--- a/docs/vcdoc.md
+++ b/docs/vcdoc.md
@@ -156,7 +156,7 @@ Defines the IR structures used throughout the rest of the compiler.
 
 #### Instruction set
 The IR uses a straightforward three-address format. The operations defined in
-[`include/ir.h`](../include/ir.h) include:
+[`include/ir_core.h`](../include/ir_core.h) include:
 
 - `IR_CONST` for integer constants
 - arithmetic ops `IR_ADD`, `IR_SUB`, `IR_MUL`, `IR_DIV`, `IR_MOD`

--- a/include/codegen.h
+++ b/include/codegen.h
@@ -9,7 +9,7 @@
 #define VC_CODEGEN_H
 
 #include <stdio.h>
-#include "ir.h"
+#include "ir_core.h"
 
 /*
  * Emit the full x86 assembly for `ir` to `out`.

--- a/include/codegen_arith.h
+++ b/include/codegen_arith.h
@@ -9,7 +9,7 @@
 #define VC_CODEGEN_ARITH_H
 
 #include "strbuf.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "regalloc.h"
 
 void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,

--- a/include/codegen_branch.h
+++ b/include/codegen_branch.h
@@ -9,7 +9,7 @@
 #define VC_CODEGEN_BRANCH_H
 
 #include "strbuf.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "regalloc.h"
 
 void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,

--- a/include/codegen_mem.h
+++ b/include/codegen_mem.h
@@ -9,7 +9,7 @@
 #define VC_CODEGEN_MEM_H
 
 #include "strbuf.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "regalloc.h"
 
 void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,

--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -1,12 +1,12 @@
 /*
- * Intermediate representation data types.
+ * Core intermediate representation data types and builders.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
 
-#ifndef VC_IR_H
-#define VC_IR_H
+#ifndef VC_IR_CORE_H
+#define VC_IR_CORE_H
 
 /* IR operation codes */
 typedef enum {
@@ -64,117 +64,78 @@ typedef enum {
     IR_LABEL
 } ir_op_t;
 
-/* Forward declaration */
 struct ir_instr;
 
-/* Value produced by an instruction */
 typedef struct {
-    int id; /* unique value id */
+    int id;
 } ir_value_t;
 
-/* IR instruction representation */
 typedef struct ir_instr {
     ir_op_t op;
-    int dest;             /* destination value id (-1 if none) */
-    int src1;             /* first operand */
-    int src2;             /* second operand */
-    long long imm;        /* immediate value for constants and sizes */
-    char *name;           /* identifier / label */
-    char *data;           /* for string literals */
-    int is_volatile;      /* volatile memory access */
+    int dest;
+    int src1;
+    int src2;
+    long long imm;
+    char *name;
+    char *data;
+    int is_volatile;
     struct ir_instr *next;
 } ir_instr_t;
 
-/* IR builder accumulates instructions sequentially */
 typedef struct {
     ir_instr_t *head;
     ir_instr_t *tail;
     int next_value_id;
 } ir_builder_t;
 
-/* Initialize an IR builder. */
 void ir_builder_init(ir_builder_t *b);
-
-/* Free all instructions accumulated in the builder. */
 void ir_builder_free(ir_builder_t *b);
 
-/* Append IR_CONST producing a new value holding an immediate. */
 ir_value_t ir_build_const(ir_builder_t *b, long long value);
-
-/* Append IR_LOAD for variable `name`. */
 ir_value_t ir_build_load(ir_builder_t *b, const char *name);
 ir_value_t ir_build_load_vol(ir_builder_t *b, const char *name);
 
-/* Append a binary arithmetic or comparison op. */
-ir_value_t ir_build_binop(ir_builder_t *b, ir_op_t op, ir_value_t left, ir_value_t right);
+ir_value_t ir_build_binop(ir_builder_t *b, ir_op_t op, ir_value_t left,
+                          ir_value_t right);
 ir_value_t ir_build_logand(ir_builder_t *b, ir_value_t left, ir_value_t right);
 ir_value_t ir_build_logor(ir_builder_t *b, ir_value_t left, ir_value_t right);
 
-/* Append IR_STORE assigning `val` to variable `name`. */
 void ir_build_store(ir_builder_t *b, const char *name, ir_value_t val);
 void ir_build_store_vol(ir_builder_t *b, const char *name, ir_value_t val);
 
-/* Append IR_LOAD_PARAM reading argument `index`. */
 ir_value_t ir_build_load_param(ir_builder_t *b, int index);
-
-/* Append IR_STORE_PARAM writing `val` to parameter `index`. */
 void ir_build_store_param(ir_builder_t *b, int index, ir_value_t val);
 
-/* Append IR_ADDR that yields the address of `name`. */
 ir_value_t ir_build_addr(ir_builder_t *b, const char *name);
-
-/* Append IR_LOAD_PTR that loads from pointer value `addr`. */
 ir_value_t ir_build_load_ptr(ir_builder_t *b, ir_value_t addr);
-
-/* Append IR_STORE_PTR that stores `val` through pointer `addr`. */
 void ir_build_store_ptr(ir_builder_t *b, ir_value_t addr, ir_value_t val);
 
-/* Pointer arithmetic helpers */
 ir_value_t ir_build_ptr_add(ir_builder_t *b, ir_value_t ptr, ir_value_t idx,
                             int elem_size);
 ir_value_t ir_build_ptr_diff(ir_builder_t *b, ir_value_t a, ir_value_t bptr,
                              int elem_size);
 
-/* Append IR_LOAD_IDX fetching `name[idx]`. */
 ir_value_t ir_build_load_idx(ir_builder_t *b, const char *name, ir_value_t idx);
-ir_value_t ir_build_load_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx);
-
-/* Append IR_STORE_IDX setting `name[idx] = val`. */
+ir_value_t ir_build_load_idx_vol(ir_builder_t *b, const char *name,
+                                 ir_value_t idx);
 void ir_build_store_idx(ir_builder_t *b, const char *name, ir_value_t idx,
                         ir_value_t val);
 void ir_build_store_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx,
                             ir_value_t val);
 
-/* Allocate `size` bytes on the stack and return the address. */
 ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size);
 
-/* Append IR_RETURN with return value `val`. */
 void ir_build_return(ir_builder_t *b, ir_value_t val);
-
-/* Push an argument for the next IR_CALL. */
 void ir_build_arg(ir_builder_t *b, ir_value_t val);
-
-/* Append IR_CALL to `name` expecting `arg_count` preceding IR_ARGs. */
 ir_value_t ir_build_call(ir_builder_t *b, const char *name, size_t arg_count);
 
-/* Mark start and end of a function. */
 void ir_build_func_begin(ir_builder_t *b, const char *name);
 void ir_build_func_end(ir_builder_t *b);
 
-/* Unconditional/conditional branches and labels. */
 void ir_build_br(ir_builder_t *b, const char *label);
 void ir_build_bcond(ir_builder_t *b, ir_value_t cond, const char *label);
 void ir_build_label(ir_builder_t *b, const char *label);
 
-/* Global data declarations. */
 ir_value_t ir_build_string(ir_builder_t *b, const char *data);
-void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
-                       int is_static);
-void ir_build_glob_array(ir_builder_t *b, const char *name,
-                         const long long *values, size_t count, int is_static);
-void ir_build_glob_union(ir_builder_t *b, const char *name, int size,
-                         int is_static);
-void ir_build_glob_struct(ir_builder_t *b, const char *name, int size,
-                          int is_static);
 
-#endif /* VC_IR_H */
+#endif /* VC_IR_CORE_H */

--- a/include/ir_dump.h
+++ b/include/ir_dump.h
@@ -8,7 +8,7 @@
 #ifndef VC_IR_DUMP_H
 #define VC_IR_DUMP_H
 
-#include "ir.h"
+#include "ir_core.h"
 
 /*
  * Generate a human readable string for the IR. Each instruction is

--- a/include/ir_global.h
+++ b/include/ir_global.h
@@ -1,0 +1,23 @@
+/*
+ * Builders for global variables and aggregates.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_IR_GLOBAL_H
+#define VC_IR_GLOBAL_H
+
+#include "ir_core.h"
+
+void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
+                       int is_static);
+void ir_build_glob_array(ir_builder_t *b, const char *name,
+                         const long long *values, size_t count,
+                         int is_static);
+void ir_build_glob_union(ir_builder_t *b, const char *name, int size,
+                         int is_static);
+void ir_build_glob_struct(ir_builder_t *b, const char *name, int size,
+                          int is_static);
+
+#endif /* VC_IR_GLOBAL_H */

--- a/include/opt.h
+++ b/include/opt.h
@@ -8,7 +8,7 @@
 #ifndef VC_OPT_H
 #define VC_OPT_H
 
-#include "ir.h"
+#include "ir_core.h"
 
 typedef struct {
     int opt_level;     /* numeric optimization level */

--- a/include/regalloc.h
+++ b/include/regalloc.h
@@ -13,7 +13,7 @@
 #ifndef VC_REGALLOC_H
 #define VC_REGALLOC_H
 
-#include "ir.h"
+#include "ir_core.h"
 
 /* Location mapping for IR values */
 typedef struct {

--- a/include/semantic_arith.h
+++ b/include/semantic_arith.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_ARITH_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 
 /* Binary operation helper used by check_binary_expr */

--- a/include/semantic_call.h
+++ b/include/semantic_call.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_CALL_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 
 type_kind_t check_call_expr(expr_t *expr, symtable_t *vars,

--- a/include/semantic_expr.h
+++ b/include/semantic_expr.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_EXPR_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 
 type_kind_t check_expr(expr_t *expr, symtable_t *vars, symtable_t *funcs,

--- a/include/semantic_global.h
+++ b/include/semantic_global.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_GLOBAL_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 
 size_t layout_union_members(union_member_t *members, size_t count);

--- a/include/semantic_loops.h
+++ b/include/semantic_loops.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_LOOPS_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 #include "semantic_switch.h"
 

--- a/include/semantic_mem.h
+++ b/include/semantic_mem.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_MEM_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 
 /* Array indexing */

--- a/include/semantic_stmt.h
+++ b/include/semantic_stmt.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_STMT_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,

--- a/include/semantic_switch.h
+++ b/include/semantic_switch.h
@@ -9,7 +9,7 @@
 #define VC_SEMANTIC_SWITCH_H
 
 #include "ast.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "symtable.h"
 #include "util.h"
 

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include "ir.h"
+#include "ir_core.h"
 #include "label.h"
 #include "strbuf.h"
 #include "util.h"
@@ -433,65 +433,4 @@ void ir_build_label(ir_builder_t *b, const char *label)
     ins->name = vc_strdup(label ? label : "");
 }
 
-/*
- * Emit IR_GLOB_VAR declaring global variable `name` with constant
- * initializer `value`.
- */
-void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
-                       int is_static)
-{
-    ir_instr_t *ins = append_instr(b);
-    if (!ins)
-        return;
-    ins->op = IR_GLOB_VAR;
-    ins->name = vc_strdup(name ? name : "");
-    ins->imm = value;
-    ins->src1 = is_static;
-}
-
-void ir_build_glob_array(ir_builder_t *b, const char *name,
-                         const long long *values, size_t count, int is_static)
-{
-    /* Emit IR_GLOB_ARRAY storing an array of constants. `data` points
-     * to a copy of the initializer values. */
-    ir_instr_t *ins = append_instr(b);
-    if (!ins)
-        return;
-    ins->op = IR_GLOB_ARRAY;
-    ins->name = vc_strdup(name ? name : "");
-    ins->imm = (long long)count;
-    ins->src1 = is_static;
-    if (count) {
-        long long *vals = malloc(count * sizeof(long long));
-        if (!vals)
-            return;
-        for (size_t i = 0; i < count; i++)
-            vals[i] = values[i];
-        ins->data = (char *)vals;
-    }
-}
-
-void ir_build_glob_union(ir_builder_t *b, const char *name, int size,
-                         int is_static)
-{
-    ir_instr_t *ins = append_instr(b);
-    if (!ins)
-        return;
-    ins->op = IR_GLOB_UNION;
-    ins->name = vc_strdup(name ? name : "");
-    ins->imm = size;
-    ins->src1 = is_static;
-}
-
-void ir_build_glob_struct(ir_builder_t *b, const char *name, int size,
-                          int is_static)
-{
-    ir_instr_t *ins = append_instr(b);
-    if (!ins)
-        return;
-    ins->op = IR_GLOB_STRUCT;
-    ins->name = vc_strdup(name ? name : "");
-    ins->imm = size;
-    ins->src1 = is_static;
-}
 

--- a/src/ir_global.c
+++ b/src/ir_global.c
@@ -1,0 +1,86 @@
+/*
+ * Global variable and structure IR builders.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include "ir_global.h"
+#include "util.h"
+
+/* Helper to append a blank instruction */
+static ir_instr_t *append_instr(ir_builder_t *b)
+{
+    ir_instr_t *ins = calloc(1, sizeof(*ins));
+    if (!ins)
+        return NULL;
+    ins->dest = -1;
+    ins->name = NULL;
+    ins->data = NULL;
+    ins->is_volatile = 0;
+    if (!b->head)
+        b->head = ins;
+    else
+        b->tail->next = ins;
+    b->tail = ins;
+    return ins;
+}
+
+void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
+                       int is_static)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return;
+    ins->op = IR_GLOB_VAR;
+    ins->name = vc_strdup(name ? name : "");
+    ins->imm = value;
+    ins->src1 = is_static;
+}
+
+void ir_build_glob_array(ir_builder_t *b, const char *name,
+                         const long long *values, size_t count,
+                         int is_static)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return;
+    ins->op = IR_GLOB_ARRAY;
+    ins->name = vc_strdup(name ? name : "");
+    ins->imm = (long long)count;
+    ins->src1 = is_static;
+    if (count) {
+        long long *vals = malloc(count * sizeof(long long));
+        if (!vals)
+            return;
+        for (size_t i = 0; i < count; i++)
+            vals[i] = values[i];
+        ins->data = (char *)vals;
+    }
+}
+
+void ir_build_glob_union(ir_builder_t *b, const char *name, int size,
+                         int is_static)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return;
+    ins->op = IR_GLOB_UNION;
+    ins->name = vc_strdup(name ? name : "");
+    ins->imm = size;
+    ins->src1 = is_static;
+}
+
+void ir_build_glob_struct(ir_builder_t *b, const char *name, int size,
+                          int is_static)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return;
+    ins->op = IR_GLOB_STRUCT;
+    ins->name = vc_strdup(name ? name : "");
+    ins->imm = size;
+    ins->src1 = is_static;
+}
+

--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,7 @@
 #include "symtable.h"
 #include "semantic.h"
 #include "error.h"
-#include "ir.h"
+#include "ir_core.h"
 #include "ir_dump.h"
 #include "opt.h"
 #include "codegen.h"

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -9,6 +9,7 @@
 #include "consteval.h"
 #include "semantic_expr.h"
 #include "symtable.h"
+#include "ir_global.h"
 #include "util.h"
 #include "label.h"
 #include "error.h"

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -9,6 +9,7 @@
 #include "consteval.h"
 #include "semantic_expr.h"
 #include "semantic_global.h"
+#include "ir_global.h"
 #include "symtable.h"
 #include "util.h"
 #include "label.h"


### PR DESCRIPTION
## Summary
- separate global IR builders into new `ir_global.c`
- keep instruction utilities in `ir_core.c`
- add `ir_core.h` and `ir_global.h`
- update all modules and Makefile

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685db3a947c483248dbf9101c4e3e11d