### PR TITLE
Handle long float ops in constant propagation

### DIFF
--- a/src/opt_constprop.c
+++ b/src/opt_constprop.c
@@ -117,6 +117,7 @@ void propagate_load_consts(ir_builder_t *ir)
         case IR_ADD: case IR_SUB: case IR_MUL: case IR_DIV: case IR_MOD:
         case IR_SHL: case IR_SHR: case IR_AND: case IR_OR: case IR_XOR:
         case IR_FADD: case IR_FSUB: case IR_FMUL: case IR_FDIV:
+        case IR_LFADD: case IR_LFSUB: case IR_LFMUL: case IR_LFDIV:
         case IR_PTR_ADD:
         case IR_PTR_DIFF:
         case IR_CMPEQ: case IR_CMPNE: case IR_CMPLT:


### PR DESCRIPTION
## Summary
- mark results of long floating point ops as non-constant during constant propagation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685dfdeb0ae0832493904b4024ab1e65