### PR TITLE
Fix warning in propagate_load_consts

### DIFF
--- a/src/opt_constprop.c
+++ b/src/opt_constprop.c
@@ -102,6 +102,7 @@ void propagate_load_consts(ir_builder_t *ir)
         case IR_ADDR:
         case IR_LOAD_PTR:
         case IR_LOAD_IDX:
+        case IR_ALLOCA:
         case IR_STORE_PARAM:
         case IR_RETURN:
         case IR_FUNC_BEGIN:


### PR DESCRIPTION
## Summary
- mark IR_ALLOCA as non-constant when propagating load constants

## Testing
- `make`
- `./tests/run.sh` *(fails: `src/parser.c: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685e08fe06648324af9defe09301874b