### PR TITLE
Add missing IR cases to constant folding

### DIFF
--- a/src/opt_fold.c
+++ b/src/opt_fold.c
@@ -109,6 +109,10 @@ void fold_constants(ir_builder_t *ir)
                 is_const[ins->dest] = 0;
             }
             break;
+        case IR_LFADD: case IR_LFSUB: case IR_LFMUL: case IR_LFDIV:
+            if (ins->dest >= 0 && ins->dest < max_id)
+                is_const[ins->dest] = 0;
+            break;
         case IR_LOAD:
         case IR_LOAD_IDX:
             if (ins->dest >= 0 && ins->dest < max_id)
@@ -126,6 +130,7 @@ void fold_constants(ir_builder_t *ir)
         case IR_STORE_PTR:
         case IR_PTR_ADD:
         case IR_PTR_DIFF:
+        case IR_ALLOCA:
             if (ins->dest >= 0 && ins->dest < max_id)
                 is_const[ins->dest] = 0;
             break;


### PR DESCRIPTION
## Summary
- handle IR_LFADD/IR_LFSUB/IR_LFMUL/IR_LFDIV in `fold_constants`
- treat IR_ALLOCA as non-foldable

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e09e0cce48324bad029dad2447547