### PR TITLE
Add docs index links and TOCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ vc --dump-asm source.c
 
 ## Documentation
 
-- [Documentation index](docs/index.md)
+The [documentation index](docs/index.md) provides an overview of all available
+pages. Key documents include:
+
 - [Compiler architecture](docs/architecture.md)
 - [Compilation pipeline](docs/pipeline.md)
 - [Command-line options](docs/command_line.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,11 @@
 # Compiler Architecture
 
+See the [documentation index](index.md) for a list of all available pages.
+
+## Table of Contents
+
+- [Overview](#overview)
+
 This document describes the high level architecture of **vc**.
 
 ## Overview

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,5 +1,14 @@
 # Building vc
 
+See the [documentation index](index.md) for a list of all available pages.
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Build options](#build-options)
+- [Additional build steps](#additional-build-steps)
+- [Running the test suite](#running-the-test-suite)
+
 `vc` targets POSIX systems with a focus on NetBSD. Building on other BSD
 variants such as FreeBSD or OpenBSD should work with little or no
 modification.

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -1,5 +1,13 @@
 ## Command-line Options
 
+See the [documentation index](index.md) for a list of all available pages.
+
+## Table of Contents
+
+- [Command-line Options](#command-line-options)
+- [Preprocessor Usage](#preprocessor-usage)
+- [Compiling a Simple Program](#compiling-a-simple-program)
+
 The compiler supports the following options:
 
 - `-o`, `--output <file>` – path for the generated assembly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,22 @@
 # vc Documentation Index
 
-`vc` is a lightweight ANSI C compiler with experimental C99 support. This page links to all project documentation.
+`vc` is a lightweight ANSI C compiler with experimental C99 support. This page
+provides an overview of all available documentation.
 
-- [Compiler architecture](architecture.md)
-- [Building vc](building.md)
-- [Compilation pipeline](pipeline.md)
-- [Supported language features](language_features.md)
-- [Command-line usage](command_line.md)
-- [Optimization passes](optimization.md)
-- [Development roadmap](roadmap.md)
-- [Contributing](../CONTRIBUTING.md)
+## Documents
+
+- [Compiler architecture](architecture.md) – overview of the compiler modules
+  and their interaction.
+- [Building vc](building.md) – requirements, build options and how to run the
+  tests.
+- [Compilation pipeline](pipeline.md) – detailed description of each stage of
+  compilation.
+- [Supported language features](language_features.md) – syntax and semantics
+  currently implemented.
+- [Command-line usage](command_line.md) – available options and example
+  invocations.
+- [Optimization passes](optimization.md) – constant folding, propagation and
+  dead code elimination.
+- [Development roadmap](roadmap.md) – planned milestones and compatibility
+  goals.
+- [Contributing](../CONTRIBUTING.md) – how to submit patches and bug reports.

--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -1,5 +1,28 @@
 ## Supported Language Features
 
+See the [documentation index](index.md) for a list of all available pages.
+
+## Table of Contents
+
+- [Basic arithmetic](#basic-arithmetic)
+- [Compound assignment](#compound-assignment)
+- [Increment and decrement](#increment-and-decrement)
+- [Floating-point arithmetic](#floating-point-arithmetic)
+- [Bitwise operations](#bitwise-operations)
+- [64-bit integers](#64-bit-integers)
+- [Numeric constants](#numeric-constants)
+- [Function calls](#function-calls)
+- [Loops](#loops)
+- [Pointers](#pointers)
+- [Arrays](#arrays)
+- [Compound literals](#compound-literals)
+- [sizeof](#sizeof)
+- [Global variables](#global-variables)
+- [Break and continue](#break-and-continue)
+- [Switch statements](#switch-statements)
+- [Logical operators](#logical-operators)
+- [Enum declarations](#enum-declarations)
+
 - Basic arithmetic expressions
 - Function definitions and calls
 - `for`, `while` and `do`/`while` loops

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -1,5 +1,7 @@
 # Optimization Passes
 
+See the [documentation index](index.md) for a list of all available pages.
+
 The optimizer in **vc** operates on the intermediate representation (IR).
 Three passes are currently available:
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,5 +1,24 @@
 # vc Documentation
 
+See the [documentation index](index.md) for a list of all available pages.
+
+## Table of Contents
+
+- [Pipeline Overview](#pipeline-overview)
+- [Modules](#modules)
+  - [preprocessor](#preprocessor)
+  - [lexer](#lexer)
+  - [parser](#parser)
+  - [semantic](#semantic)
+  - [ir](#ir)
+  - [opt](#opt)
+  - [regalloc](#regalloc)
+  - [codegen](#codegen)
+- [Optimization Passes](#optimization-passes)
+  - [Constant folding](#constant-folding)
+  - [Constant propagation](#constant-propagation)
+  - [Dead code elimination](#dead-code-elimination)
+
 This document describes the compilation pipeline, the role of each module
 and the language features currently supported. Recent updates add basic
 support for floating-point types and operations, along with preliminary

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,13 @@
 # Development Roadmap
 
+See the [documentation index](index.md) for a list of all available pages.
+
+## Table of Contents
+
+- [Planned Compiler Phases](#planned-compiler-phases)
+- [Initial Language Features](#initial-language-features)
+- [Compatibility Goals](#compatibility-goals)
+
 This document outlines the planned phases of the `vc` compiler and the
 initial features targeted for early development. It also summarizes the
 compatibility goals for NetBSD and other supported systems.


### PR DESCRIPTION
## Summary
- expand docs index with descriptions
- link index from README and individual docs
- add small table of contents sections to documentation files

## Testing
- `tests/run.sh` *(fails: src/parser.c not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e10efb8fc8324a6aa2462039c183a