### PR TITLE
Document global symbol table helpers

### DIFF
--- a/include/symtable.h
+++ b/include/symtable.h
@@ -65,11 +65,11 @@ int symtable_add(symtable_t *table, const char *name, const char *ir_name,
 /* Parameters are stored as locals with an index */
 int symtable_add_param(symtable_t *table, const char *name, type_kind_t type,
                        size_t elem_size, int index, int is_restrict);
-/* Functions record return and parameter types */
+/* Add a function symbol with its return and parameter types */
 int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
                       type_kind_t *param_types, size_t param_count,
                       int is_prototype);
-/* Globals live in a separate list */
+/* Add a variable to the global list */
 int symtable_add_global(symtable_t *table, const char *name, const char *ir_name,
                         type_kind_t type, size_t array_size, size_t elem_size,
                         int is_static, int is_register, int is_const, int is_volatile,
@@ -97,6 +97,7 @@ symbol_t *symtable_lookup_struct(symtable_t *table, const char *tag);
 
 /* Look up a symbol by name. Returns NULL if not found. */
 symbol_t *symtable_lookup(symtable_t *table, const char *name);
+/* Search only the global list for a name */
 symbol_t *symtable_lookup_global(symtable_t *table, const char *name);
 
 #endif /* VC_SYMTABLE_H */

--- a/src/symtable_globals.c
+++ b/src/symtable_globals.c
@@ -1,9 +1,19 @@
+/*
+ * Global symbol table utilities.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 #include "symtable.h"
 #include "util.h"
 
-/* Insert a global variable into the table. */
+/*
+ * Add a variable to the global list.
+ * Returns non-zero on success and fails if the name already exists.
+ */
 int symtable_add_global(symtable_t *table, const char *name, const char *ir_name,
                         type_kind_t type, size_t array_size, size_t elem_size,
                         int is_static, int is_register, int is_const, int is_volatile,
@@ -30,7 +40,8 @@ int symtable_add_global(symtable_t *table, const char *name, const char *ir_name
 }
 
 /*
- * Insert a function symbol along with its return type and parameter types.
+ * Add a function symbol along with its return type and parameter types.
+ * `is_prototype` marks declarations without a body.
  */
 int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
                       type_kind_t *param_types, size_t param_count,
@@ -60,7 +71,7 @@ int symtable_add_func(symtable_t *table, const char *name, type_kind_t ret_type,
     return 1;
 }
 
-/* Look up a name only in the global list. */
+/* Look up a symbol only in the global list. */
 symbol_t *symtable_lookup_global(symtable_t *table, const char *name)
 {
     for (symbol_t *sym = table->globals; sym; sym = sym->next) {


### PR DESCRIPTION
## Summary
- add BSD-2 header for `symtable_globals.c`
- document `symtable_add_global`, `symtable_add_func`, and `symtable_lookup_global`
- document related prototypes in `symtable.h`

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e1d483c908324965dfa7e9ad81293