### PR TITLE
Improve register allocator comments

### DIFF
--- a/src/regalloc.c
+++ b/src/regalloc.c
@@ -19,8 +19,15 @@
 #define NUM_ALLOC_REGS (REGALLOC_NUM_REGS - 1)
 
 /*
- * Record the index of the final instruction that references each value.
- * Returns an array indexed by value id or NULL on allocation failure.
+ * Compute the "last use" position for every value in the IR.
+ *
+ * The instruction list is scanned exactly once.  Whenever a value is
+ * seen as a source operand we record the index of the current
+ * instruction.  By the end of the scan each entry holds the index of
+ * the final instruction that references that value (or -1 if the value
+ * is never used).  The resulting array is indexed by value id and
+ * should be freed by the caller.  NULL is returned on allocation
+ * failure.
  */
 static int *compute_last_use(ir_builder_t *ir, int max_id)
 {

--- a/src/regalloc_x86.c
+++ b/src/regalloc_x86.c
@@ -22,7 +22,15 @@ static const char *phys_regs_64[REGALLOC_NUM_REGS] = {
     "%rax", "%rbx", "%rcx", "%rdx", "%rsi", "%rdi"
 };
 
-/* Translate an allocator register index to a physical register name. */
+/*
+ * Translate an allocator register index into the textual name of the
+ * underlying CPU register.
+ *
+ * The allocator itself works only with small integer indices.  This
+ * function maps those indices to the appropriate register name using
+ * either the 32-bit or 64-bit table above.  Out-of-range indices fall
+ * back to the first register of the selected table.
+ */
 const char *regalloc_reg_name(int idx)
 {
     const char **regs = use_x86_64 ? phys_regs_64 : phys_regs_32;


### PR DESCRIPTION
## Summary
- document last use computation in the allocator
- clarify register index to name mapping on x86

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e27010e80832492228ac664d38cf1