### PR TITLE
Improve preprocessor docs and comments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ provides an overview of all available documentation.
   tests.
 - [Compilation pipeline](pipeline.md) – detailed description of each stage of
   compilation.
+- [Preprocessor workflow](preprocessor.md) – how macros and directives are
+  handled before lexing.
 - [Supported language features](language_features.md) – syntax and semantics
   currently implemented.
 - [Command-line usage](command_line.md) – available options and example

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -41,8 +41,11 @@ The modules described below implement these steps.
 ## Modules
 
 ### preprocessor
-Expands `#include` directives and simple object-like `#define` macros before lexing.
-Basic conditional directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else` and `#endif`) are supported using simple expression evaluation with the `defined` operator.
+Expands `#include` directives and simple object-like `#define` macros before
+lexing.  Basic conditional directives (`#if`, `#ifdef`, `#ifndef`, `#elif`,
+`#else` and `#endif`) are supported using simple expression evaluation with the
+`defined` operator.  See [preprocessor workflow](preprocessor.md) for a more
+detailed description.
 
 ### lexer
 Translates raw characters into tokens for the parser.

--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -1,0 +1,38 @@
+# Preprocessor Workflow
+
+The preprocessor is the first stage of the compilation pipeline.  It reads
+source files, expands macros and resolves conditional blocks before any tokens
+are produced.  `preproc_run` in `src/preproc_file.c` drives this process.
+
+## File processing
+
+`preproc_run` builds a list of include search paths then calls `process_file` to
+read the initial source.  Each line is inspected in order and any recognised
+preprocessor directive is handled immediately:
+
+- `#include` resolves the requested path and recursively invokes `process_file`
+  on the included file when the current conditional state is active.
+- `#define` adds a new macro definition.  Parameterised forms are supported and
+  stored in a `macro_t` structure.
+- `#undef` removes existing definitions.
+- Conditional directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else` and
+  `#endif`) manipulate a stack of state objects so nested conditions may be
+  evaluated correctly.
+- `#pragma` lines are passed through verbatim when active.
+- Any other line has macros expanded and is appended to the output buffer.
+
+At the end of processing the combined text is returned to the compiler and fed
+into the lexer.
+
+## Macro handling
+
+Macros are stored in a simple vector declared in `preproc_macros.h`.  Each
+`macro_t` holds the macro name, an optional parameter list and its body text.
+`expand_line` walks each line character by character replacing identifiers with
+matching macros.  When a macro takes parameters the argument list is parsed and
+substituted using `expand_params` which implements the `#` and `##` operators.
+Macro expansion is recursive so macro bodies may reference other macros.
+
+Conditional expressions in `#if` directives are parsed by the small recursive
+descent parser in `preproc_expr.c`.  The `defined` operator queries the current
+macro table so feature tests work as expected.

--- a/include/preproc_expr.h
+++ b/include/preproc_expr.h
@@ -1,6 +1,10 @@
 /*
  * Expression evaluation used by the preprocessor.
  *
+ * Provides `eval_expr` which parses and evaluates the limited boolean
+ * expressions permitted in conditional directives.  Evaluation uses the
+ * currently defined macros to resolve the `defined` operator.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -1,6 +1,12 @@
 /*
  * File processing entry points for the preprocessor.
  *
+ * The preprocessor reads a source file, handles directives such as
+ * `#include`, `#define`, `#ifdef` and friends and returns the expanded
+ * text.  Included files are processed recursively using the caller
+ * provided search paths.  Macro definitions are collected into a simple
+ * vector and expanded on demand.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */

--- a/include/preproc_macros.h
+++ b/include/preproc_macros.h
@@ -1,6 +1,10 @@
 /*
  * Macro handling for the preprocessor.
  *
+ * Defines the `macro_t` structure and helper routines used to store,
+ * expand and query macros.  Expansion occurs line by line and is
+ * recursive so macro bodies may themselves contain macro invocations.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */

--- a/src/preproc_expr.c
+++ b/src/preproc_expr.c
@@ -1,5 +1,11 @@
 /*
- * Expression parsing for conditional directives.
+ * Tiny expression parser used by the preprocessor.
+ *
+ * This module implements a very small recursive descent parser for the
+ * arithmetic used in `#if` and related directives.  The grammar supports the
+ * `defined` operator, integer constants and the logical `!`, `&&` and `||`
+ * operators.  Expressions are evaluated to an integer result used to control
+ * conditional blocks during preprocessing.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -6,7 +6,9 @@
  * processing.  It works with the helpers in `preproc_macros.c`
  * and `preproc_expr.c` to expand macros and evaluate conditional
  * expressions, forming a small stand-alone preprocessor used by
- * the compiler.
+ * the compiler.  The core routine `process_file` reads input one
+ * line at a time, handles `#include`, `#define`, conditional blocks
+ * and macro expansion, and writes the final text to a buffer.
  *
  * Part of vc under the BSD 2-Clause Simplified License.
  * See LICENSE for details.

--- a/src/preproc_macros.c
+++ b/src/preproc_macros.c
@@ -2,6 +2,11 @@
 /*
  * Macro table management and expansion logic.
  *
+ * This module stores macro definitions and performs textual replacement
+ * during preprocessing.  Macros may be object-like or take parameters,
+ * supporting the `#` stringize and `##` token pasting operators.  Macro
+ * bodies are expanded recursively so definitions can reference other macros.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */


### PR DESCRIPTION
## Summary
- document how preprocessing works and add new page
- add reference to preprocessor workflow doc
- expand module headers and comments for the preprocessor implementation

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e28d904a8832480982689b47edc84