### PR TITLE
Improve IR builder documentation

### DIFF
--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -88,54 +88,106 @@ typedef struct {
     int next_value_id;
 } ir_builder_t;
 
+/*
+ * Reset the builder and clear any previously emitted instructions. The
+ * next value id generated will start at 1.
+ */
 void ir_builder_init(ir_builder_t *b);
+
+/* Release all memory owned by the builder, including instruction nodes. */
 void ir_builder_free(ir_builder_t *b);
 
+/* Emit IR_CONST for `value` and return the resulting value id. */
 ir_value_t ir_build_const(ir_builder_t *b, long long value);
+
+/* Emit IR_LOAD of variable `name`. */
 ir_value_t ir_build_load(ir_builder_t *b, const char *name);
+
+/* Emit a volatile IR_LOAD of variable `name`. */
 ir_value_t ir_build_load_vol(ir_builder_t *b, const char *name);
 
+/* Emit the binary operation `op` with operands `left` and `right`. */
 ir_value_t ir_build_binop(ir_builder_t *b, ir_op_t op, ir_value_t left,
                           ir_value_t right);
+
+/* Emit IR_LOGAND using `left` and `right`. */
 ir_value_t ir_build_logand(ir_builder_t *b, ir_value_t left, ir_value_t right);
+
+/* Emit IR_LOGOR using `left` and `right`. */
 ir_value_t ir_build_logor(ir_builder_t *b, ir_value_t left, ir_value_t right);
 
+/* Emit IR_STORE of `val` into variable `name`. */
 void ir_build_store(ir_builder_t *b, const char *name, ir_value_t val);
+
+/* Emit a volatile IR_STORE of `val` into variable `name`. */
 void ir_build_store_vol(ir_builder_t *b, const char *name, ir_value_t val);
 
+/* Load function parameter `index` via IR_LOAD_PARAM. */
 ir_value_t ir_build_load_param(ir_builder_t *b, int index);
+
+/* Store `val` into parameter slot `index` using IR_STORE_PARAM. */
 void ir_build_store_param(ir_builder_t *b, int index, ir_value_t val);
 
+/* Obtain the address of variable `name` via IR_ADDR. */
 ir_value_t ir_build_addr(ir_builder_t *b, const char *name);
+
+/* Emit IR_LOAD_PTR from pointer `addr`. */
 ir_value_t ir_build_load_ptr(ir_builder_t *b, ir_value_t addr);
+
+/* Emit IR_STORE_PTR writing `val` to pointer `addr`. */
 void ir_build_store_ptr(ir_builder_t *b, ir_value_t addr, ir_value_t val);
 
+/* Emit IR_PTR_ADD adding `idx` (scaled by `elem_size`) to `ptr`. */
 ir_value_t ir_build_ptr_add(ir_builder_t *b, ir_value_t ptr, ir_value_t idx,
                             int elem_size);
+
+/* Emit IR_PTR_DIFF computing `a - bptr` in elements of size `elem_size`. */
 ir_value_t ir_build_ptr_diff(ir_builder_t *b, ir_value_t a, ir_value_t bptr,
                              int elem_size);
 
+/* Load element `name[idx]` using IR_LOAD_IDX. */
 ir_value_t ir_build_load_idx(ir_builder_t *b, const char *name, ir_value_t idx);
+
+/* Volatile version of IR_LOAD_IDX. */
 ir_value_t ir_build_load_idx_vol(ir_builder_t *b, const char *name,
                                  ir_value_t idx);
+
+/* Store `val` into `name[idx]` using IR_STORE_IDX. */
 void ir_build_store_idx(ir_builder_t *b, const char *name, ir_value_t idx,
                         ir_value_t val);
+
+/* Volatile version of IR_STORE_IDX. */
 void ir_build_store_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx,
                             ir_value_t val);
 
+/* Emit IR_ALLOCA reserving `size` bytes on the stack. */
 ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size);
 
+/* Emit IR_RETURN of `val`. */
 void ir_build_return(ir_builder_t *b, ir_value_t val);
+
+/* Push `val` as an argument via IR_ARG. */
 void ir_build_arg(ir_builder_t *b, ir_value_t val);
+
+/* Emit IR_CALL to `name` expecting `arg_count` previously pushed args. */
 ir_value_t ir_build_call(ir_builder_t *b, const char *name, size_t arg_count);
 
+/* Mark the start of a function with IR_FUNC_BEGIN. */
 void ir_build_func_begin(ir_builder_t *b, const char *name);
+
+/* Mark the end of the current function with IR_FUNC_END. */
 void ir_build_func_end(ir_builder_t *b);
 
+/* Emit IR_BR jumping to `label`. */
 void ir_build_br(ir_builder_t *b, const char *label);
+
+/* Emit IR_BCOND using `cond` to branch to `label`. */
 void ir_build_bcond(ir_builder_t *b, ir_value_t cond, const char *label);
+
+/* Emit IR_LABEL marking the current position as `label`. */
 void ir_build_label(ir_builder_t *b, const char *label);
 
+/* Define a global string literal and return its value id (IR_GLOB_STRING). */
 ir_value_t ir_build_string(ir_builder_t *b, const char *data);
 
 #endif /* VC_IR_CORE_H */

--- a/include/ir_dump.h
+++ b/include/ir_dump.h
@@ -11,11 +11,14 @@
 #include "ir_core.h"
 
 /*
- * Generate a human readable string for the IR. Each instruction is
- * printed on a separate line starting with the opcode name followed by
- * the fields "dest", "src1", "src2", "imm", "name" and "data".  For
- * IR_GLOB_ARRAY the count is printed instead of the generic fields.
- * Caller must free the returned buffer.
+ * Generate a human readable string for the IR.
+ *
+ * Each instruction is printed on a separate line beginning with the
+ * opcode name followed by the common fields "dest", "src1", "src2",
+ * "imm", "name" and "data". For IR_GLOB_ARRAY the element count is
+ * listed instead. Values that were spilled by the register allocator
+ * are annotated with their stack slot.  Caller must free the returned
+ * buffer.
  */
 char *ir_to_string(ir_builder_t *b);
 

--- a/include/ir_global.h
+++ b/include/ir_global.h
@@ -10,13 +10,24 @@
 
 #include "ir_core.h"
 
+/* Emit IR_GLOB_VAR to define `name` with optional initial `value`. */
 void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
                        int is_static);
+
+/*
+ * Emit IR_GLOB_ARRAY defining `name` with `count` initial values. The
+ * values are copied into the instruction and `is_static` controls
+ * linkage.
+ */
 void ir_build_glob_array(ir_builder_t *b, const char *name,
                          const long long *values, size_t count,
                          int is_static);
+
+/* Begin a global union using IR_GLOB_UNION. `size` specifies the type size. */
 void ir_build_glob_union(ir_builder_t *b, const char *name, int size,
                          int is_static);
+
+/* Begin a global struct using IR_GLOB_STRUCT with the given size. */
 void ir_build_glob_struct(ir_builder_t *b, const char *name, int size,
                           int is_static);
 

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -1,6 +1,11 @@
 /*
  * Intermediate representation builder.
  *
+ * The routines in this file append instructions to an ir_builder_t and
+ * generate value identifiers used as operands.  Each helper corresponds
+ * to a single IR opcode and may allocate strings or other data owned by
+ * the builder.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */

--- a/src/ir_dump.c
+++ b/src/ir_dump.c
@@ -1,6 +1,10 @@
 /*
  * Utilities for printing IR for debugging.
  *
+ * The dump helpers walk the instruction list and produce a textual
+ * representation.  Register allocation is run to annotate spilled
+ * values with their stack slots.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */

--- a/src/ir_global.c
+++ b/src/ir_global.c
@@ -1,6 +1,10 @@
 /*
  * Global variable and structure IR builders.
  *
+ * These helpers emit IR directives that describe global data such as
+ * variables, arrays and aggregates.  The emitted instructions are
+ * appended to an ir_builder_t and later consumed by the code generator.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */


### PR DESCRIPTION
## Summary
- expand file header comments for IR modules
- document every IR builder function in `ir_core.h`
- clarify global builder and dump helper comments

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e29b461b48324b747ce0e1cb5e143