### PR TITLE
Improve codegen comments

### DIFF
--- a/include/codegen.h
+++ b/include/codegen.h
@@ -1,6 +1,11 @@
 /*
  * Interfaces for generating assembly from IR.
  *
+ * The public code generation API converts the intermediate representation
+ * into x86 assembly.  Each routine accepts a flag selecting 32- or
+ * 64-bit output so that the caller may target either variant of the
+ * architecture.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
@@ -14,23 +19,29 @@
 /*
  * Emit the full x86 assembly for `ir` to `out`.
  *
- * The function first outputs any IR global directives under a `.data`
- * section. The instruction stream is then translated to x86 using the
- * register allocator and written after an optional `.text` directive.
- * Pass a non-zero `x86_64` to produce 64-bit instructions.
+ * Global directives such as string literals are written first under a
+ * `.data` section.  The instruction stream is then lowered via the
+ * register allocator and printed after an optional `.text` header.
+ * Passing a non-zero `x86_64` enables 64-bit register names and pointer
+ * sizes.
  */
 void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x86_64);
 
 /*
  * Convert the IR to an assembly string.
  *
- * Only the instruction stream is returned. Global data directives are
- * omitted. The caller owns the returned buffer and must free it. Use
- * `x86_64` to choose between 32- and 64-bit code generation.
+ * Only the instruction stream is returned; global data is omitted.  The
+ * caller owns the returned buffer and must free it.  The `x86_64` flag
+ * selects whether 32- or 64-bit mnemonics are produced.
  */
 char *codegen_ir_to_string(ir_builder_t *ir, int x86_64);
 
-/* Set whether function symbols should be exported */
+/*
+ * Set whether function symbols should be exported.
+ *
+ * When enabled, the generated assembly marks each function with `.globl`
+ * so that it is visible to the linker.
+ */
 void codegen_set_export(int flag);
 
 #endif /* VC_CODEGEN_H */

--- a/include/codegen_arith.h
+++ b/include/codegen_arith.h
@@ -1,6 +1,10 @@
 /*
  * Arithmetic instruction emission helpers.
  *
+ * These functions translate IR arithmetic opcodes using register
+ * allocation results.  An `x64` flag selects 32- or 64-bit instruction
+ * variants.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
@@ -12,6 +16,12 @@
 #include "ir_core.h"
 #include "regalloc.h"
 
+/*
+ * Emit assembly for an arithmetic instruction.
+ *
+ * `ra` provides operand locations and `x64` selects between 32- and
+ * 64-bit instruction encodings.
+ */
 void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
                       regalloc_t *ra, int x64);
 

--- a/include/codegen_branch.h
+++ b/include/codegen_branch.h
@@ -1,6 +1,9 @@
 /*
  * Branch instruction emission helpers.
  *
+ * These functions generate prologue/epilogue code and lower branches and
+ * calls.  An `x64` argument determines the x86 variant that is emitted.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
@@ -12,6 +15,12 @@
 #include "ir_core.h"
 #include "regalloc.h"
 
+/*
+ * Emit assembly for branching and function control flow instructions.
+ *
+ * Uses `ra` for stack frame information and chooses between 32- and
+ * 64-bit encodings according to `x64`.
+ */
 void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
                        regalloc_t *ra, int x64);
 

--- a/include/codegen_mem.h
+++ b/include/codegen_mem.h
@@ -1,6 +1,10 @@
 /*
  * Memory instruction emission helpers.
  *
+ * These functions lower loads, stores and address computations using the
+ * register allocation results.  The `x64` flag selects 32- or 64-bit
+ * addressing modes.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
@@ -12,6 +16,12 @@
 #include "ir_core.h"
 #include "regalloc.h"
 
+/*
+ * Emit assembly for a memory-related instruction.
+ *
+ * Operands are looked up in `ra` and the `x64` parameter controls the
+ * pointer size used in addressing modes.
+ */
 void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
                        regalloc_t *ra, int x64);
 

--- a/src/codegen_arith.c
+++ b/src/codegen_arith.c
@@ -1,6 +1,11 @@
 /*
  * Emitters for arithmetic IR instructions.
  *
+ * Functions in this file translate high level arithmetic operations to
+ * x86 assembly after register allocation.  Helpers choose the correct
+ * register names and instruction suffixes depending on whether the
+ * 32-bit or 64-bit backend is requested via the `x64` flag.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
@@ -284,7 +289,14 @@ static void emit_logor(strbuf_t *sb, ir_instr_t *ins,
     strbuf_appendf(sb, "%s:\n", end);
 }
 
-/* Top-level dispatcher for arithmetic instructions. */
+/*
+ * Top-level dispatcher for arithmetic instructions.
+ *
+ * `ra` contains the locations assigned by the register allocator and is
+ * used to decide whether a result must be written back to memory.  The
+ * `x64` flag selects between 32- and 64-bit instruction forms and register
+ * names.
+ */
 void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
                       regalloc_t *ra, int x64)
 {

--- a/src/codegen_branch.c
+++ b/src/codegen_branch.c
@@ -1,6 +1,11 @@
 /*
  * Emitters for branch and control-flow IR instructions.
  *
+ * This module handles function prologues/epilogues, calls and jumps.  The
+ * generated code uses the stack layout computed by the register allocator
+ * and adapts instruction suffixes and frame sizes for 32- or 64-bit mode
+ * based on the `x64` argument passed to the emitters.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
@@ -26,7 +31,15 @@ static const char *loc_str(char buf[32], regalloc_t *ra, int id, int x64)
     return buf;
 }
 
-/* Emit jumps, calls and other branch instructions. */
+/*
+ * Emit jumps, calls and other branch instructions.
+ *
+ * The register allocator provides operand locations and frame size.  This
+ * function uses that information to generate correct prologue/epilogue
+ * code and to lower control-flow opcodes.  Instruction variants differ
+ * between 32- and 64-bit mode; the `x64` flag selects the proper suffixes
+ * and stack pointer registers.
+ */
 void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
                        regalloc_t *ra, int x64)
 {

--- a/src/codegen_mem.c
+++ b/src/codegen_mem.c
@@ -1,6 +1,12 @@
 /*
  * Emitters for memory-related IR instructions.
  *
+ * Operations such as loads, stores and address calculations are lowered
+ * here after registers have been assigned.  Spilled values are written to
+ * or read from the stack as dictated by the register allocator.  The
+ * `x64` flag chooses between 32- and 64-bit addressing modes and register
+ * names.
+ *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
@@ -26,7 +32,14 @@ static const char *loc_str(char buf[32], regalloc_t *ra, int id, int x64)
     return buf;
 }
 
-/* Emit x86 for load/store and other memory instructions. */
+/*
+ * Emit x86 for load/store and other memory instructions.
+ *
+ * Operand locations are taken from the register allocator.  If the
+ * destination is spilled, a temporary register is used and the value is
+ * stored back to the stack.  The `x64` flag determines pointer size and
+ * register names so that either 32- or 64-bit code can be produced.
+ */
 void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
                        regalloc_t *ra, int x64)
 {


### PR DESCRIPTION
## Summary
- document how IR instructions become x86 assembly
- explain 32- vs 64-bit code generation in file and function comments

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e2ae0c18c832488885899f3b76c9c