### PR TITLE
Improve register allocator documentation

### DIFF
--- a/include/regalloc_x86.h
+++ b/include/regalloc_x86.h
@@ -1,10 +1,11 @@
 /*
  * x86 register name helpers.
  *
- * These routines translate allocator register indices to the
- * textual names required by the assembler. The same allocator
- * implementation works for both 32- and 64-bit code generation;
- * `regalloc_set_x86_64` selects the appropriate naming.
+ * The register allocator itself only deals with small integer indices.
+ * This header provides helpers that map those indices to textual
+ * register names understood by the assembler.  Two tables are kept for
+ * 32- and 64-bit code generation and `regalloc_set_x86_64` selects the
+ * active one.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
@@ -19,12 +20,16 @@
  * Register indices returned by the allocator range from
  * 0 to REGALLOC_NUM_REGS-1.
  */
-#define REGALLOC_NUM_REGS 6
+#define REGALLOC_NUM_REGS 6  /* size of the register pool used by regalloc */
 
-/* Return physical register name for given index */
+/*
+ * Return the textual CPU register name for the allocator index `idx`.
+ * Indices outside the valid range fall back to the first register of
+ * the selected table.
+ */
 const char *regalloc_reg_name(int idx);
 
-/* Select register naming for 64-bit or 32-bit mode. */
+/* Enable or disable 64-bit register naming. */
 void regalloc_set_x86_64(int enable);
 
 #endif /* VC_REGALLOC_X86_H */

--- a/src/regalloc.c
+++ b/src/regalloc.c
@@ -1,10 +1,17 @@
 /*
  * Linear scan register allocator.
  *
- * Each IR value is mapped to one of a small set of registers or to a
- * stack slot when all registers are in use. The allocator performs a
- * single pass over the instruction stream and releases registers when
- * the last use of a value is reached.
+ * This allocator walks the IR once assigning every value either a
+ * register or a stack slot.  A small array of physical registers forms
+ * the free pool; when it is exhausted new values are "spilled" to the
+ * stack.  Lifetimes are tracked by computing the last instruction that
+ * references each value so that registers can be released as soon as a
+ * value is no longer needed.
+ *
+ * Each allocated location is stored in the `regalloc_t` structure where
+ * non-negative entries represent a physical register and negative values
+ * encode a stack slot number (\-n).  The table is later used by the code
+ * generator to decide whether to emit register or memory operands.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
@@ -21,13 +28,12 @@
 /*
  * Compute the "last use" position for every value in the IR.
  *
- * The instruction list is scanned exactly once.  Whenever a value is
- * seen as a source operand we record the index of the current
- * instruction.  By the end of the scan each entry holds the index of
- * the final instruction that references that value (or -1 if the value
- * is never used).  The resulting array is indexed by value id and
- * should be freed by the caller.  NULL is returned on allocation
- * failure.
+ * The instruction stream is scanned exactly once.  Whenever a value
+ * appears as a source operand the index of the current instruction is
+ * recorded.  At the end of the scan each entry holds the index of the
+ * final instruction that references the value (or -1 if the value is
+ * never used).  The resulting array is indexed by value id and should
+ * be freed by the caller.  NULL is returned on allocation failure.
  */
 static int *compute_last_use(ir_builder_t *ir, int max_id)
 {
@@ -50,11 +56,14 @@ static int *compute_last_use(ir_builder_t *ir, int max_id)
 /*
  * Populate `ra` with locations for every value defined in `ir`.
  *
- * The allocator walks the instruction list once. New values are
- * assigned a free register if one exists; otherwise a fresh stack
- * slot number is used. The `last` array records when each value is
- * seen for the final time so its register can be returned to the
- * free pool.
+ * The allocator performs a linear pass over the IR instructions.
+ * When a new value is defined a register is taken from the free
+ * pool if available; otherwise a new stack slot is allocated.  As
+ * soon as the current instruction index matches the pre-computed
+ * last-use index of a value its register is returned to the pool
+ * for reuse by later instructions.  This strategy ensures that
+ * register pressure remains low while avoiding complex live range
+ * analysis.
  */
 void regalloc_run(ir_builder_t *ir, regalloc_t *ra)
 {
@@ -105,7 +114,12 @@ void regalloc_run(ir_builder_t *ir, regalloc_t *ra)
     free(last);
 }
 
-/* Release any memory allocated during `regalloc_run`. */
+/*
+ * Release any memory allocated during `regalloc_run`.
+ *
+ * This simply frees the location table and resets the bookkeeping
+ * fields.  It does not alter the IR itself.
+ */
 void regalloc_free(regalloc_t *ra)
 {
     free(ra->loc);

--- a/src/regalloc_x86.c
+++ b/src/regalloc_x86.c
@@ -1,10 +1,10 @@
 /*
  * Register naming for x86 code generation.
  *
- * The register allocator deals only with abstract indices. This
- * module provides the textual names for those indices in either
- * 32- or 64-bit mode. `regalloc_set_x86_64` toggles between the
- * two tables below.
+ * The register allocator deals only with abstract indices.  This module
+ * translates those indices into the textual names expected by the
+ * assembler.  Separate lookup tables exist for 32-bit and 64-bit mode
+ * and `regalloc_set_x86_64` toggles between them.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
@@ -12,12 +12,15 @@
 
 #include "regalloc_x86.h"
 
+/* Current register naming mode: 0 for 32-bit, 1 for 64-bit. */
 static int use_x86_64 = 0;
 
+/* register names for 32-bit mode */
 static const char *phys_regs_32[REGALLOC_NUM_REGS] = {
     "%eax", "%ebx", "%ecx", "%edx", "%esi", "%edi"
 };
 
+/* register names for 64-bit mode */
 static const char *phys_regs_64[REGALLOC_NUM_REGS] = {
     "%rax", "%rbx", "%rcx", "%rdx", "%rsi", "%rdi"
 };
@@ -39,7 +42,10 @@ const char *regalloc_reg_name(int idx)
     return use_x86_64 ? "%rax" : "%eax";
 }
 
-/* Select between 32-bit and 64-bit register naming. */
+/*
+ * Select between 32-bit and 64-bit register naming.
+ * A non-zero argument enables 64-bit names.
+ */
 void regalloc_set_x86_64(int enable)
 {
     use_x86_64 = enable ? 1 : 0;


### PR DESCRIPTION
## Summary
- clarify how the linear scan allocator works
- document register mapping structures and helper APIs
- add comments on x86 register naming helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e2ae79be0832487add23544dc12a0