### PR TITLE
Improve CLI source documentation

### DIFF
--- a/include/cli.h
+++ b/include/cli.h
@@ -1,5 +1,8 @@
 /*
- * Command line option structures.
+ * Definitions for the vc command line interface.
+ *
+ * This header declares the cli_options_t structure used by
+ * the compiler and the function for parsing argv.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.

--- a/src/cli.c
+++ b/src/cli.c
@@ -1,5 +1,8 @@
 /*
- * Command line option parsing.
+ * Command line option parsing for the vc compiler.
+ *
+ * This module translates argv into a cli_options_t structure
+ * that drives later compilation stages.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.

--- a/src/main.c
+++ b/src/main.c
@@ -2,7 +2,8 @@
 /*
  * Entry point of the vc compiler.
  *
- * This file drives the entire compilation pipeline:
+ * This module orchestrates command line parsing and drives the
+ * entire compilation pipeline:
  *  1. Source code is tokenized by the lexer.
  *  2. The parser builds an AST from those tokens.
  *  3. Semantic analysis creates an intermediate representation (IR).
@@ -324,6 +325,11 @@ static int create_startup_object(int use_x86_64, char **out_path)
     return 1;
 }
 
+/*
+ * Program entry point. Parses command line options and drives the
+ * compilation stages for each input file. Handles linking when the
+ * --link option is used.
+ */
 int main(int argc, char **argv)
 {
     cli_options_t cli;


### PR DESCRIPTION
## Summary
- expand file headers for `cli.c`, `main.c`, and `cli.h`
- document the `main` entry function

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e2aee80008324866be1c885253e96