### PR TITLE
Refactor cli_parse_args using helpers

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -43,6 +43,127 @@ static void print_usage(const char *prog)
 }
 
 /*
+ * Initialise "opts" with default settings.  Vectors are prepared for use
+ * and all flags are reset to their default state.
+ */
+static void init_default_opts(cli_options_t *opts)
+{
+    if (!opts)
+        return;
+
+    opts->output = NULL;
+    opts->opt_cfg.opt_level = 1;
+    opts->opt_cfg.fold_constants = 1;
+    opts->opt_cfg.dead_code = 1;
+    opts->opt_cfg.const_prop = 1;
+    opts->use_x86_64 = 0;
+    opts->compile = 0;
+    opts->link = 0;
+    opts->dump_asm = 0;
+    opts->dump_ir = 0;
+    opts->preprocess = 0;
+    opts->std = STD_C99;
+    vector_init(&opts->include_dirs, sizeof(char *));
+    vector_init(&opts->sources, sizeof(char *));
+}
+
+/*
+ * Append a source file path to "opts->sources".  Returns 0 on success and
+ * 1 on out-of-memory failure.
+ */
+static int push_source(cli_options_t *opts, const char *src)
+{
+    if (!vector_push(&opts->sources, &src)) {
+        fprintf(stderr, "Out of memory\n");
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * Handle a single getopt option.  "opt" is the value returned by
+ * getopt_long(), "arg" is the option argument if any and "prog" is used for
+ * help output.  Returns 0 on success and 1 on error.  The function may exit
+ * the process for -h/--help and -v/--version.
+ */
+static int handle_option(int opt, const char *arg, const char *prog,
+                         cli_options_t *opts)
+{
+    switch (opt) {
+    case 'h':
+        print_usage(prog);
+        exit(0);
+    case 'v':
+        printf("vc version %s\n", VERSION);
+        exit(0);
+    case 'o':
+        opts->output = (char *)arg;
+        break;
+    case 'c':
+        opts->compile = 1;
+        break;
+    case 'I':
+        if (!vector_push(&opts->include_dirs, &arg)) {
+            fprintf(stderr, "Out of memory\n");
+            return 1;
+        }
+        break;
+    case 'O':
+        opts->opt_cfg.opt_level = atoi(arg);
+        if (opts->opt_cfg.opt_level <= 0) {
+            opts->opt_cfg.fold_constants = 0;
+            opts->opt_cfg.dead_code = 0;
+            opts->opt_cfg.const_prop = 0;
+        } else {
+            opts->opt_cfg.fold_constants = 1;
+            opts->opt_cfg.dead_code = 1;
+            opts->opt_cfg.const_prop = 1;
+        }
+        break;
+    case 1:
+        opts->opt_cfg.fold_constants = 0;
+        break;
+    case 2:
+        opts->opt_cfg.dead_code = 0;
+        break;
+    case 3:
+        opts->use_x86_64 = 1;
+        break;
+    case 'S':
+    case 4:
+        opts->dump_asm = 1;
+        break;
+    case 5:
+        opts->opt_cfg.const_prop = 0;
+        break;
+    case 6:
+        opts->dump_ir = 1;
+        break;
+    case 'E':
+        opts->preprocess = 1;
+        break;
+    case 7:
+        opts->link = 1;
+        break;
+    case 8:
+        if (strcmp(arg, "c99") == 0)
+            opts->std = STD_C99;
+        else if (strcmp(arg, "gnu99") == 0)
+            opts->std = STD_GNU99;
+        else {
+            fprintf(stderr, "Unknown standard '%s'\n", arg);
+            return 1;
+        }
+        break;
+    default:
+        print_usage(prog);
+        return 1;
+    }
+
+    return 0;
+}
+
+/*
  * Parse argv using getopt_long and fill the cli_options_t structure
  * with the selected settings. The long_opts table defines the
  * mapping between short (-o) and long (--output) options. Default
@@ -69,95 +190,12 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {0, 0, 0, 0}
     };
 
-    opts->output = NULL;
-    opts->opt_cfg.opt_level = 1;
-    opts->opt_cfg.fold_constants = 1;
-    opts->opt_cfg.dead_code = 1;
-    opts->opt_cfg.const_prop = 1;
-    opts->use_x86_64 = 0;
-    opts->compile = 0;
-    opts->link = 0;
-    opts->dump_asm = 0;
-    opts->dump_ir = 0;
-    opts->preprocess = 0;
-    opts->std = STD_C99;
-    vector_init(&opts->include_dirs, sizeof(char *));
-    vector_init(&opts->sources, sizeof(char *));
+    init_default_opts(opts);
 
     int opt;
     while ((opt = getopt_long(argc, argv, "hvo:O:cEI:S", long_opts, NULL)) != -1) {
-        switch (opt) {
-        case 'h':
-            print_usage(argv[0]);
-            exit(0);
-        case 'v':
-            printf("vc version %s\n", VERSION);
-            exit(0);
-        case 'o':
-            opts->output = optarg;
-            break;
-        case 'c':
-            opts->compile = 1;
-            break;
-        case 'I':
-            if (!vector_push(&opts->include_dirs, &optarg)) {
-                fprintf(stderr, "Out of memory\n");
-                return 1;
-            }
-            break;
-        case 'O':
-            opts->opt_cfg.opt_level = atoi(optarg);
-            if (opts->opt_cfg.opt_level <= 0) {
-                opts->opt_cfg.fold_constants = 0;
-                opts->opt_cfg.dead_code = 0;
-                opts->opt_cfg.const_prop = 0;
-            } else {
-                opts->opt_cfg.fold_constants = 1;
-                opts->opt_cfg.dead_code = 1;
-                opts->opt_cfg.const_prop = 1;
-            }
-            break;
-        case 1:
-            opts->opt_cfg.fold_constants = 0;
-            break;
-        case 2:
-            opts->opt_cfg.dead_code = 0;
-            break;
-        case 3:
-            opts->use_x86_64 = 1;
-            break;
-        case 'S':
-            opts->dump_asm = 1;
-            break;
-        case 4:
-            opts->dump_asm = 1;
-            break;
-        case 5:
-            opts->opt_cfg.const_prop = 0;
-            break;
-        case 6:
-            opts->dump_ir = 1;
-            break;
-        case 'E':
-            opts->preprocess = 1;
-            break;
-        case 7:
-            opts->link = 1;
-            break;
-        case 8:
-            if (strcmp(optarg, "c99") == 0)
-                opts->std = STD_C99;
-            else if (strcmp(optarg, "gnu99") == 0)
-                opts->std = STD_GNU99;
-            else {
-                fprintf(stderr, "Unknown standard '%s'\n", optarg);
-                return 1;
-            }
-            break;
-        default:
-            print_usage(argv[0]);
+        if (handle_option(opt, optarg, argv[0], opts))
             return 1;
-        }
     }
 
     if (optind >= argc) {
@@ -173,10 +211,8 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
     }
 
     for (int i = optind; i < argc; i++) {
-        if (!vector_push(&opts->sources, &argv[i])) {
-            fprintf(stderr, "Out of memory\n");
+        if (push_source(opts, argv[i]))
             return 1;
-        }
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- break out cli_parse_args logic into smaller helpers
- add helper functions to init defaults, process options and record sources
- update cli_parse_args to use helpers

## Testing
- `make -j$(nproc)`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e3cb255dc832491034cf152c777ac