### PR TITLE
Refactor ast_free_stmt into helper functions

### DIFF
--- a/src/ast_stmt.c
+++ b/src/ast_stmt.c
@@ -377,6 +377,131 @@ func_t *ast_make_func(const char *name, type_kind_t ret_type,
     fn->body_count = body_count;
     return fn;
 }
+
+/* Helpers for freeing individual statement types */
+static void free_expr_stmt(stmt_t *stmt)
+{
+    ast_free_expr(stmt->expr.expr);
+}
+
+static void free_return_stmt(stmt_t *stmt)
+{
+    ast_free_expr(stmt->ret.expr);
+}
+
+static void free_var_decl_stmt(stmt_t *stmt)
+{
+    free(stmt->var_decl.name);
+    ast_free_expr(stmt->var_decl.size_expr);
+    ast_free_expr(stmt->var_decl.init);
+    for (size_t i = 0; i < stmt->var_decl.init_count; i++) {
+        ast_free_expr(stmt->var_decl.init_list[i].index);
+        ast_free_expr(stmt->var_decl.init_list[i].value);
+        free(stmt->var_decl.init_list[i].field);
+    }
+    free(stmt->var_decl.init_list);
+    free(stmt->var_decl.tag);
+    for (size_t i = 0; i < stmt->var_decl.member_count; i++)
+        free(stmt->var_decl.members[i].name);
+    free(stmt->var_decl.members);
+}
+
+static void free_if_stmt(stmt_t *stmt)
+{
+    ast_free_expr(stmt->if_stmt.cond);
+    ast_free_stmt(stmt->if_stmt.then_branch);
+    ast_free_stmt(stmt->if_stmt.else_branch);
+}
+
+static void free_while_stmt(stmt_t *stmt)
+{
+    ast_free_expr(stmt->while_stmt.cond);
+    ast_free_stmt(stmt->while_stmt.body);
+}
+
+static void free_do_while_stmt(stmt_t *stmt)
+{
+    ast_free_expr(stmt->do_while_stmt.cond);
+    ast_free_stmt(stmt->do_while_stmt.body);
+}
+
+static void free_for_stmt(stmt_t *stmt)
+{
+    ast_free_stmt(stmt->for_stmt.init_decl);
+    ast_free_expr(stmt->for_stmt.init);
+    ast_free_expr(stmt->for_stmt.cond);
+    ast_free_expr(stmt->for_stmt.incr);
+    ast_free_stmt(stmt->for_stmt.body);
+}
+
+static void free_switch_stmt(stmt_t *stmt)
+{
+    ast_free_expr(stmt->switch_stmt.expr);
+    for (size_t i = 0; i < stmt->switch_stmt.case_count; i++) {
+        ast_free_expr(stmt->switch_stmt.cases[i].expr);
+        ast_free_stmt(stmt->switch_stmt.cases[i].body);
+    }
+    free(stmt->switch_stmt.cases);
+    ast_free_stmt(stmt->switch_stmt.default_body);
+}
+
+static void free_label_stmt(stmt_t *stmt)
+{
+    free(stmt->label.name);
+}
+
+static void free_goto_stmt(stmt_t *stmt)
+{
+    free(stmt->goto_stmt.name);
+}
+
+static void free_typedef_stmt(stmt_t *stmt)
+{
+    free(stmt->typedef_decl.name);
+}
+
+static void free_enum_decl_stmt(stmt_t *stmt)
+{
+    free(stmt->enum_decl.tag);
+    for (size_t i = 0; i < stmt->enum_decl.count; i++) {
+        free(stmt->enum_decl.items[i].name);
+        ast_free_expr(stmt->enum_decl.items[i].value);
+    }
+    free(stmt->enum_decl.items);
+}
+
+static void free_struct_decl_stmt(stmt_t *stmt)
+{
+    free(stmt->struct_decl.tag);
+    for (size_t i = 0; i < stmt->struct_decl.count; i++)
+        free(stmt->struct_decl.members[i].name);
+    free(stmt->struct_decl.members);
+}
+
+static void free_union_decl_stmt(stmt_t *stmt)
+{
+    free(stmt->union_decl.tag);
+    for (size_t i = 0; i < stmt->union_decl.count; i++)
+        free(stmt->union_decl.members[i].name);
+    free(stmt->union_decl.members);
+}
+
+static void free_block_stmt(stmt_t *stmt)
+{
+    for (size_t i = 0; i < stmt->block.count; i++)
+        ast_free_stmt(stmt->block.stmts[i]);
+    free(stmt->block.stmts);
+}
+
+static void free_break_stmt(stmt_t *stmt)
+{
+    (void)stmt;
+}
+
+static void free_continue_stmt(stmt_t *stmt)
+{
+    (void)stmt;
+}
 /* Free a statement node and all of its children. */
 void ast_free_stmt(stmt_t *stmt)
 {
@@ -384,91 +509,55 @@ void ast_free_stmt(stmt_t *stmt)
         return;
     switch (stmt->kind) {
     case STMT_EXPR:
-        ast_free_expr(stmt->expr.expr);
+        free_expr_stmt(stmt);
         break;
     case STMT_RETURN:
-        ast_free_expr(stmt->ret.expr);
+        free_return_stmt(stmt);
         break;
     case STMT_VAR_DECL:
-        free(stmt->var_decl.name);
-        ast_free_expr(stmt->var_decl.size_expr);
-        ast_free_expr(stmt->var_decl.init);
-        for (size_t i = 0; i < stmt->var_decl.init_count; i++) {
-            ast_free_expr(stmt->var_decl.init_list[i].index);
-            ast_free_expr(stmt->var_decl.init_list[i].value);
-            free(stmt->var_decl.init_list[i].field);
-        }
-        free(stmt->var_decl.init_list);
-        free(stmt->var_decl.tag);
-        for (size_t i = 0; i < stmt->var_decl.member_count; i++)
-            free(stmt->var_decl.members[i].name);
-        free(stmt->var_decl.members);
+        free_var_decl_stmt(stmt);
         break;
     case STMT_IF:
-        ast_free_expr(stmt->if_stmt.cond);
-        ast_free_stmt(stmt->if_stmt.then_branch);
-        ast_free_stmt(stmt->if_stmt.else_branch);
+        free_if_stmt(stmt);
         break;
     case STMT_WHILE:
-        ast_free_expr(stmt->while_stmt.cond);
-        ast_free_stmt(stmt->while_stmt.body);
+        free_while_stmt(stmt);
         break;
     case STMT_DO_WHILE:
-        ast_free_expr(stmt->do_while_stmt.cond);
-        ast_free_stmt(stmt->do_while_stmt.body);
+        free_do_while_stmt(stmt);
         break;
     case STMT_FOR:
-        ast_free_stmt(stmt->for_stmt.init_decl);
-        ast_free_expr(stmt->for_stmt.init);
-        ast_free_expr(stmt->for_stmt.cond);
-        ast_free_expr(stmt->for_stmt.incr);
-        ast_free_stmt(stmt->for_stmt.body);
+        free_for_stmt(stmt);
         break;
     case STMT_SWITCH:
-        ast_free_expr(stmt->switch_stmt.expr);
-        for (size_t i = 0; i < stmt->switch_stmt.case_count; i++) {
-            ast_free_expr(stmt->switch_stmt.cases[i].expr);
-            ast_free_stmt(stmt->switch_stmt.cases[i].body);
-        }
-        free(stmt->switch_stmt.cases);
-        ast_free_stmt(stmt->switch_stmt.default_body);
+        free_switch_stmt(stmt);
         break;
     case STMT_LABEL:
-        free(stmt->label.name);
+        free_label_stmt(stmt);
         break;
     case STMT_GOTO:
-        free(stmt->goto_stmt.name);
+        free_goto_stmt(stmt);
         break;
     case STMT_TYPEDEF:
-        free(stmt->typedef_decl.name);
+        free_typedef_stmt(stmt);
         break;
     case STMT_ENUM_DECL:
-        free(stmt->enum_decl.tag);
-        for (size_t i = 0; i < stmt->enum_decl.count; i++) {
-            free(stmt->enum_decl.items[i].name);
-            ast_free_expr(stmt->enum_decl.items[i].value);
-        }
-        free(stmt->enum_decl.items);
+        free_enum_decl_stmt(stmt);
         break;
     case STMT_STRUCT_DECL:
-        free(stmt->struct_decl.tag);
-        for (size_t i = 0; i < stmt->struct_decl.count; i++)
-            free(stmt->struct_decl.members[i].name);
-        free(stmt->struct_decl.members);
+        free_struct_decl_stmt(stmt);
         break;
     case STMT_UNION_DECL:
-        free(stmt->union_decl.tag);
-        for (size_t i = 0; i < stmt->union_decl.count; i++)
-            free(stmt->union_decl.members[i].name);
-        free(stmt->union_decl.members);
+        free_union_decl_stmt(stmt);
         break;
     case STMT_BREAK:
+        free_break_stmt(stmt);
+        break;
     case STMT_CONTINUE:
+        free_continue_stmt(stmt);
         break;
     case STMT_BLOCK:
-        for (size_t i = 0; i < stmt->block.count; i++)
-            ast_free_stmt(stmt->block.stmts[i]);
-        free(stmt->block.stmts);
+        free_block_stmt(stmt);
         break;
     }
     free(stmt);


### PR DESCRIPTION
## Summary
- break down `ast_free_stmt` cases into dedicated static functions
- delegate cleanup to these helpers for easier maintenance

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e3cdcb2988324bf4c3b1d55cd3ffc