### PR TITLE
Refactor toplevel parser helpers

### DIFF
--- a/src/parser_toplevel.c
+++ b/src/parser_toplevel.c
@@ -135,6 +135,169 @@ static int parse_typedef_decl(parser_t *p, size_t start_pos, stmt_t **out)
     return 1;
 }
 
+/* Parse the parameter list of a function and either record a prototype or
+ * parse a full definition.
+ *
+ * On entry the current token must be the '(' following the function name.
+ * spec_pos should reference the start of the declaration so the parser can
+ * rewind when invoking parser_parse_func for a definition.
+ * The parser position will end up just past the terminating ';' for
+ * prototypes or at the end of the function definition.  On failure the
+ * parser position is left unchanged. */
+static int parse_func_prototype(parser_t *p, symtable_t *funcs, const char *name,
+                                type_kind_t ret_type, size_t spec_pos,
+                                func_t **out_func)
+{
+    size_t start = p->pos; /* at '(' */
+    p->pos++; /* consume '(' */
+
+    vector_t param_types_v;
+    vector_init(&param_types_v, sizeof(type_kind_t));
+
+    if (!match(p, TOK_RPAREN)) {
+        do {
+            type_kind_t pt;
+            if (!parse_basic_type(p, &pt)) {
+                vector_free(&param_types_v);
+                p->pos = start;
+                return 0;
+            }
+            if (match(p, TOK_STAR)) {
+                pt = TYPE_PTR;
+                match(p, TOK_KW_RESTRICT);
+            }
+            token_t *tmp = peek(p);
+            if (tmp && tmp->type == TOK_IDENT)
+                p->pos++; /* optional name */
+            if (!vector_push(&param_types_v, &pt)) {
+                vector_free(&param_types_v);
+                p->pos = start;
+                return 0;
+            }
+        } while (match(p, TOK_COMMA));
+        if (!match(p, TOK_RPAREN)) {
+            vector_free(&param_types_v);
+            p->pos = start;
+            return 0;
+        }
+    }
+
+    token_t *after = peek(p);
+    if (after && after->type == TOK_SEMI) {
+        p->pos++; /* ';' */
+        symtable_add_func(funcs, name, ret_type,
+                         (type_kind_t *)param_types_v.data,
+                         param_types_v.count, 1);
+        vector_free(&param_types_v);
+        return 1;
+    } else if (after && after->type == TOK_LBRACE) {
+        vector_free(&param_types_v);
+        p->pos = spec_pos;
+        if (out_func)
+            *out_func = parser_parse_func(p);
+        return out_func ? *out_func != NULL : 0;
+    }
+
+    vector_free(&param_types_v);
+    p->pos = start;
+    return 0;
+}
+
+/* Parse a global variable after its name handling optional array sizes and
+ * initializer expressions.  The parser must start immediately after the
+ * identifier.  On success the parser is positioned after the terminating
+ * semicolon and the created declaration stored in out_global.  The function
+ * returns zero and restores the start position on syntax errors. */
+static int parse_global_var_init(parser_t *p, const char *name, type_kind_t type,
+                                 size_t elem_size, int is_static, int is_register,
+                                 int is_extern, int is_const, int is_volatile,
+                                 int is_restrict, size_t line, size_t column,
+                                 stmt_t **out_global)
+{
+    size_t start = p->pos;
+    size_t arr_size = 0;
+    expr_t *size_expr = NULL;
+
+    token_t *tok = peek(p);
+    if (tok && tok->type == TOK_LBRACKET) {
+        p->pos++; /* '[' */
+        if (match(p, TOK_RBRACKET)) {
+            type = TYPE_ARRAY;
+        } else {
+            size_expr = parser_parse_expr(p);
+            if (!size_expr || !match(p, TOK_RBRACKET)) {
+                ast_free_expr(size_expr);
+                p->pos = start;
+                return 0;
+            }
+            if (size_expr->kind == EXPR_NUMBER)
+                arr_size = strtoul(size_expr->number.value, NULL, 10);
+            type = TYPE_ARRAY;
+        }
+        tok = peek(p);
+    }
+
+    if (tok && tok->type == TOK_SEMI) {
+        if (type == TYPE_VOID) {
+            p->pos = start;
+            return 0;
+        }
+        p->pos++;
+        if (out_global)
+            *out_global = ast_make_var_decl(name, type, arr_size, size_expr,
+                                           elem_size, is_static, is_register,
+                                           is_extern, is_const, is_volatile,
+                                           is_restrict, NULL, NULL, 0,
+                                           NULL, NULL, 0,
+                                           line, column);
+        return 1;
+    }
+
+    if (tok && tok->type == TOK_ASSIGN) {
+        if (type == TYPE_VOID) {
+            p->pos = start;
+            return 0;
+        }
+        p->pos++; /* '=' */
+        expr_t *init = NULL;
+        init_entry_t *init_list = NULL;
+        size_t init_count = 0;
+        if (type == TYPE_ARRAY && peek(p) && peek(p)->type == TOK_LBRACE) {
+            init_list = parser_parse_init_list(p, &init_count);
+            if (!init_list || !match(p, TOK_SEMI)) {
+                if (init_list) {
+                    for (size_t i = 0; i < init_count; i++) {
+                        ast_free_expr(init_list[i].index);
+                        ast_free_expr(init_list[i].value);
+                        free(init_list[i].field);
+                    }
+                    free(init_list);
+                }
+                p->pos = start;
+                return 0;
+            }
+        } else {
+            init = parser_parse_expr(p);
+            if (!init || !match(p, TOK_SEMI)) {
+                ast_free_expr(init);
+                p->pos = start;
+                return 0;
+            }
+        }
+        if (out_global)
+            *out_global = ast_make_var_decl(name, type, arr_size, size_expr,
+                                           elem_size, is_static, is_register,
+                                           is_extern, is_const, is_volatile,
+                                           is_restrict, init, init_list,
+                                           init_count, NULL, NULL, 0,
+                                           line, column);
+        return 1;
+    }
+
+    p->pos = start;
+    return 0;
+}
+
 /* Helper to parse a function definition or variable declaration */
 static int parse_function_or_var(parser_t *p, symtable_t *funcs,
                                  int is_extern, int is_static, int is_register,
@@ -161,138 +324,15 @@ static int parse_function_or_var(parser_t *p, symtable_t *funcs,
     }
     p->pos++;
 
-    size_t arr_size = 0;
     token_t *next_tok = peek(p);
-    if (next_tok && next_tok->type == TOK_LPAREN) {
-        p->pos++; /* '(' */
-        vector_t param_types_v;
-        vector_init(&param_types_v, sizeof(type_kind_t));
-        if (!match(p, TOK_RPAREN)) {
-            do {
-                type_kind_t pt;
-                if (!parse_basic_type(p, &pt)) {
-                    vector_free(&param_types_v);
-                    p->pos = save;
-                    return 0;
-                }
-                if (match(p, TOK_STAR)) {
-                    pt = TYPE_PTR;
-                    match(p, TOK_KW_RESTRICT);
-                }
-                token_t *tmp = peek(p);
-                if (tmp && tmp->type == TOK_IDENT)
-                    p->pos++; /* optional name */
-                if (!vector_push(&param_types_v, &pt)) {
-                    vector_free(&param_types_v);
-                    p->pos = save;
-                    return 0;
-                }
-            } while (match(p, TOK_COMMA));
-            if (!match(p, TOK_RPAREN)) {
-                vector_free(&param_types_v);
-                p->pos = save;
-                return 0;
-            }
-        }
-        token_t *after = peek(p);
-        if (after && after->type == TOK_SEMI) {
-            p->pos++; /* ';' */
-            symtable_add_func(funcs, id->lexeme, t,
-                             (type_kind_t *)param_types_v.data,
-                             param_types_v.count, 1);
-            vector_free(&param_types_v);
-            return 1;
-        } else if (after && after->type == TOK_LBRACE) {
-            vector_free(&param_types_v);
-            p->pos = spec_pos;
-            if (out_func)
-                *out_func = parser_parse_func(p);
-            return out_func ? *out_func != NULL : 0;
-        } else {
-            vector_free(&param_types_v);
-            p->pos = save;
-            return 0;
-        }
-    }
+    if (next_tok && next_tok->type == TOK_LPAREN)
+        return parse_func_prototype(p, funcs, id->lexeme, t, spec_pos,
+                                    out_func);
 
-    expr_t *size_expr = NULL;
-    if (next_tok && next_tok->type == TOK_LBRACKET) {
-        p->pos++; /* '[' */
-        if (match(p, TOK_RBRACKET)) {
-            t = TYPE_ARRAY;
-        } else {
-            size_expr = parser_parse_expr(p);
-            if (!size_expr || !match(p, TOK_RBRACKET)) {
-                ast_free_expr(size_expr);
-                p->pos = save;
-                return 0;
-            }
-            if (size_expr->kind == EXPR_NUMBER)
-                arr_size = strtoul(size_expr->number.value, NULL, 10);
-            t = TYPE_ARRAY;
-        }
-        next_tok = peek(p);
-    }
-
-    if (next_tok && next_tok->type == TOK_SEMI) {
-        if (t == TYPE_VOID) {
-            p->pos = save;
-            return 0;
-        }
-        p->pos++; /* consume ';' */
-        if (out_global)
-            *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_register,
-                                           is_extern, is_const, is_volatile,
-                                           is_restrict, NULL, NULL, 0,
-                                           NULL, NULL, 0,
-                                           line, column);
-        return 1;
-    } else if (next_tok && next_tok->type == TOK_ASSIGN) {
-        if (t == TYPE_VOID) {
-            p->pos = save;
-            return 0;
-        }
-        p->pos++; /* consume '=' */
-        expr_t *init = NULL;
-        init_entry_t *init_list = NULL;
-        size_t init_count = 0;
-        if (t == TYPE_ARRAY && peek(p) && peek(p)->type == TOK_LBRACE) {
-            init_list = parser_parse_init_list(p, &init_count);
-            if (!init_list || !match(p, TOK_SEMI)) {
-                if (init_list) {
-                    for (size_t i = 0; i < init_count; i++) {
-                        ast_free_expr(init_list[i].index);
-                        ast_free_expr(init_list[i].value);
-                        free(init_list[i].field);
-                    }
-                    free(init_list);
-                }
-                p->pos = save;
-                return 0;
-            }
-        } else {
-            init = parser_parse_expr(p);
-            if (!init || !match(p, TOK_SEMI)) {
-                ast_free_expr(init);
-                p->pos = save;
-                return 0;
-            }
-        }
-        if (out_global)
-            *out_global = ast_make_var_decl(id->lexeme, t, arr_size, size_expr,
-                                           elem_size, is_static, is_register,
-                                           is_extern, is_const, is_volatile,
-                                           is_restrict, init, init_list,
-                                           init_count, NULL, NULL, 0,
-                                           line, column);
-        return 1;
-    }
-
-    p->pos = spec_pos;
-    if (out_func)
-        *out_func = parser_parse_func(p);
-    return out_func ? *out_func != NULL : 0;
+    return parse_global_var_init(p, id->lexeme, t, elem_size, is_static,
+                                 is_register, is_extern, is_const,
+                                 is_volatile, is_restrict, line, column,
+                                 out_global);
 }
 
 /* Parse either a global variable declaration or a full function definition */


### PR DESCRIPTION
## Summary
- add `parse_func_prototype` helper for parsing parameter lists
- add `parse_global_var_init` helper for array sizes and initializers
- refactor `parse_function_or_var` to delegate to the helpers

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e3ddbb6fc832482beddf03b1ffd01