### PR TITLE
Implement argument list parser helper

### DIFF
--- a/src/parser_expr.c
+++ b/src/parser_expr.c
@@ -134,7 +134,13 @@ static expr_t *parse_identifier_expr(parser_t *p)
             return NULL;
         expr_t **args = (expr_t **)args_v.data;
         size_t count = args_v.count;
-        return ast_make_call(name, args, count, tok->line, tok->column);
+        expr_t *call = ast_make_call(name, args, count,
+                                     tok->line, tok->column);
+        if (!call) {
+            free_expr_vector(&args_v);
+            return NULL;
+        }
+        return call;
     }
     match(p, TOK_IDENT);
     return ast_make_ident(tok->lexeme, tok->line, tok->column);


### PR DESCRIPTION
## Summary
- add new helper `parse_argument_list` for call argument parsing
- use it from `parse_identifier_expr`
- free partially parsed arguments if the call expression allocation fails

## Testing
- `make`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ec98e292483249b175e7bbefd88ab