### PR TITLE
Refactor macro parameter helpers

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -30,7 +30,9 @@ Macros are stored in a simple vector declared in `preproc_macros.h`.  Each
 `macro_t` holds the macro name, an optional parameter list and its body text.
 `expand_line` walks each line character by character replacing identifiers with
 matching macros.  When a macro takes parameters the argument list is parsed and
-substituted using `expand_params` which implements the `#` and `##` operators.
+substituted using `expand_params`.  That routine now delegates to helper
+functions that perform parameter lookup, handle the `#` stringize operator and
+manage `##` token pasting.
 Macro expansion is recursive so macro bodies may reference other macros.
 
 Conditional expressions in `#if` directives are parsed by the small recursive


### PR DESCRIPTION
## Summary
- extract helpers for identifier parsing and parameter lookup
- add helpers for `#` stringification and `##` token pasting
- keep `expand_params` as a thin loop invoking these helpers
- update preprocessor documentation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ee532ee3883249fc5597d7072b9d8