### PR TITLE
Refactor macro expansion helpers

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -28,11 +28,11 @@ into the lexer.
 
 Macros are stored in a simple vector declared in `preproc_macros.h`.  Each
 `macro_t` holds the macro name, an optional parameter list and its body text.
-`expand_line` walks each line character by character replacing identifiers with
-matching macros.  When a macro takes parameters the argument list is parsed and
-substituted using `expand_params`.  That routine now delegates to helper
-functions that perform parameter lookup, handle the `#` stringize operator and
-manage `##` token pasting.
+`expand_line` loops over each character delegating to `parse_macro_invocation`
+for identifiers or `emit_plain_char` otherwise.  The invocation helper parses
+any argument list and calls `expand_macro_call` so expansion remains recursive.
+`expand_params` continues to rely on helper routines that perform parameter
+lookup, handle the `#` stringize operator and manage `##` token pasting.
 Macro expansion is recursive so macro bodies may reference other macros.
 
 Conditional expressions in `#if` directives are parsed by the small recursive


### PR DESCRIPTION
## Summary
- simplify macro expansion loop
- add helpers `parse_macro_invocation` and `emit_plain_char`
- document macro expansion helpers

## Testing
- `make -j4`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f4d5ac85c8324a870efc437c6ca70