### PR TITLE
Add #error preprocessor directive

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -15,6 +15,8 @@ preprocessor directive is handled immediately:
 - `#define` adds a new macro definition.  Parameterised forms are supported and
   stored in a `macro_t` structure.
 - `#undef` removes existing definitions.
+- `#error` prints the given message to stderr and aborts preprocessing when
+  encountered in an active block.
 - Conditional directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else` and
   `#endif`) manipulate a stack of state objects so nested conditions may be
   evaluated correctly.

--- a/man/vc.1
+++ b/man/vc.1
@@ -18,6 +18,8 @@ The built-in preprocessor expands \fB#include\fR directives, object-like
 and parameterized macros defined with \fB#define\fR. Macro bodies may be
 expanded recursively. The \fB#\fR operator stringizes a parameter and
 \fB##\fR concatenates two tokens. Macros may be removed with \fB#undef\fR.
+The \fB#error\fR directive prints its message to stderr and aborts
+preprocessing when encountered.
 Several standard identifiers are always defined and expand to context
 information: \fB__FILE__\fR yields the current file name, \fB__LINE__\fR
 the current line number and \fB__DATE__\fR/\fB__TIME__\fR the build date

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -560,6 +560,23 @@ static int handle_undef_directive(char *line, const char *dir, vector_t *macros,
     return 1;
 }
 
+/* Emit an error message and abort preprocessing when active. */
+static int handle_error_directive(char *line, const char *dir,
+                                  vector_t *macros, vector_t *conds,
+                                  strbuf_t *out,
+                                  const vector_t *incdirs)
+{
+    (void)dir; (void)macros; (void)out; (void)incdirs;
+    char *msg = line + 6; /* skip '#error' */
+    while (*msg == ' ' || *msg == '\t')
+        msg++;
+    if (stack_active(conds)) {
+        fprintf(stderr, "%s\n", *msg ? msg : "preprocessor error");
+        return 0;
+    }
+    return 1;
+}
+
 /* Copy a #pragma line into the output when active. */
 static int handle_pragma_directive(char *line, const char *dir,
                                    vector_t *macros, vector_t *conds,
@@ -627,6 +644,7 @@ static int handle_directive(char *line, const char *dir, vector_t *macros,
         {"#line",    SPACE_ANY,   handle_line_directive},
         {"#define",  SPACE_BLANK, handle_define_directive},
         {"#undef",   SPACE_ANY,   handle_undef_directive},
+        {"#error",   SPACE_ANY,   handle_error_directive},
         {"#pragma",  SPACE_ANY,   handle_pragma_directive},
         {"#ifdef",   SPACE_ANY,   handle_conditional_directive},
         {"#ifndef",  SPACE_ANY,   handle_conditional_directive},

--- a/tests/invalid/preproc_error.c
+++ b/tests/invalid/preproc_error.c
@@ -1,0 +1,2 @@
+#error Build stopped
+int main() { return 0; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -144,6 +144,19 @@ if [ $ret -eq 0 ] || ! grep -q "Semantic error" "$err"; then
 fi
 rm -f "$out" "$err"
 
+# negative test for #error directive
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "$out" "$DIR/invalid/preproc_error.c" 2> "$err"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Build stopped" "$err"; then
+    echo "Test preproc_error failed"
+    fail=1
+fi
+rm -f "$out" "$err"
+
 # test --dump-asm option
 dump_out=$(mktemp)
 "$BINARY" --dump-asm "$DIR/fixtures/simple_add.c" > "$dump_out"


### PR DESCRIPTION
## Summary
- implement `#error` directive in the preprocessor
- update directive table to recognise it
- test that `#error` stops compilation
- document the directive
- mention it in the man page

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f64adffe88324a7900d3e948f9c1a