### PR TITLE
Add bitfield metadata to struct and union members

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -331,6 +331,8 @@ struct union_member {
     type_kind_t type;
     size_t elem_size;
     size_t offset;
+    unsigned bit_width;
+    unsigned bit_offset;
 };
 
 struct struct_member {
@@ -338,6 +340,8 @@ struct struct_member {
     type_kind_t type;
     size_t elem_size;
     size_t offset;
+    unsigned bit_width;
+    unsigned bit_offset;
 };
 
 

--- a/src/parser_decl.c
+++ b/src/parser_decl.c
@@ -213,11 +213,15 @@ static int parse_member(parser_t *p, int is_union,
         um->type = mt;
         um->elem_size = mem_sz;
         um->offset = 0;
+        um->bit_width = 0;
+        um->bit_offset = 0;
     } else {
         sm->name = name;
         sm->type = mt;
         sm->elem_size = mem_sz;
         sm->offset = 0;
+        sm->bit_width = 0;
+        sm->bit_offset = 0;
     }
 
     return 1;

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -35,6 +35,7 @@ size_t layout_union_members(union_member_t *members, size_t count)
     size_t max = 0;
     for (size_t i = 0; i < count; i++) {
         members[i].offset = off;
+        members[i].bit_offset = 0;
         off += members[i].elem_size;
         if (members[i].elem_size > max)
             max = members[i].elem_size;
@@ -52,6 +53,7 @@ size_t layout_struct_members(struct_member_t *members, size_t count)
     size_t off = 0;
     for (size_t i = 0; i < count; i++) {
         members[i].offset = off;
+        members[i].bit_offset = 0;
         off += members[i].elem_size;
     }
     return off;
@@ -228,6 +230,8 @@ static int copy_union_metadata(symbol_t *sym, union_member_t *members,
         sym->members[i].type = m->type;
         sym->members[i].elem_size = m->elem_size;
         sym->members[i].offset = m->offset;
+        sym->members[i].bit_width = m->bit_width;
+        sym->members[i].bit_offset = m->bit_offset;
     }
     return 1;
 }
@@ -253,6 +257,8 @@ static int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
         sym->struct_members[i].type = m->type;
         sym->struct_members[i].elem_size = m->elem_size;
         sym->struct_members[i].offset = m->offset;
+        sym->struct_members[i].bit_width = m->bit_width;
+        sym->struct_members[i].bit_offset = m->bit_offset;
     }
     return 1;
 }

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -318,6 +318,8 @@ static int copy_union_metadata(symbol_t *sym, union_member_t *members,
         sym->members[i].type = m->type;
         sym->members[i].elem_size = m->elem_size;
         sym->members[i].offset = m->offset;
+        sym->members[i].bit_width = m->bit_width;
+        sym->members[i].bit_offset = m->bit_offset;
     }
     return 1;
 }
@@ -343,6 +345,8 @@ static int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
         sym->struct_members[i].type = m->type;
         sym->struct_members[i].elem_size = m->elem_size;
         sym->struct_members[i].offset = m->offset;
+        sym->struct_members[i].bit_width = m->bit_width;
+        sym->struct_members[i].bit_offset = m->bit_offset;
     }
     return 1;
 }

--- a/src/symtable_struct.c
+++ b/src/symtable_struct.c
@@ -114,6 +114,8 @@ int symtable_add_union(symtable_t *table, const char *tag,
             sym->members[i].type = members[i].type;
             sym->members[i].elem_size = members[i].elem_size;
             sym->members[i].offset = members[i].offset;
+            sym->members[i].bit_width = members[i].bit_width;
+            sym->members[i].bit_offset = members[i].bit_offset;
         }
     }
     sym->member_count = member_count;
@@ -152,6 +154,8 @@ int symtable_add_union_global(symtable_t *table, const char *tag,
             sym->members[i].type = members[i].type;
             sym->members[i].elem_size = members[i].elem_size;
             sym->members[i].offset = members[i].offset;
+            sym->members[i].bit_width = members[i].bit_width;
+            sym->members[i].bit_offset = members[i].bit_offset;
         }
     }
     sym->member_count = member_count;
@@ -207,6 +211,8 @@ int symtable_add_struct(symtable_t *table, const char *tag,
             sym->struct_members[i].type = members[i].type;
             sym->struct_members[i].elem_size = members[i].elem_size;
             sym->struct_members[i].offset = members[i].offset;
+            sym->struct_members[i].bit_width = members[i].bit_width;
+            sym->struct_members[i].bit_offset = members[i].bit_offset;
         }
     }
     sym->struct_member_count = member_count;
@@ -246,6 +252,8 @@ int symtable_add_struct_global(symtable_t *table, const char *tag,
             sym->struct_members[i].type = members[i].type;
             sym->struct_members[i].elem_size = members[i].elem_size;
             sym->struct_members[i].offset = members[i].offset;
+            sym->struct_members[i].bit_width = members[i].bit_width;
+            sym->struct_members[i].bit_offset = members[i].bit_offset;
         }
     }
     sym->struct_member_count = member_count;


### PR DESCRIPTION
## Summary
- track bit-field width/offset for struct and union members
- preserve the new fields when copying metadata
- initialise bit-field information to zero when parsing and when laying out aggregates

## Testing
- `make -j$(nproc)`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f6c5b829883249c126691ef150820