### PR TITLE
Support bit-field members

### DIFF
--- a/src/parser_decl.c
+++ b/src/parser_decl.c
@@ -197,6 +197,17 @@ static int parse_member(parser_t *p, int is_union,
             return 0;
         mt = TYPE_ARRAY;
     }
+
+    unsigned bit_width = 0;
+    if (match(p, TOK_COLON)) {
+        if (mt == TYPE_ARRAY)
+            return 0;
+        token_t *num = peek(p);
+        if (!num || num->type != TOK_NUMBER)
+            return 0;
+        p->pos++;
+        bit_width = strtoul(num->lexeme, NULL, 10);
+    }
     if (!match(p, TOK_SEMI))
         return 0;
 
@@ -213,14 +224,14 @@ static int parse_member(parser_t *p, int is_union,
         um->type = mt;
         um->elem_size = mem_sz;
         um->offset = 0;
-        um->bit_width = 0;
+        um->bit_width = bit_width;
         um->bit_offset = 0;
     } else {
         sm->name = name;
         sm->type = mt;
         sm->elem_size = mem_sz;
         sm->offset = 0;
-        sm->bit_width = 0;
+        sm->bit_width = bit_width;
         sm->bit_offset = 0;
     }
 

--- a/src/parser_types.c
+++ b/src/parser_types.c
@@ -47,8 +47,12 @@ int parse_basic_type(parser_t *p, type_kind_t *out)
         (void)is_unsigned;
         t = TYPE_ENUM;
     } else {
-        p->pos = save;
-        return 0;
+        if (is_unsigned) {
+            t = TYPE_UINT;
+        } else {
+            p->pos = save;
+            return 0;
+        }
     }
     if (out)
         *out = t;

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -433,6 +433,23 @@ static void test_parser_block(void)
     lexer_free_tokens(toks, count);
 }
 
+/* Parsing of a simple bit-field within a struct. */
+static void test_parser_bitfield(void)
+{
+    const char *src = "struct S { unsigned f : 1; };";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    stmt_t *stmt = parser_parse_struct_decl(&p);
+    ASSERT(stmt);
+    ASSERT(stmt->kind == STMT_STRUCT_DECL);
+    ASSERT(stmt->struct_decl.count == 1);
+    ASSERT(strcmp(stmt->struct_decl.members[0].name, "f") == 0);
+    ASSERT(stmt->struct_decl.members[0].bit_width == 1);
+    ast_free_stmt(stmt);
+    lexer_free_tokens(toks, count);
+}
+
 /* Verify that line directives influence token line/column fields. */
 static void test_line_directive(void)
 {
@@ -501,6 +518,7 @@ int main(void)
     test_parser_sizeof();
     test_parser_func();
     test_parser_block();
+    test_parser_bitfield();
     test_line_directive();
     test_lexer_escapes();
     if (failures == 0) {


### PR DESCRIPTION
## Summary
- parse ':' width after struct/union member names
- allow `unsigned` without explicit base type
- add bit-field test to unit suite

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f6dffe82c83248d26d7dea6496b16