### PR TITLE
Fix struct and union layout for bitfields

### DIFF
--- a/src/symtable_struct.c
+++ b/src/symtable_struct.c
@@ -218,8 +218,16 @@ int symtable_add_struct(symtable_t *table, const char *tag,
     sym->struct_member_count = member_count;
     size_t total = 0;
     for (size_t i = 0; i < member_count; i++) {
-        sym->struct_members[i].offset = total;
-        total += members[i].elem_size;
+        size_t end = sym->struct_members[i].offset;
+        if (sym->struct_members[i].bit_width > 0) {
+            unsigned bits = sym->struct_members[i].bit_offset +
+                            sym->struct_members[i].bit_width;
+            end += (bits + 7) / 8;
+        } else {
+            end += sym->struct_members[i].elem_size;
+        }
+        if (end > total)
+            total = end;
     }
     sym->struct_total_size = total;
     sym->next = table->head;
@@ -259,8 +267,16 @@ int symtable_add_struct_global(symtable_t *table, const char *tag,
     sym->struct_member_count = member_count;
     size_t total = 0;
     for (size_t i = 0; i < member_count; i++) {
-        sym->struct_members[i].offset = total;
-        total += members[i].elem_size;
+        size_t end = sym->struct_members[i].offset;
+        if (sym->struct_members[i].bit_width > 0) {
+            unsigned bits = sym->struct_members[i].bit_offset +
+                            sym->struct_members[i].bit_width;
+            end += (bits + 7) / 8;
+        } else {
+            end += sym->struct_members[i].elem_size;
+        }
+        if (end > total)
+            total = end;
     }
     sym->struct_total_size = total;
     sym->next = table->globals;

--- a/tests/fixtures/union_char.s
+++ b/tests/fixtures/union_char.s
@@ -7,13 +7,13 @@ main:
     movl %esp, %ebp
     movl $u, %eax
     movl $65, %ebx
-    movl $4, %ecx
+    movl $0, %ecx
     movl %ecx, %edx
     imull $1, %edx
     addl %eax, %edx
     movl %ebx, (%edx)
     movl $u, %ebx
-    movl $4, %edx
+    movl $0, %edx
     movl %edx, %ecx
     imull $1, %ecx
     addl %ebx, %ecx

--- a/tests/fixtures/union_example.s
+++ b/tests/fixtures/union_example.s
@@ -13,7 +13,7 @@ main:
     addl %eax, %edx
     movl %ebx, (%edx)
     movl $u, %ebx
-    movl $4, %edx
+    movl $0, %edx
     movl %edx, %ecx
     imull $1, %ecx
     addl %ebx, %ecx


### PR DESCRIPTION
## Summary
- correct union layout so all members share offset zero
- compute struct layout with bit-field awareness
- preserve member offsets when recording struct types
- update union test fixtures

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685f7049eac88324905c0778267d6b21