### PR TITLE
Document bit-field support

### DIFF
--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -44,6 +44,7 @@ See the [documentation index](index.md) for a list of all available pages.
 - `break` and `continue` statements
 - Labels and `goto`
 - `struct` and `union` objects with member assignments
+- Bit-field members using `type name : width`
 - Object-like and multi-parameter `#define` macros with recursive expansion
 - `#undef` to remove a previously defined macro
 - Conditional preprocessing directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else`, `#endif`)
@@ -589,6 +590,31 @@ int main() {
 Compile with:
 ```sh
 vc -o union_char.s union_char.c
+```
+
+### Bit-fields
+
+Bit-field members have the syntax `type name : width;`. Consecutive fields of
+the same type share storage and are packed starting from the least significant
+bits of the underlying type. When the combined width exceeds that type's size,
+a new storage unit is allocated. A field declared with width `0` forces the next
+bit-field to begin in a new unit.
+
+```c
+/* bitfield_example.c */
+struct Flags {
+    unsigned a : 1;
+    unsigned b : 2;
+    unsigned pad : 5;
+};
+int main() {
+    struct Flags f = {1, 3, 0};
+    return f.a + f.b;
+}
+```
+Compile with:
+```sh
+vc -o bitfield_example.s bitfield_example.c
 ```
 
 ### Labels and goto

--- a/man/vc.1
+++ b/man/vc.1
@@ -11,7 +11,7 @@ It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Supported constructs include arrays (with variable length support, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
-\fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers with standard escape sequences such as \n, \t, \r, \b, \f, \v and numeric forms like \e123 or \ex7F, complete \fBstruct\fR and \fBunion\fR declarations, enum variables, the
+\fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers with standard escape sequences such as \n, \t, \r, \b, \f, \v and numeric forms like \e123 or \ex7F, complete \fBstruct\fR and \fBunion\fR declarations with bit-field members, enum variables, the
 \fBconst\fR (which requires an initializer), \fBvolatile\fR and \fBrestrict\fR and \fBregister\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, variadic functions using \fB...\fR, as well as labels and \fBgoto\fR.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like


### PR DESCRIPTION
## Summary
- describe bit-field syntax and packing rules in language features docs
- mention bit-field members in the vc(1) description

## Testing
- `make docs`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685f770d0cfc8324958ac06f2fbaf795