### PR TITLE
Add common subexpression elimination pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CORE_SRC = src/main.c src/compile.c src/cli.c src/lexer.c src/ast_expr.c src/ast
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
 
 # Optional optimization sources
-OPT_SRC = src/opt.c src/opt_constprop.c src/opt_fold.c src/opt_dce.c src/opt_inline.c
+OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_dce.c src/opt_inline.c
 # Additional sources can be specified by the user
 EXTRA_SRC ?=
 # Final source list
@@ -191,6 +191,9 @@ src/opt_constprop.o: src/opt_constprop.c $(HDR)
 
 src/opt_fold.o: src/opt_fold.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt_fold.c -o src/opt_fold.o
+
+src/opt_cse.o: src/opt_cse.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt_cse.c -o src/opt_cse.o
 
 src/opt_dce.o: src/opt_dce.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt_dce.c -o src/opt_dce.o

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -3,19 +3,25 @@
 See the [documentation index](index.md) for a list of all available pages.
 
 The optimizer in **vc** operates on the intermediate representation (IR).
-Four passes are currently available and are executed in order:
+Five passes are currently available and are executed in order:
 1. **Constant propagation** – replaces loads of variables whose values are
    known constants with immediate constants.
-2. **Inline expansion** – replaces calls to small inline functions with their body.
-3. **Constant folding** – evaluates arithmetic instructions whose operands are
+2. **Common subexpression elimination** – reuses results of identical
+   computations.
+3. **Inline expansion** – replaces calls to small inline functions with their body.
+4. **Constant folding** – evaluates arithmetic instructions whose operands are
    constants and replaces them with a single constant.
-4. **Dead code elimination** – removes instructions that produce values which
+5. **Dead code elimination** – removes instructions that produce values which
    are never used and have no side effects.
 
 Constant propagation tracks variables written with constants. When a later
 load of such a variable is encountered, it becomes an immediate constant.
 Long-double arithmetic results are propagated when both operands are known
 constants, enabling subsequent folding.
+
+Common subexpression elimination scans previously seen computations and
+replaces duplicates with the existing value. This avoids emitting
+identical arithmetic instructions multiple times.
 
 Inline expansion scans for functions consisting of two parameter loads,
 a single arithmetic operation and a return statement. Calls to such

--- a/include/opt.h
+++ b/include/opt.h
@@ -26,9 +26,10 @@ void opt_error(const char *msg);
  *
  * Passes execute in the following order:
  * 1. Constant propagation
- * 2. Inline expansion
- * 3. Constant folding
- * 4. Dead code elimination
+ * 2. Common subexpression elimination
+ * 3. Inline expansion
+ * 4. Constant folding
+ * 5. Dead code elimination
  */
 void opt_run(ir_builder_t *ir, const opt_config_t *cfg);
 

--- a/man/vc.1
+++ b/man/vc.1
@@ -42,7 +42,8 @@ Display usage information and exit.
 Print version information and exit.
 .TP
 .B \-O\fIN\fR
-Set optimization level (0 disables all optimizations).
+Set optimization level (0 disables all optimizations). The optimizer also
+performs common subexpression elimination.
 .TP
 .BR -I "," \fB--include\fR \fIdir\fR
 Add directory to the include search path. Angle-bracket includes search these

--- a/src/opt.c
+++ b/src/opt.c
@@ -10,6 +10,7 @@
 
 /* Pass implementations */
 void propagate_load_consts(ir_builder_t *ir);
+void common_subexpr_elim(ir_builder_t *ir);
 void inline_small_funcs(ir_builder_t *ir);
 void fold_constants(ir_builder_t *ir);
 void dead_code_elim(ir_builder_t *ir);
@@ -27,6 +28,7 @@ void opt_run(ir_builder_t *ir, const opt_config_t *cfg)
     const opt_config_t *c = cfg ? cfg : &def;
     if (c->const_prop)
         propagate_load_consts(ir);
+    common_subexpr_elim(ir);
     if (c->inline_funcs)
         inline_small_funcs(ir);
     if (c->fold_constants)

--- a/src/opt_cse.c
+++ b/src/opt_cse.c
@@ -1,0 +1,103 @@
+/*
+ * Common subexpression elimination pass.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include "opt.h"
+
+typedef struct expr_entry {
+    ir_op_t op;
+    int src1;
+    int src2;
+    long long imm;
+    int dest;
+    struct expr_entry *next;
+} expr_entry_t;
+
+static int is_commutative(ir_op_t op)
+{
+    switch (op) {
+    case IR_ADD: case IR_MUL: case IR_AND: case IR_OR: case IR_XOR:
+    case IR_FADD: case IR_FMUL:
+    case IR_LFADD: case IR_LFMUL:
+    case IR_CMPEQ: case IR_CMPNE: case IR_LOGAND: case IR_LOGOR:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static int is_pure_op(ir_op_t op)
+{
+    switch (op) {
+    case IR_ADD: case IR_SUB: case IR_MUL: case IR_DIV: case IR_MOD:
+    case IR_SHL: case IR_SHR: case IR_AND: case IR_OR: case IR_XOR:
+    case IR_FADD: case IR_FSUB: case IR_FMUL: case IR_FDIV:
+    case IR_LFADD: case IR_LFSUB: case IR_LFMUL: case IR_LFDIV:
+    case IR_PTR_ADD: case IR_PTR_DIFF:
+    case IR_CMPEQ: case IR_CMPNE: case IR_CMPLT: case IR_CMPGT:
+    case IR_CMPLE: case IR_CMPGE:
+    case IR_LOGAND: case IR_LOGOR:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+void common_subexpr_elim(ir_builder_t *ir)
+{
+    if (!ir)
+        return;
+
+    expr_entry_t *list = NULL;
+
+    for (ir_instr_t *ins = ir->head; ins; ins = ins->next) {
+        if (!is_pure_op(ins->op))
+            continue;
+
+        int a = ins->src1;
+        int b = ins->src2;
+        if (is_commutative(ins->op) && a > b) {
+            int t = a; a = b; b = t;
+        }
+
+        expr_entry_t *e;
+        for (e = list; e; e = e->next) {
+            if (e->op == ins->op && e->src1 == a && e->src2 == b &&
+                e->imm == ins->imm) {
+                int old = e->dest;
+                for (ir_instr_t *u = ins->next; u; u = u->next) {
+                    if (u->src1 == ins->dest)
+                        u->src1 = old;
+                    if (u->src2 == ins->dest)
+                        u->src2 = old;
+                }
+                break;
+            }
+        }
+        if (!e) {
+            e = malloc(sizeof(*e));
+            if (!e) {
+                opt_error("out of memory");
+                break;
+            }
+            e->op = ins->op;
+            e->src1 = a;
+            e->src2 = b;
+            e->imm = ins->imm;
+            e->dest = ins->dest;
+            e->next = list;
+            list = e;
+        }
+    }
+
+    while (list) {
+        expr_entry_t *n = list->next;
+        free(list);
+        list = n;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `common_subexpr_elim` in new module `src/opt_cse.c`
- run CSE after constant propagation
- document pass ordering in header and docs
- note optimisation in manpage
- include new file in build system

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68602fcd18588324ae6e11a0eff10ab2