### PR TITLE
Add VCINC search path support

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -44,7 +44,8 @@ The preprocessor runs automatically before the lexer. It supports both
 file. Additional directories to search for included files can be provided with
 the `-I`/`--include` option. Angle-bracket includes search those directories,
 then any paths listed in the `VCPATH` environment variable (colon separated),
-followed by the standard system locations such as `/usr/include`. It also supports
+followed by the standard system locations such as `/usr/include`. Quoted includes
+also consult directories from `VCINC`. It also supports
 object-like `#define` macros and parameterized
 macros such as `#define NAME(a, b)`; macro bodies are expanded recursively.
 The `#` operator stringizes a parameter and `##` concatenates two tokens during

--- a/man/vc.1
+++ b/man/vc.1
@@ -48,7 +48,8 @@ performs common subexpression elimination.
 .BR -I "," \fB--include\fR \fIdir\fR
 Add directory to the include search path. Angle-bracket includes search these
 directories, then any paths from the \fBVCPATH\fR environment variable,
-followed by the standard locations such as \fI/usr/include\fR.
+followed by the standard locations such as \fI/usr/include\fR. Quoted
+includes also consult directories from \fBVCINC\fR.
 .TP
 .B --no-fold
 Disable constant folding optimization.
@@ -116,6 +117,11 @@ Call a function via a pointer variable:
 .TP
 .B VCPATH
 Colon separated list of additional directories searched for headers after any
+.B -I
+paths are processed.
+.TP
+.B VCINC
+Colon separated list of directories added to the include search path after any
 .B -I
 paths are processed.
 .SH SEE ALSO

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -723,6 +723,21 @@ char *preproc_run(const char *path, const vector_t *include_dirs)
         free(tmp);
     }
 
+    env = getenv("VCINC");
+    if (env && *env) {
+        char *tmp = vc_strdup(env);
+        char *tok; char *sp;
+        tok = strtok_r(tmp, ":", &sp);
+        while (tok) {
+            if (*tok) {
+                char *dup = vc_strdup(tok);
+                vector_push(&search_dirs, &dup);
+            }
+            tok = strtok_r(NULL, ":", &sp);
+        }
+        free(tmp);
+    }
+
     vector_t macros;
     vector_init(&macros, sizeof(macro_t));
     vector_t conds;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -92,6 +92,15 @@ if ! diff -u "$DIR/fixtures/include_env.s" "$env_out"; then
 fi
 rm -f "$env_out"
 
+# verify VCINC include search
+inc_env_out=$(mktemp)
+VCINC="$DIR/includes" "$BINARY" -o "$inc_env_out" "$DIR/fixtures/include_search.c"
+if ! diff -u "$DIR/fixtures/include_search.s" "$inc_env_out"; then
+    echo "Test include_vcinc failed"
+    fail=1
+fi
+rm -f "$inc_env_out"
+
 # negative test for parse error message
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- support `VCINC` env var for include search
- document the new variable
- test header lookup through `VCINC`

## Testing
- `make -j$(nproc)`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686033407a148324850e44194aef4f0a