### PR TITLE
Improve macro location tracking

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -77,3 +77,8 @@ file:line:column: function: message
 ```
 
 If an error occurs outside a function, the function portion is omitted.
+
+Macro expansions now track the column where each invocation begins.  When
+an error originates from within a macro body or uses `__FILE__`/`__LINE__`,
+the reported position refers to the invocation site rather than the macro
+definition.

--- a/include/preproc_macros.h
+++ b/include/preproc_macros.h
@@ -26,7 +26,7 @@ typedef struct {
 void macro_free(macro_t *m);
 
 /* Expand macros in one line */
-void expand_line(const char *line, vector_t *macros, strbuf_t *out);
+void expand_line(const char *line, vector_t *macros, strbuf_t *out, size_t column);
 
 /* Check whether a macro exists */
 int is_macro_defined(vector_t *macros, const char *name);
@@ -35,7 +35,7 @@ int is_macro_defined(vector_t *macros, const char *name);
 void remove_macro(vector_t *macros, const char *name);
 
 /* Update builtin macro expansion context */
-void preproc_set_location(const char *file, size_t line);
+void preproc_set_location(const char *file, size_t line, size_t column);
 
 /* Set the current function name for __func__ expansion */
 void preproc_set_function(const char *name);

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -483,7 +483,7 @@ static int process_all_lines(char **lines, const char *path, const char *dir,
                              strbuf_t *out, const vector_t *incdirs)
 {
     for (size_t i = 0; lines[i]; i++) {
-        preproc_set_location(path, i + 1);
+        preproc_set_location(path, i + 1, 1);
         if (!process_line(lines[i], dir, macros, conds, out, incdirs))
             return 0;
     }
@@ -611,7 +611,7 @@ static int handle_text_line(char *line, const char *dir, vector_t *macros,
     if (stack_active(conds)) {
         strbuf_t tmp;
         strbuf_init(&tmp);
-        expand_line(line, macros, &tmp);
+        expand_line(line, macros, &tmp, 0);
         strbuf_append(&tmp, "\n");
         strbuf_append(out, tmp.data);
         strbuf_free(&tmp);


### PR DESCRIPTION
## Summary
- add column tracking for preprocessor macro expansions
- update semantic helpers and preprocessing APIs
- document the more precise diagnostics

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860334df1f88324bc6169a45fa044c7