### PR TITLE
Add argument type tracking in IR

### DIFF
--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -8,6 +8,8 @@
 #ifndef VC_IR_CORE_H
 #define VC_IR_CORE_H
 
+#include "ast.h"
+
 /* IR operation codes */
 typedef enum {
     IR_CONST,
@@ -187,8 +189,8 @@ ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size);
 /* Emit IR_RETURN of `val`. */
 void ir_build_return(ir_builder_t *b, ir_value_t val);
 
-/* Push `val` as an argument via IR_ARG. */
-void ir_build_arg(ir_builder_t *b, ir_value_t val);
+/* Push `val` as an argument via IR_ARG. The argument's type is stored in imm. */
+void ir_build_arg(ir_builder_t *b, ir_value_t val, type_kind_t type);
 
 /* Emit IR_CALL to `name` expecting `arg_count` previously pushed args. */
 ir_value_t ir_build_call(ir_builder_t *b, const char *name, size_t arg_count);

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -18,6 +18,7 @@
 #include "label.h"
 #include "strbuf.h"
 #include "util.h"
+#include "ast.h"
 
 
 /*
@@ -422,14 +423,17 @@ ir_value_t ir_build_logor(ir_builder_t *b, ir_value_t left, ir_value_t right)
     return (ir_value_t){ins->dest};
 }
 
-/* Emit IR_ARG to push an argument value for a call. */
-void ir_build_arg(ir_builder_t *b, ir_value_t val)
+/* Emit IR_ARG to push an argument value for a call. The argument's
+ * type kind is stored in the instruction's imm field for later
+ * optimisations or code generation. */
+void ir_build_arg(ir_builder_t *b, ir_value_t val, type_kind_t type)
 {
     ir_instr_t *ins = append_instr(b);
     if (!ins)
         return;
     ins->op = IR_ARG;
     ins->src1 = val.id;
+    ins->imm = (long long)type;
 }
 
 /* Emit IR_RETURN using the supplied value id. */


### PR DESCRIPTION
## Summary
- extend `ir_build_arg` to store the argument type in `imm`
- propagate types from call expressions when emitting `IR_ARG`
- include `ast.h` where `type_kind_t` is used

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68603b7d397083249d589496bd8fb404