### PR TITLE
Add pointer arithmetic fixtures and docs

### DIFF
--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -285,6 +285,39 @@ Compile with:
 vc -o ptr_inc.s ptr_inc.c
 ```
 
+Pointer subtraction using a variable offset works the same way:
+
+```c
+/* ptr_var_sub.c */
+int main() {
+    int nums[3] = {1, 2, 3};
+    int i = 2;
+    int *p = nums + i;
+    p = p - i;
+    return *p;
+}
+```
+Compile with:
+```sh
+vc -o ptr_var_sub.s ptr_var_sub.c
+```
+
+Pointers can also be compared when they refer to elements of the same array:
+
+```c
+/* ptr_compare.c */
+int main() {
+    int arr[2];
+    int *p1 = arr;
+    int *p2 = arr + 1;
+    return p1 < p2;
+}
+```
+Compile with:
+```sh
+vc -o ptr_compare.s ptr_compare.c
+```
+
 #### Function pointers
 Pointers may reference functions and use the standard `(*name)(...)` notation.
 They can be called through just like normal identifiers.

--- a/src/semantic_arith.c
+++ b/src/semantic_arith.c
@@ -106,6 +106,15 @@ type_kind_t check_binary(expr_t *left, expr_t *right, symtable_t *vars,
         if (out)
             *out = ir_build_ptr_diff(ir, lval, rval, (int)esz);
         return TYPE_INT;
+    } else if (lt == TYPE_PTR && rt == TYPE_PTR &&
+               (op == BINOP_EQ || op == BINOP_NEQ ||
+                op == BINOP_LT || op == BINOP_GT ||
+                op == BINOP_LE || op == BINOP_GE)) {
+        if (out) {
+            ir_op_t ir_op = binop_to_ir[op];
+            *out = ir_build_binop(ir, ir_op, lval, rval);
+        }
+        return TYPE_INT;
     }
     error_set(left->line, left->column, error_current_file, error_current_function);
     return TYPE_UNKNOWN;

--- a/tests/fixtures/pointer_compare.c
+++ b/tests/fixtures/pointer_compare.c
@@ -1,0 +1,6 @@
+int main() {
+    int arr[2];
+    int *p1 = arr;
+    int *p2 = arr + 1;
+    return p1 < p2;
+}

--- a/tests/fixtures/pointer_compare.s
+++ b/tests/fixtures/pointer_compare.s
@@ -1,0 +1,22 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $arr, %eax
+    movl %eax, p1
+    movl $arr, %eax
+    movl $1, %ebx
+    movl %ebx, %ecx
+    imull $4, %ecx
+    addl %eax, %ecx
+    movl %ecx, p2
+    movl p1, %ecx
+    movl p2, %ebx
+    movl %ecx, %eax
+    cmpl %ebx, %eax
+    setl %al
+    movzbl %al, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/pointer_var_sub.c
+++ b/tests/fixtures/pointer_var_sub.c
@@ -1,0 +1,7 @@
+int main() {
+    int arr[3] = {1, 2, 3};
+    int i = 2;
+    int *p = arr + i;
+    p = p - i;
+    return *p;
+}

--- a/tests/fixtures/pointer_var_sub.s
+++ b/tests/fixtures/pointer_var_sub.s
@@ -1,0 +1,33 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $0, %eax
+    movl $1, %ebx
+    movl %ebx, arr(,%eax,4)
+    movl $1, %ebx
+    movl $2, %eax
+    movl %eax, arr(,%ebx,4)
+    movl $2, %eax
+    movl $3, %ebx
+    movl %ebx, arr(,%eax,4)
+    movl $2, %ebx
+    movl %ebx, i
+    movl $arr, %ebx
+    movl $2, %eax
+    movl %eax, %ecx
+    imull $4, %ecx
+    addl %ebx, %ecx
+    movl %ecx, p
+    movl p, %ecx
+    movl $-2, %eax
+    movl %eax, %ebx
+    imull $4, %ebx
+    addl %ecx, %ebx
+    movl %ebx, p
+    movl p, %ebx
+    movl (%ebx), %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- add pointer comparison and variable offset subtraction examples
- support pointer comparison operators in `check_binary`
- reference new examples in the language docs
- include new fixtures

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686042e3657c832499b1dff10ab7a8ae