### PR TITLE
Implement VLA allocation

### DIFF
--- a/include/symtable.h
+++ b/include/symtable.h
@@ -10,6 +10,7 @@
 
 #include <stddef.h>
 #include "ast.h"
+#include "ir_core.h"
 
 /* Symbol table entry */
 typedef struct symbol {
@@ -19,6 +20,8 @@ typedef struct symbol {
     int param_index; /* -1 for locals */
     size_t array_size;
     size_t elem_size;
+    ir_value_t vla_addr; /* base pointer for variable-length arrays */
+    ir_value_t vla_size; /* runtime element count */
     int enum_value;
     int is_enum_const;
     int is_typedef;


### PR DESCRIPTION
## Summary
- extend `symbol_t` with fields for VLA address and size
- allocate stack space for VLAs in `check_var_decl_stmt`

## Testing
- `make -j4`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860473671d08324949777fa816837cb