### PR TITLE
Handle variable array sizes

### DIFF
--- a/src/parser_decl.c
+++ b/src/parser_decl.c
@@ -111,8 +111,11 @@ static int parse_array_suffix(parser_t *p, type_kind_t *type, char **name,
                 p->pos = save;
                 return 0;
             }
-            if ((*size_expr)->kind == EXPR_NUMBER)
+            if ((*size_expr)->kind == EXPR_NUMBER) {
                 *arr_size = strtoul((*size_expr)->number.value, NULL, 10);
+                ast_free_expr(*size_expr);
+                *size_expr = NULL;
+            }
             *type = TYPE_ARRAY;
         }
     }

--- a/src/parser_toplevel.c
+++ b/src/parser_toplevel.c
@@ -235,8 +235,11 @@ static int parse_array_size(parser_t *p, type_kind_t *type, size_t *arr_size,
                 p->pos = start;
                 return 0;
             }
-            if ((*size_expr)->kind == EXPR_NUMBER)
+            if ((*size_expr)->kind == EXPR_NUMBER) {
                 *arr_size = strtoul((*size_expr)->number.value, NULL, 10);
+                ast_free_expr(*size_expr);
+                *size_expr = NULL;
+            }
             *type = TYPE_ARRAY;
         }
     }


### PR DESCRIPTION
## Summary
- keep expressions for VLA sizes in parser helpers
- free constant array size expressions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686049ac15b48324acf9edd8e65c2fdb