### PR TITLE
Handle missing inline source file

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -29,6 +29,9 @@ functions are replaced by the equivalent operation in the caller. This
 reduces call overhead and allows the following passes to fold the
 resulting expression.
 
+If the optimizer cannot open the source file referenced by a candidate
+function, a warning is printed and the call remains non-inline.
+
 Constant folding evaluates arithmetic instructions whose operands are constant
 values, replacing them with a single constant instruction.  Support now
 includes the long double operations `IR_LFADD`, `IR_LFSUB`, `IR_LFMUL` and

--- a/src/opt_inline.c
+++ b/src/opt_inline.c
@@ -72,6 +72,13 @@ static int collect_funcs(ir_builder_t *ir, inline_func_t **out, size_t *count)
                     }
                 }
                 fclose(f);
+            } else {
+                char msg[256];
+                snprintf(msg, sizeof(msg),
+                         "could not open %s for inline check; "
+                         "treating %s as non-inline",
+                         src_file, ins->name);
+                opt_error(msg);
             }
         }
         if (!is_inline) {


### PR DESCRIPTION
## Summary
- warn if the optimizer cannot open the source file while checking for the `inline` keyword
- note this warning behaviour in the optimization docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68604c613d7883249aacf6f30aadef9b