### PR TITLE
Add docs for VLA support

### DIFF
--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -16,6 +16,7 @@ See the [documentation index](index.md) for a list of all available pages.
 - [Loops](#loops)
 - [Pointers](#pointers)
 - [Arrays](#arrays)
+- [Variable length arrays](#variable-length-arrays)
 - [Compound literals](#compound-literals)
 - [sizeof](#sizeof)
 - [Global variables](#global-variables)
@@ -30,6 +31,7 @@ See the [documentation index](index.md) for a list of all available pages.
 - Loop initialization may declare a variable
 - Pointers
 - Arrays
+- Variable length arrays inside functions
 - Compound assignment operators (`+=`, `-=`, `*=`, `/=`, `%=`)
 - Increment and decrement operators (`++`, `--`)
 - Logical operators `&&`, `||` and `!`
@@ -375,6 +377,7 @@ Compile with:
 vc -o array_init.s array_init.c
 ```
 
+#### Variable length arrays
 Variable length arrays may use any runtime expression between the brackets:
 
 ```c

--- a/man/vc.1
+++ b/man/vc.1
@@ -10,11 +10,15 @@ is a lightweight ANSI C compiler with experimental C99 support.
 It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
-Supported constructs include arrays (with variable length support, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
+Supported constructs include arrays (including variable length arrays inside functions with sizes determined at runtime, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers with standard escape sequences such as \n, \t, \r, \b, \f, \v and numeric forms like \e123 or \ex7F, complete \fBstruct\fR and \fBunion\fR declarations with bit-field members, enum variables, typedef declarations, the
 Wide character and string literals may be written using L'c' and L"text".
 \fBconst\fR (which requires an initializer), \fBvolatile\fR and \fBrestrict\fR and \fBregister\fR qualifiers, and the \fBbreak\fR and \fBcontinue\fR statements, \fBswitch\fR with \fBcase\fR and \fBdefault\fR labels, variadic functions using \fB...\fR (including \fBfloat\fR, \fBdouble\fR and \fBlong double\fR arguments), as well as labels and \fBgoto\fR.
 Function definitions may also use the \fBinline\fR keyword.
+.PP
+Variable length arrays are supported only for block scope variables.
+They may be sized using any runtime expression and are fully compatible
+with \fBsizeof\fR, but cannot appear at file scope or as struct members.
 .PP
 The built-in preprocessor expands \fB#include\fR directives, object-like
 and parameterized macros defined with \fB#define\fR. Macro bodies may be


### PR DESCRIPTION
## Summary
- document variable length array (VLA) support in `docs/language_features.md`
- describe VLA usage and limitations in `man/vc.1`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68604c37e5788324abc65df0f490eab5