### PR TITLE
Check vector capacity multiplication for overflow

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -7,6 +7,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdint.h>
 #include "vector.h"
 #include "util.h"
 
@@ -35,6 +37,10 @@ int vector_push(vector_t *vec, const void *elem)
         return 0;
     if (vec->count >= vec->cap) {
         size_t new_cap = vec->cap ? vec->cap * 2 : 16;
+        if (new_cap > SIZE_MAX / vec->elem_size) {
+            fprintf(stderr, "vc: vector too large\n");
+            exit(1);
+        }
         void *tmp = vc_realloc_or_exit(vec->data, new_cap * vec->elem_size);
         vec->data = tmp;
         vec->cap = new_cap;

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -18,6 +18,7 @@
 #include "ast.h"
 #include "ast_expr.h"
 #include "ast_stmt.h"
+#include "vector.h"
 
 /*
  * Number of failed assertions recorded so far.  The main function prints
@@ -503,6 +504,22 @@ static void test_lexer_escapes(void)
     lexer_free_tokens(toks, count);
 }
 
+/* Ensure the vector grows correctly for large element counts */
+static void test_vector_large(void)
+{
+    const size_t big_count = 1000000;
+    vector_t v;
+    vector_init(&v, sizeof(int));
+    for (size_t i = 0; i < big_count; i++) {
+        ASSERT(vector_push(&v, &i));
+    }
+    ASSERT(v.count == big_count);
+    for (size_t i = 0; i < big_count; i++) {
+        ASSERT(((int *)v.data)[i] == (int)i);
+    }
+    vector_free(&v);
+}
+
 /*
  * Entry point for the test executable.  Each unit test is run in
  * sequence and the total number of failures reported at the end.
@@ -538,6 +555,7 @@ int main(void)
     test_parser_bitfield();
     test_line_directive();
     test_lexer_escapes();
+    test_vector_large();
     if (failures == 0) {
         printf("All unit tests passed\n");
     } else {


### PR DESCRIPTION
## Summary
- prevent `vector_push` from overflowing when expanding
- include `<stdio.h>` and `<stdint.h>` in `vector.c`
- test large vector growth in unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686050a5d0508324949f9310052227fa