### PR TITLE
Fix vc_strndup length check

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -54,9 +54,12 @@ char *vc_strdup(const char *s)
 /* Duplicate at most "n" characters of a string. */
 char *vc_strndup(const char *s, size_t n)
 {
-    char *out = vc_alloc_or_exit(n + 1);
-    memcpy(out, s, n);
-    out[n] = '\0';
+    size_t len = strlen(s);
+    if (len > n)
+        len = n;
+    char *out = vc_alloc_or_exit(len + 1);
+    memcpy(out, s, len);
+    out[len] = '\0';
     return out;
 }
 


### PR DESCRIPTION
## Summary
- ensure `vc_strndup` copies only up to `n` or the length of the source string

## Testing
- `make`
- `./tests/run.sh` *(fails: assertion failure in unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_686058ded4188324a892ade82ec50cee