### PR TITLE
Quote mktemp output variables

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,12 +18,12 @@ for cfile in $(ls "$DIR"/fixtures/*.c | sort); do
     expect="$DIR/fixtures/$base.s"
     out=$(mktemp)
     echo "Running fixture $base"
-    "$BINARY" -o "$out" "$cfile"
-    if ! diff -u "$expect" "$out"; then
+    "$BINARY" -o "${out}" "$cfile"
+    if ! diff -u "$expect" "${out}"; then
         echo "Test $base failed"
         fail=1
     fi
-    rm -f "$out"
+    rm -f "${out}"
 done
 
 # run struct fixtures separately to ensure struct member access and assignment
@@ -33,12 +33,12 @@ for cfile in "$DIR"/fixtures/struct_*.c; do
     expect="$DIR/fixtures/$base.s"
     out=$(mktemp)
     echo "Running fixture $base"
-    "$BINARY" -o "$out" "$cfile"
-    if ! diff -u "$expect" "$out"; then
+    "$BINARY" -o "${out}" "$cfile"
+    if ! diff -u "$expect" "${out}"; then
         echo "Test $base failed"
         fail=1
     fi
-    rm -f "$out"
+    rm -f "${out}"
 done
 
 # verify -O0 disables all optimizations for selected fixtures
@@ -46,12 +46,12 @@ for o0asm in "$DIR"/fixtures/*_O0.s; do
     base=$(basename "$o0asm" _O0.s)
     cfile="$DIR/fixtures/$base.c"
     out=$(mktemp)
-    "$BINARY" -O0 -o "$out" "$cfile"
-    if ! diff -u "$o0asm" "$out"; then
+    "$BINARY" -O0 -o "${out}" "$cfile"
+    if ! diff -u "$o0asm" "${out}"; then
         echo "Test O0_$base failed"
         fail=1
     fi
-    rm -f "$out"
+    rm -f "${out}"
 done
 
 # verify 64-bit code generation for selected fixtures
@@ -59,258 +59,258 @@ for asm64 in "$DIR"/fixtures/*_x86-64.s; do
     base=$(basename "$asm64" _x86-64.s)
     cfile="$DIR/fixtures/$base.c"
     out=$(mktemp)
-    "$BINARY" --x86-64 -o "$out" "$cfile"
-    if ! diff -u "$asm64" "$out"; then
+    "$BINARY" --x86-64 -o "${out}" "$cfile"
+    if ! diff -u "$asm64" "${out}"; then
         echo "Test x86_64_$base failed"
         fail=1
     fi
-    rm -f "$out"
+    rm -f "${out}"
 done
 
 # verify include search path option
 inc_out=$(mktemp)
-"$BINARY" -I "$DIR/includes" -o "$inc_out" "$DIR/fixtures/include_search.c"
-if ! diff -u "$DIR/fixtures/include_search.s" "$inc_out"; then
+"$BINARY" -I "$DIR/includes" -o "${inc_out}" "$DIR/fixtures/include_search.c"
+if ! diff -u "$DIR/fixtures/include_search.s" "${inc_out}"; then
     echo "Test include_search failed"
     fail=1
 fi
-rm -f "$inc_out"
+rm -f "${inc_out}"
 
 # verify angle-bracket include search
 angle_out=$(mktemp)
-"$BINARY" -I "$DIR/includes" -o "$angle_out" "$DIR/fixtures/include_angle.c"
-if ! diff -u "$DIR/fixtures/include_angle.s" "$angle_out"; then
+"$BINARY" -I "$DIR/includes" -o "${angle_out}" "$DIR/fixtures/include_angle.c"
+if ! diff -u "$DIR/fixtures/include_angle.s" "${angle_out}"; then
     echo "Test include_angle failed"
     fail=1
 fi
-rm -f "$angle_out"
+rm -f "${angle_out}"
 
 # verify VCPATH include search
 env_out=$(mktemp)
-VCPATH="$DIR/includes" "$BINARY" -o "$env_out" "$DIR/fixtures/include_env.c"
-if ! diff -u "$DIR/fixtures/include_env.s" "$env_out"; then
+VCPATH="$DIR/includes" "$BINARY" -o "${env_out}" "$DIR/fixtures/include_env.c"
+if ! diff -u "$DIR/fixtures/include_env.s" "${env_out}"; then
     echo "Test include_env failed"
     fail=1
 fi
-rm -f "$env_out"
+rm -f "${env_out}"
 
 # verify VCINC include search
 inc_env_out=$(mktemp)
-VCINC="$DIR/includes" "$BINARY" -o "$inc_env_out" "$DIR/fixtures/include_search.c"
-if ! diff -u "$DIR/fixtures/include_search.s" "$inc_env_out"; then
+VCINC="$DIR/includes" "$BINARY" -o "${inc_env_out}" "$DIR/fixtures/include_search.c"
+if ! diff -u "$DIR/fixtures/include_search.s" "${inc_env_out}"; then
     echo "Test include_vcinc failed"
     fail=1
 fi
-rm -f "$inc_env_out"
+rm -f "${inc_env_out}"
 
 # negative test for parse error message
 err=$(mktemp)
 out=$(mktemp)
 set +e
-"$BINARY" -o "$out" "$DIR/invalid/parse_error.c" 2> "$err"
+"$BINARY" -o "${out}" "$DIR/invalid/parse_error.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Unexpected token" "$err" || ! grep -q "expected" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Unexpected token" "${err}" || ! grep -q "expected" "${err}"; then
     echo "Test parse_error failed"
     fail=1
 fi
-rm -f "$out" "$err"
+rm -f "${out}" "${err}"
 
 # negative test for undefined variable error message
 err=$(mktemp)
 out=$(mktemp)
 set +e
-"$BINARY" -o "$out" "$DIR/invalid/undef_var.c" 2> "$err"
+"$BINARY" -o "${out}" "$DIR/invalid/undef_var.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
     echo "Test undef_var failed"
     fail=1
 fi
-rm -f "$out" "$err"
+rm -f "${out}" "${err}"
 
 # negative test for assigning to const variable
 err=$(mktemp)
 out=$(mktemp)
 set +e
-"$BINARY" -o "$out" "$DIR/invalid/const_assign.c" 2> "$err"
+"$BINARY" -o "${out}" "$DIR/invalid/const_assign.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
     echo "Test const_assign failed"
     fail=1
 fi
-rm -f "$out" "$err"
+rm -f "${out}" "${err}"
 
 # negative test for const variable without initializer
 err=$(mktemp)
 out=$(mktemp)
 set +e
-"$BINARY" -o "$out" "$DIR/invalid/const_no_init.c" 2> "$err"
+"$BINARY" -o "${out}" "$DIR/invalid/const_no_init.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
     echo "Test const_no_init failed"
     fail=1
 fi
-rm -f "$out" "$err"
+rm -f "${out}" "${err}"
 
 # negative test for #error directive
 err=$(mktemp)
 out=$(mktemp)
 set +e
-"$BINARY" -o "$out" "$DIR/invalid/preproc_error.c" 2> "$err"
+"$BINARY" -o "${out}" "$DIR/invalid/preproc_error.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Build stopped" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Build stopped" "${err}"; then
     echo "Test preproc_error failed"
     fail=1
 fi
-rm -f "$out" "$err"
+rm -f "${out}" "${err}"
 
 # negative test for include cycle detection
 err=$(mktemp)
 out=$(mktemp)
 set +e
-"$BINARY" -o "$out" "$DIR/invalid/include_cycle.c" 2> "$err"
+"$BINARY" -o "${out}" "$DIR/invalid/include_cycle.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Include cycle detected" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Include cycle detected" "${err}"; then
     echo "Test include_cycle failed"
     fail=1
 fi
-rm -f "$out" "$err"
+rm -f "${out}" "${err}"
 
 # test --dump-asm option
 dump_out=$(mktemp)
-"$BINARY" --dump-asm "$DIR/fixtures/simple_add.c" > "$dump_out"
-if ! grep -q "movl \$7, %eax" "$dump_out"; then
+"$BINARY" --dump-asm "$DIR/fixtures/simple_add.c" > "${dump_out}"
+if ! grep -q "movl \$7, %eax" "${dump_out}"; then
     echo "Test dump_asm failed"
     fail=1
 fi
-rm -f "$dump_out"
+rm -f "${dump_out}"
 
 # test -S option
 dashS_out=$(mktemp)
-"$BINARY" -S "$DIR/fixtures/simple_add.c" > "$dashS_out"
-if ! grep -q "movl \$7, %eax" "$dashS_out"; then
+"$BINARY" -S "$DIR/fixtures/simple_add.c" > "${dashS_out}"
+if ! grep -q "movl \$7, %eax" "${dashS_out}"; then
     echo "Test dash_S failed"
     fail=1
 fi
-rm -f "$dashS_out"
+rm -f "${dashS_out}"
 
 # test --dump-ir option
 ir_out=$(mktemp)
-"$BINARY" --dump-ir "$DIR/fixtures/simple_add.c" > "$ir_out"
-if ! grep -q "IR_CONST" "$ir_out"; then
+"$BINARY" --dump-ir "$DIR/fixtures/simple_add.c" > "${ir_out}"
+if ! grep -q "IR_CONST" "${ir_out}"; then
     echo "Test dump_ir failed"
     fail=1
 fi
-rm -f "$ir_out"
+rm -f "${ir_out}"
 
 # test -E/--preprocess option
 pp_out=$(mktemp)
-"$BINARY" -E "$DIR/fixtures/macro_object.c" > "$pp_out"
-if ! grep -q "return 42;" "$pp_out"; then
+"$BINARY" -E "$DIR/fixtures/macro_object.c" > "${pp_out}"
+if ! grep -q "return 42;" "${pp_out}"; then
     echo "Test preprocess_option failed"
     fail=1
 fi
-rm -f "$pp_out"
+rm -f "${pp_out}"
 
 # test --no-cprop option
 cprop_out=$(mktemp)
-"$BINARY" --no-cprop -o "$cprop_out" "$DIR/fixtures/const_load.c"
-if ! grep -q "movl x, %eax" "$cprop_out"; then
+"$BINARY" --no-cprop -o "${cprop_out}" "$DIR/fixtures/const_load.c"
+if ! grep -q "movl x, %eax" "${cprop_out}"; then
     echo "Test no_cprop failed"
     fail=1
 fi
-rm -f "$cprop_out"
+rm -f "${cprop_out}"
 
 # test --no-inline option
 inline_out=$(mktemp)
-"$BINARY" --no-inline -o "$inline_out" "$DIR/fixtures/inline_func.c"
-if ! grep -q "call add" "$inline_out"; then
+"$BINARY" --no-inline -o "${inline_out}" "$DIR/fixtures/inline_func.c"
+if ! grep -q "call add" "${inline_out}"; then
     echo "Test no_inline failed"
     fail=1
 fi
-rm -f "$inline_out"
+rm -f "${inline_out}"
 
 # test --debug option
 debug_out=$(mktemp)
-"$BINARY" --debug -S "$DIR/fixtures/simple_add.c" > "$debug_out"
-if ! grep -q "\.file" "$debug_out"; then
+"$BINARY" --debug -S "$DIR/fixtures/simple_add.c" > "${debug_out}"
+if ! grep -q "\.file" "${debug_out}"; then
     echo "Test debug_option failed"
     fail=1
 fi
-rm -f "$debug_out"
+rm -f "${debug_out}"
 
 # test -c/--compile option
 obj_out=$(mktemp --suffix=.o)
-"$BINARY" -c -o "$obj_out" "$DIR/fixtures/simple_add.c"
-if ! od -An -t x1 "$obj_out" | head -n 1 | grep -q "7f 45 4c 46"; then
+"$BINARY" -c -o "${obj_out}" "$DIR/fixtures/simple_add.c"
+if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
     echo "Test compile_option failed"
     fail=1
 fi
-rm -f "$obj_out"
+rm -f "${obj_out}"
 
 # test --link option with spaces and semicolons in output path
 link_tmpdir=$(mktemp -d)
-exe_space="$link_tmpdir/out with space"
-"$BINARY" --x86-64 --link -o "$exe_space" "$DIR/fixtures/simple_add.c"
-if ! od -An -t x1 "$exe_space" | head -n 1 | grep -q "7f 45 4c 46"; then
+exe_space="${link_tmpdir}/out with space"
+"$BINARY" --x86-64 --link -o "${exe_space}" "$DIR/fixtures/simple_add.c"
+if ! od -An -t x1 "${exe_space}" | head -n 1 | grep -q "7f 45 4c 46"; then
     echo "Test link_option_space failed"
     fail=1
 fi
-exe_semi="$link_tmpdir/out;semi"
-"$BINARY" --x86-64 --link -o "$exe_semi" "$DIR/fixtures/simple_add.c"
-if ! od -An -t x1 "$exe_semi" | head -n 1 | grep -q "7f 45 4c 46"; then
+exe_semi="${link_tmpdir}/out;semi"
+"$BINARY" --x86-64 --link -o "${exe_semi}" "$DIR/fixtures/simple_add.c"
+if ! od -An -t x1 "${exe_semi}" | head -n 1 | grep -q "7f 45 4c 46"; then
     echo "Test link_option_semi failed"
     fail=1
 fi
-rm -f "$exe_space" "$exe_semi"
-rmdir "$link_tmpdir"
+rm -f "${exe_space}" "${exe_semi}"
+rmdir "${link_tmpdir}"
 
 # test --std option
 std_out=$(mktemp)
-"$BINARY" --std=gnu99 -o "$std_out" "$DIR/fixtures/simple_add.c"
-if ! diff -u "$DIR/fixtures/simple_add.s" "$std_out" > /dev/null; then
+"$BINARY" --std=gnu99 -o "${std_out}" "$DIR/fixtures/simple_add.c"
+if ! diff -u "$DIR/fixtures/simple_add.s" "${std_out}" > /dev/null; then
     echo "Test std_gnu99 failed"
     fail=1
 fi
-rm -f "$std_out"
+rm -f "${std_out}"
 
 err=$(mktemp)
 set +e
-"$BINARY" --std=c23 -o "$std_out" "$DIR/fixtures/simple_add.c" 2> "$err"
+"$BINARY" --std=c23 -o "${std_out}" "$DIR/fixtures/simple_add.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Unknown standard" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Unknown standard" "${err}"; then
     echo "Test invalid_std failed"
     fail=1
 fi
-rm -f "$std_out" "$err"
+rm -f "${std_out}" "${err}"
 
 # invalid optimization level should fail
 err=$(mktemp)
 out=$(mktemp)
 set +e
-"$BINARY" -O4 -o "$out" "$DIR/fixtures/simple_add.c" 2> "$err"
+"$BINARY" -O4 -o "${out}" "$DIR/fixtures/simple_add.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Invalid optimization level" "$err"; then
+if [ $ret -eq 0 ] || ! grep -q "Invalid optimization level" "${err}"; then
     echo "Test invalid_opt_level failed"
     fail=1
 fi
-rm -f "$out" "$err"
+rm -f "${out}" "${err}"
 
 # test reading source from stdin
 stdin_out=$(mktemp)
-cat "$DIR/fixtures/simple_add.c" | "$BINARY" -o "$stdin_out" -
-if ! diff -u "$DIR/fixtures/simple_add.s" "$stdin_out" > /dev/null; then
+cat "$DIR/fixtures/simple_add.c" | "$BINARY" -o "${stdin_out}" -
+if ! diff -u "$DIR/fixtures/simple_add.s" "${stdin_out}" > /dev/null; then
     echo "Test stdin_source failed"
     fail=1
 fi
-rm -f "$stdin_out"
+rm -f "${stdin_out}"
 
 if [ $fail -eq 0 ]; then
     echo "All tests passed"


### PR DESCRIPTION
## Summary
- ensure mktemp file paths are quoted when used

## Testing
- `./tests/run.sh` *(fails: Assertion failed; Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68605e214d7883248e180220750bcc31