### PR TITLE
Fix path output on temp file error

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -460,13 +460,16 @@ static int create_temp_file(const cli_options_t *cli, const char *prefix,
     const char *dir = cli->obj_dir ? cli->obj_dir : "/tmp";
     size_t len = strlen(dir) + strlen(prefix) + 8; /* / prefix XXXXXX \0 */
     char *tmpl = malloc(len);
-    if (!tmpl)
+    if (!tmpl) {
+        *out_path = NULL;
         return -1;
+    }
     snprintf(tmpl, len, "%s/%sXXXXXX", dir, prefix);
     int fd = mkstemp(tmpl);
     if (fd < 0) {
         perror("mkstemp");
         free(tmpl);
+        *out_path = NULL;
         return -1;
     }
     *out_path = tmpl;


### PR DESCRIPTION
## Summary
- ensure `create_temp_file` resets path on failure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68606c60fbd08324924df022aa553c9e