### PR TITLE
Handle incomplete \x escapes in lexer

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -285,6 +285,8 @@ static int unescape_char(const char *src, size_t *i)
             (*i)++;
             digits++;
         }
+        if (digits == 0)
+            return 'x';
         return value;
     }
     default:

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -504,6 +504,21 @@ static void test_lexer_escapes(void)
     lexer_free_tokens(toks, count);
 }
 
+/* Hex escape with no digits should yield literal 'x' */
+static void test_lexer_invalid_hex_escape(void)
+{
+    const char *src = "'\\x'";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    ASSERT(toks[0].type == TOK_CHAR && toks[0].lexeme[0] == 'x');
+    lexer_free_tokens(toks, count);
+
+    const char *str_src = "\"\\x\"";
+    toks = lexer_tokenize(str_src, &count);
+    ASSERT(toks[0].type == TOK_STRING && strcmp(toks[0].lexeme, "x") == 0);
+    lexer_free_tokens(toks, count);
+}
+
 /* Unterminated character constant should yield an error token */
 static void test_lexer_char_missing_quote(void)
 {
@@ -575,6 +590,7 @@ int main(void)
     test_parser_bitfield();
     test_line_directive();
     test_lexer_escapes();
+    test_lexer_invalid_hex_escape();
     test_lexer_char_missing_quote();
     test_lexer_string_missing_quote();
     test_vector_large();


### PR DESCRIPTION
## Summary
- return the literal `x` if no hex digits follow `\x`
- test lexer behaviour for incomplete hex escapes

## Testing
- `tests/run.sh` *(fails: Assertion failed: toks[4].type == TOK_NUMBER && strcmp(toks[4].lexeme, "2.0") == 0; Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68606c851f64832486c3a849bada8680