### PR TITLE
Handle memory allocation failure in ir_build_glob_array

### DIFF
--- a/include/ir_global.h
+++ b/include/ir_global.h
@@ -19,9 +19,10 @@ void ir_build_glob_var(ir_builder_t *b, const char *name, long long value,
  * values are copied into the instruction and `is_static` controls
  * linkage.
  */
-void ir_build_glob_array(ir_builder_t *b, const char *name,
-                         const long long *values, size_t count,
-                         int is_static);
+/* Returns non-zero on success, zero on allocation failure. */
+int ir_build_glob_array(ir_builder_t *b, const char *name,
+                        const long long *values, size_t count,
+                        int is_static);
 
 /* Begin a global union using IR_GLOB_UNION. `size` specifies the type size. */
 void ir_build_glob_union(ir_builder_t *b, const char *name, int size,

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -388,9 +388,12 @@ static int emit_global_initializer(stmt_t *decl, symbol_t *sym,
                                       decl->var_decl.array_size, globals,
                                       decl->line, decl->column, &vals))
             return 0;
-        ir_build_glob_array(ir, decl->var_decl.name, vals,
-                            decl->var_decl.array_size,
-                            decl->var_decl.is_static);
+        if (!ir_build_glob_array(ir, decl->var_decl.name, vals,
+                                 decl->var_decl.array_size,
+                                 decl->var_decl.is_static)) {
+            free(vals);
+            return 0;
+        }
         free(vals);
         return 1;
     }

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -129,10 +129,10 @@ static int check_typedef_stmt(stmt_t *stmt, symtable_t *vars)
  * array contents are provided up front and written directly to the
  * global data section.
  */
-static void init_static_array(ir_builder_t *ir, const char *name,
-                              const long long *vals, size_t count)
+static int init_static_array(ir_builder_t *ir, const char *name,
+                             const long long *vals, size_t count)
 {
-    ir_build_glob_array(ir, name, vals, count, 1);
+    return ir_build_glob_array(ir, name, vals, count, 1);
 }
 
 /*
@@ -180,8 +180,12 @@ static int handle_array_init(stmt_t *stmt, symbol_t *sym, symtable_t *vars, ir_b
                                   sym->array_size, vars, stmt->line, stmt->column,
                                   &vals))
         return 0;
-    if (stmt->var_decl.is_static)
-        init_static_array(ir, sym->ir_name, vals, sym->array_size);
+    if (stmt->var_decl.is_static) {
+        if (!init_static_array(ir, sym->ir_name, vals, sym->array_size)) {
+            free(vals);
+            return 0;
+        }
+    }
     else
         init_dynamic_array(ir, sym->ir_name, vals, sym->array_size,
                            stmt->var_decl.is_volatile);


### PR DESCRIPTION
## Summary
- report failure from `ir_build_glob_array`
- clean up appended instruction when allocation fails
- propagate the new return value to callers

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68608ef8afa083249481ecbedd4660d8