### PR TITLE
Fix __STDC_VERSION__ expansion

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -232,6 +232,10 @@ static void read_number(const char *src, size_t *i, size_t *col,
     }
 
     size_t len = *i - start;
+    if (src[*i] == 'L' || src[*i] == 'l') {
+        (*i)++;
+        len++;
+    }
     append_token(tokens, TOK_NUMBER, src + start, len, line, *col);
     *col += len;
 }

--- a/src/preproc_macros.c
+++ b/src/preproc_macros.c
@@ -346,7 +346,7 @@ static int parse_macro_invocation(const char *line, size_t *pos,
         }
     } else if (len == 16 && strncmp(line + i, "__STDC_VERSION__", 16) == 0) {
         preproc_set_location(NULL, builtin_line, column);
-        strbuf_append(out, "199901");
+        strbuf_append(out, "199901L");
         *pos = j;
         return 1;
     }

--- a/tests/fixtures/builtin_version.c
+++ b/tests/fixtures/builtin_version.c
@@ -1,3 +1,3 @@
-int foo() {
+long foo() {
     return __STDC_VERSION__;
 }


### PR DESCRIPTION
## Summary
- expand `__STDC_VERSION__` as `199901L`
- allow the lexer to consume a trailing `L` suffix on numbers
- adjust builtin test to return a long value

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860b0ae49d88324aca38009f93fa7ab