### PR TITLE
Fix param_types allocation failure handling

### DIFF
--- a/src/parser_types.c
+++ b/src/parser_types.c
@@ -151,6 +151,8 @@ int parse_func_ptr_suffix(parser_t *p, char **name,
         *param_types = malloc(params_v.count * sizeof(type_kind_t));
         if (!*param_types) {
             vector_free(&params_v);
+            *param_types = NULL;
+            *param_count = 0;
             p->pos = start;
             return 0;
         }


### PR DESCRIPTION
## Summary
- return an error if `malloc` fails when allocating `param_types`
- reset `param_count` and `param_types` on failure so callers don't access invalid memory

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860b316ed008324b5555df747f17501