### PR TITLE
Fix temp file truncation handling

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -471,7 +471,13 @@ static int create_temp_file(const cli_options_t *cli, const char *prefix,
         *out_path = NULL;
         return -1;
     }
-    snprintf(tmpl, len, "%s/%sXXXXXX", dir, prefix);
+    int n = snprintf(tmpl, len, "%s/%sXXXXXX", dir, prefix);
+    if (n < 0 || (size_t)n >= len) {
+        free(tmpl);
+        *out_path = NULL;
+        errno = ENAMETOOLONG;
+        return -1;
+    }
     int fd = mkstemp(tmpl);
     if (fd < 0) {
         perror("mkstemp");


### PR DESCRIPTION
## Summary
- check snprintf result when creating temporary file paths
- abort if truncation occurs before calling `mkstemp`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860b30f4e5c83248f759b59d4807539