### PR TITLE
Ensure newline between preprocessed outputs

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -707,6 +707,9 @@ int run_preprocessor(const cli_options_t *cli)
             return 1;
         }
         printf("%s", text);
+        size_t len = strlen(text);
+        if (len == 0 || text[len - 1] != '\n')
+            putchar('\n');
         free(text);
     }
     return 0;


### PR DESCRIPTION
## Summary
- print a trailing newline after each preprocessed file if needed

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860b4820ed483249e995d12629ac0ff