### PR TITLE
Handle failed argument checks in calls

### DIFF
--- a/src/semantic_call.c
+++ b/src/semantic_call.c
@@ -65,6 +65,11 @@ type_kind_t check_call_expr(expr_t *expr, symtable_t *vars,
         type_kind_t at = check_expr(expr->call.args[i], vars, funcs, ir,
                                     &vals[i]);
         atypes[i] = at;
+        if (at == TYPE_UNKNOWN) {
+            free(vals);
+            free(atypes);
+            return TYPE_UNKNOWN;
+        }
         if (i < expected) {
             type_kind_t pt = ptypes[i];
             if (!(((is_intlike(pt) && is_intlike(at)) ||


### PR DESCRIPTION
## Summary
- exit `check_call_expr` early when any argument check fails

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860b49a8d0c832499c46db70ec34c02