### PR TITLE
Use strtoll for option parsing

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
+#include <limits.h>
+#include <errno.h>
 
 #include "cli.h"
 
@@ -105,9 +107,10 @@ static int add_include_dir(cli_options_t *opts, const char *dir)
  */
 static int set_opt_level(cli_options_t *opts, const char *level)
 {
+    errno = 0;
     char *end;
-    long val = strtol(level, &end, 10);
-    if (*end != '\0' || val < 0 || val > 3) {
+    long long val = strtoll(level, &end, 10);
+    if (*end != '\0' || errno != 0 || val < 0 || val > INT_MAX || val > 3) {
         fprintf(stderr, "Invalid optimization level '%s'\n", level);
         return 1;
     }

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -605,8 +605,8 @@ static int handle_line_directive(char *line, const char *dir, vector_t *macros,
         p++;
     errno = 0;
     char *end;
-    long val = strtol(p, &end, 10);
-    if (p == end || errno != 0 || val <= 0 || val > INT_MAX) {
+    long long val = strtoll(p, &end, 10);
+    if (p == end || errno != 0 || val > INT_MAX || val <= 0) {
         fprintf(stderr, "Invalid line number in #line directive\n");
         return 0;
     }


### PR DESCRIPTION
## Summary
- ensure numeric options use `strtoll`
- validate parsed values fit in `int`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860b770922883249f7d059c6b6522f3