### PR TITLE
Fix macro param leak when ')' missing

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -270,7 +270,7 @@ static char *parse_macro_params(char *p, vector_t *out)
             p = start - 1; /* restore '(' position */
             for (size_t i = 0; i < out->count; i++)
                 free(((char **)out->data)[i]);
-            vector_free(out);
+            free(out->data);
             vector_init(out, sizeof(char *));
         }
     } else if (*p) {

--- a/tests/fixtures/macro_bad_define.c
+++ b/tests/fixtures/macro_bad_define.c
@@ -1,0 +1,2 @@
+#define FOO(x
+int main() { return 0; }

--- a/tests/fixtures/macro_bad_define.s
+++ b/tests/fixtures/macro_bad_define.s
@@ -1,0 +1,9 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $0, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- avoid leaking vector memory when a closing parenthesis is missing in `#define`
- add a regression test that defines a malformed macro

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860b877acb88324b75894c1ad388825