### PR TITLE
Use strbuf for command error output

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -638,28 +638,15 @@ static int run_command(char *const argv[])
     int status;
     int ret = posix_spawnp(&pid, argv[0], NULL, NULL, argv, environ);
     if (ret != 0) {
-        char cmd[256];
-        size_t off = 0;
+        strbuf_t cmd;
+        strbuf_init(&cmd);
         for (size_t i = 0; argv[i]; i++) {
-            if (i > 0 && off + 1 < sizeof(cmd) - 4)
-                cmd[off++] = ' ';
-            const char *arg = argv[i];
-            size_t len = strlen(arg);
-            if (off + len >= sizeof(cmd) - 4) {
-                size_t avail = sizeof(cmd) - off - 4;
-                if (avail > 0) {
-                    memcpy(cmd + off, arg, avail);
-                    off += avail;
-                }
-                memcpy(cmd + off, "...", 4);
-                off += 3;
-                break;
-            }
-            memcpy(cmd + off, arg, len);
-            off += len;
+            if (i > 0)
+                strbuf_append(&cmd, " ");
+            strbuf_append(&cmd, argv[i]);
         }
-        cmd[off] = '\0';
-        fprintf(stderr, "posix_spawnp %s: %s\n", cmd, strerror(ret));
+        fprintf(stderr, "posix_spawnp %s: %s\n", cmd.data, strerror(ret));
+        strbuf_free(&cmd);
         return 0;
     }
     if (waitpid(pid, &status, 0) < 0) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -318,6 +318,21 @@ if [ $ret -eq 0 ] || ! grep -q "Invalid optimization level" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# regression test for long command error message
+long_tmpdir=$(mktemp -d)
+long_out="$long_tmpdir/$(printf 'a%.0s' {1..50})/$(printf 'b%.0s' {1..50})/$(printf 'c%.0s' {1..50})/$(printf 'd%.0s' {1..50})/$(printf 'e%.0s' {1..50})/out.o"
+mkdir -p "$(dirname "$long_out")"
+err=$(mktemp)
+set +e
+PATH=/nonexistent "$BINARY" -c -o "$long_out" "$DIR/fixtures/simple_add.c" 2> "$err"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "$long_out" "$err"; then
+    echo "Test long_command_error failed"
+    fail=1
+fi
+rm -rf "$long_tmpdir" "$err"
+
 # test reading source from stdin
 stdin_out=$(mktemp)
 cat "$DIR/fixtures/simple_add.c" | "$BINARY" -o "${stdin_out}" -


### PR DESCRIPTION
## Summary
- replace fixed command buffer with dynamic `strbuf_t`
- ensure command string is always fully printed when spawning fails
- add regression test for long command error output

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860bb4d6c988324be5ccd120342d90c