### PR TITLE
Improve CLI error handling for vector push failures

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -78,26 +78,26 @@ static void init_default_opts(cli_options_t *opts)
 
 /*
  * Append a source file path to "opts->sources".  Returns 0 on success and
- * 1 on out-of-memory failure.
+ * non-zero on failure.
  */
 static int push_source(cli_options_t *opts, const char *src)
 {
     if (!vector_push(&opts->sources, &src)) {
         fprintf(stderr, "Out of memory\n");
-        return 1;
+        return -1;
     }
     return 0;
 }
 
 /*
  * Add an include directory to "opts->include_dirs". Returns 0 on success
- * and 1 on out-of-memory failure.
+ * and non-zero on failure.
  */
 static int add_include_dir(cli_options_t *opts, const char *dir)
 {
     if (!vector_push(&opts->include_dirs, &dir)) {
         fprintf(stderr, "Out of memory\n");
-        return 1;
+        return -1;
     }
     return 0;
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -12,7 +12,15 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/symtable_globals.c src/symtable_struct.c src/ast_clone.c \
     src/ast_expr.c src/ast_stmt.c src/lexer.c src/util.c \
     src/vector.c src/error.c
+# build cli unit test binary with vector_push wrapper
+cc -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push -c src/cli.c -o cli_test.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_cli.c" -o "$DIR/test_cli.o"
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_test.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_test.o
+cc -o "$DIR/cli_tests" cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
+rm -f cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
 # run unit tests
 "$DIR/unit_tests"
+"$DIR/cli_tests"
 # run integration tests
 "$DIR/run_tests.sh"

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "cli.h"
+#include "vector.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+/* wrapper for vector_push allowing failure injection */
+extern int vector_push(vector_t *vec, const void *elem); /* real impl */
+static int fail_push = 0;
+int test_vector_push(vector_t *vec, const void *elem)
+{
+    if (fail_push)
+        return 0;
+    return vector_push(vec, elem);
+}
+
+static void test_parse_success(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "-o", "out.s", "file.c", NULL};
+    int ret = cli_parse_args(4, argv, &opts);
+    ASSERT(ret == 0);
+    ASSERT(opts.sources.count == 1);
+    ASSERT(strcmp(((char **)opts.sources.data)[0], "file.c") == 0);
+    vector_free(&opts.sources);
+    vector_free(&opts.include_dirs);
+}
+
+static void test_parse_failure(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "file.c", NULL};
+    fail_push = 1;
+    FILE *tmp = tmpfile();
+    int saved = dup(fileno(stderr));
+    dup2(fileno(tmp), fileno(stderr));
+
+    int ret = cli_parse_args(2, argv, &opts);
+
+    fflush(stderr);
+    fseek(tmp, 0, SEEK_SET);
+    char buf[256];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    buf[n] = '\0';
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+    fclose(tmp);
+    fail_push = 0;
+
+    ASSERT(ret != 0);
+    ASSERT(strstr(buf, "Out of memory") != NULL);
+}
+
+int main(void)
+{
+    test_parse_success();
+    test_parse_failure();
+    if (failures == 0)
+        printf("All cli tests passed\n");
+    else
+        printf("%d cli test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- update `push_source` and `add_include_dir` to return an error when `vector_push` fails
- add CLI unit test exercising failure path via `vector_push` mock
- build and run new CLI test in `tests/run.sh`

## Testing
- `make clean >/dev/null && ./tests/run.sh > /tmp/test.log && tail -n 5 /tmp/test.log` *(fails: `Assertion failed` and `Segmentation fault`)*

------
https://chatgpt.com/codex/tasks/task_e_6860bb6d1d8c83249a9668135912da32