### PR TITLE
Add include cycle search path test

### DIFF
--- a/tests/includes/cycle1.h
+++ b/tests/includes/cycle1.h
@@ -1,0 +1,4 @@
+#ifndef CYCLE1_H
+#define CYCLE1_H
+#include "cycle2.h"
+#endif

--- a/tests/includes/cycle2.h
+++ b/tests/includes/cycle2.h
@@ -1,0 +1,4 @@
+#ifndef CYCLE2_H
+#define CYCLE2_H
+#include "cycle1.h"
+#endif

--- a/tests/invalid/include_cycle_search.c
+++ b/tests/invalid/include_cycle_search.c
@@ -1,0 +1,2 @@
+#include "cycle1.h"
+int main() { return 0; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -181,6 +181,19 @@ if [ $ret -eq 0 ] || ! grep -q "Include cycle detected" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# negative test for include cycle through search path
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -I "$DIR/includes" -o "${out}" "$DIR/invalid/include_cycle_search.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Include cycle detected" "${err}"; then
+    echo "Test include_cycle_search failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 # negative test for macro recursion limit
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- add cyclical headers under `tests/includes`
- add invalid source referencing the cyclical header
- extend `run_tests.sh` with a test ensuring include cycle errors occur even with an include path

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860bc82f8088324b76c8f7a0e828b84