### PR TITLE
Check vector_push failures in macro parser

### DIFF
--- a/src/preproc_macros.c
+++ b/src/preproc_macros.c
@@ -244,7 +244,10 @@ static int parse_macro_args(const char *line, size_t *pos, vector_t *out)
             while (end > a && (line[end - 1] == ' ' || line[end - 1] == '\t'))
                 end--;
             char *dup = vc_strndup(line + a, end - a);
-            vector_push(out, &dup);
+            if (!vector_push(out, &dup)) {
+                free(dup);
+                goto fail;
+            }
             *pos = p + 1;
             return 1;
         }
@@ -256,7 +259,10 @@ static int parse_macro_args(const char *line, size_t *pos, vector_t *out)
             while (end > a && (line[end - 1] == ' ' || line[end - 1] == '\t'))
                 end--;
             char *dup = vc_strndup(line + a, end - a);
-            vector_push(out, &dup);
+            if (!vector_push(out, &dup)) {
+                free(dup);
+                goto fail;
+            }
             p++; /* skip ',' */
             while (line[p] == ' ' || line[p] == '\t')
                 p++;
@@ -265,6 +271,11 @@ static int parse_macro_args(const char *line, size_t *pos, vector_t *out)
             continue;
         }
     }
+fail:
+    for (size_t i = 0; i < out->count; i++)
+        free(((char **)out->data)[i]);
+    vector_free(out);
+    return 0;
 }
 
 /* Expand a macro invocation and append the result to "out". */


### PR DESCRIPTION
## Summary
- ensure `parse_macro_args` handles failed pushes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860c8c731308324a4100f0f1713f31a