### PR TITLE
Fix truncated escape sequence handling in lexer

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -247,6 +247,9 @@ static void read_number(const char *src, size_t *i, size_t *col,
  */
 static int unescape_char(const char *src, size_t *i)
 {
+    if (!src[*i])
+        return 0;
+
     char c = src[*i];
     switch (c) {
     case 'n':

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -524,6 +524,21 @@ static void test_lexer_string_missing_quote(void)
     lexer_free_tokens(toks, count);
 }
 
+/* Unterminated escape sequence should not crash the lexer */
+static void test_lexer_truncated_escape(void)
+{
+    const char *char_src = "'\\";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(char_src, &count);
+    ASSERT(toks[0].type == TOK_UNKNOWN);
+    lexer_free_tokens(toks, count);
+
+    const char *str_src = "\"\\";
+    toks = lexer_tokenize(str_src, &count);
+    ASSERT(toks[0].type == TOK_UNKNOWN);
+    lexer_free_tokens(toks, count);
+}
+
 /* Ensure the vector grows correctly for large element counts */
 static void test_vector_large(void)
 {
@@ -588,6 +603,7 @@ int main(void)
     test_lexer_escapes();
     test_lexer_char_missing_quote();
     test_lexer_string_missing_quote();
+    test_lexer_truncated_escape();
     test_vector_zero_elem_size();
     test_vector_large();
     if (failures == 0) {


### PR DESCRIPTION
## Summary
- prevent `unescape_char` from reading past the end of input
- add regression test for truncated escape sequences in character and string literals

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860cb874b8c8324846a1ac8d0ccde16