### PR TITLE
Handle IR builder wstring malloc failure

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,8 +19,16 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_test.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_test.o
 cc -o "$DIR/cli_tests" cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
 rm -f cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
+# build ir_core unit test binary with malloc wrapper
+cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c src/ir_core.c -o ir_core_test.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_ircore.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/label.c -o label_ircore.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_ir_core.c" -o "$DIR/test_ir_core.o"
+cc -o "$DIR/ir_core_tests" ir_core_test.o util_ircore.o label_ircore.o "$DIR/test_ir_core.o"
+rm -f ir_core_test.o util_ircore.o label_ircore.o "$DIR/test_ir_core.o"
 # run unit tests
 "$DIR/unit_tests"
 "$DIR/cli_tests"
+"$DIR/ir_core_tests"
 # run integration tests
 "$DIR/run_tests.sh"

--- a/tests/unit/test_ir_core.c
+++ b/tests/unit/test_ir_core.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "ir_core.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+extern void *malloc(size_t size); /* real malloc */
+static int fail_malloc = 0;
+void *test_malloc(size_t size)
+{
+    if (fail_malloc)
+        return NULL;
+    return malloc(size);
+}
+
+static void test_wstring_alloc_fail(void)
+{
+    ir_builder_t b;
+    ir_builder_init(&b);
+    fail_malloc = 1;
+    ir_value_t v = ir_build_wstring(&b, "abc");
+    ASSERT(v.id == 0);
+    ASSERT(b.head == NULL && b.tail == NULL);
+    fail_malloc = 0;
+    ir_builder_free(&b);
+}
+
+int main(void)
+{
+    test_wstring_alloc_fail();
+    if (failures == 0)
+        printf("All ir_core tests passed\n");
+    else
+        printf("%d ir_core test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- clean up wide string IR emission when memory allocation fails
- add a unit test to ensure the builder remains consistent
- extend `tests/run.sh` to build and run the new unit test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860ce0621708324b6a09706eabc81c7