### PR TITLE
Fix string literal terminator handling

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -374,11 +374,18 @@ static void read_string_lit(const char *src, size_t *i, size_t *col,
         }
         (*col)++;
     }
+    /* NUL-terminate the buffer for convenience */
+    char nul = '\0';
+    if (!vector_push(&buf_v, &nul)) {
+        vector_free(&buf_v);
+        return;
+    }
     if (src[*i] == '"') {
         (*i)++;
         (*col)++;
 
-        append_token(tokens, tok_type, buf_v.data, buf_v.count, line, column);
+        append_token(tokens, tok_type, buf_v.data, buf_v.count - 1,
+                     line, column);
         vector_free(&buf_v);
     } else {
         error_set(line, column, error_current_file, error_current_function);


### PR DESCRIPTION
## Summary
- ensure buffers used for string literals are explicitly NUL terminated
- pass correct length to `append_token`

## Testing
- `make -j4`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860d5c8fc848324ba0a9b0c08738fad