### PR TITLE
Fix inline analysis abort on missing source file

### DIFF
--- a/src/opt_inline.c
+++ b/src/opt_inline.c
@@ -167,10 +167,11 @@ static int collect_funcs(ir_builder_t *ir, inline_func_t **out, size_t *count)
             } else if (r < 0) {
                 char msg[256];
                 snprintf(msg, sizeof(msg),
-                         "could not open %s for inline check; "
-                         "treating %s as non-inline",
-                         src_file, ins->name);
+                         "could not open %s for inline check", src_file);
                 opt_error(msg);
+                free(*out);
+                *out = NULL;
+                return 0;
             }
         }
         if (!is_inline) {


### PR DESCRIPTION
## Summary
- abort `collect_funcs` when the source file cannot be opened

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860e15a664083249ab302da02ea25dc