### PR TITLE
Update float evaluation and fix CLI tests

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -328,6 +328,9 @@ static int handle_option(int opt, const char *arg, const char *prog,
  */
 int cli_parse_args(int argc, char **argv, cli_options_t *opts)
 {
+    /* getopt_long maintains state between calls, reset for reuse */
+    optind = 1;
+
     static struct option long_opts[] = {
         {"help",    no_argument,       0, 'h'},
         {"version", no_argument,       0, 'v'},
@@ -363,15 +366,15 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         return 1;
     }
 
+    for (int i = optind; i < argc; i++) {
+        if (push_source(opts, argv[i]))
+            return 1;
+    }
+
     if (!opts->output && !opts->dump_asm && !opts->dump_ir && !opts->preprocess) {
         fprintf(stderr, "Error: no output path specified.\n");
         print_usage(argv[0]);
         return 1;
-    }
-
-    for (int i = optind; i < argc; i++) {
-        if (push_source(opts, argv[i]))
-            return 1;
     }
 
     return 0;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -217,6 +217,7 @@ static void read_number(const char *src, size_t *i, size_t *col,
                         vector_t *tokens, size_t line)
 {
     size_t start = *i;
+    int is_float = 0;
 
     if (src[*i] == '0' && (src[*i + 1] == 'x' || src[*i + 1] == 'X')) {
         (*i) += 2; /* consume 0x */
@@ -231,11 +232,29 @@ static void read_number(const char *src, size_t *i, size_t *col,
             (*i)++;
     }
 
-    size_t len = *i - start;
-    if (src[*i] == 'L' || src[*i] == 'l') {
-        (*i)++;
-        len++;
+    if (src[*i] == '.') {
+        is_float = 1;
+        (*i)++; /* consume '.' */
+        while (isdigit((unsigned char)src[*i]))
+            (*i)++;
     }
+
+    if (src[*i] == 'e' || src[*i] == 'E') {
+        is_float = 1;
+        (*i)++; /* consume exponent marker */
+        if (src[*i] == '+' || src[*i] == '-')
+            (*i)++;
+        while (isdigit((unsigned char)src[*i]))
+            (*i)++;
+    }
+
+    if (src[*i] == 'f' || src[*i] == 'F' ||
+        src[*i] == 'l' || src[*i] == 'L') {
+        (*i)++;
+    }
+
+    size_t len = *i - start;
+    (void)is_float; /* not used but kept for clarity */
     append_token(tokens, TOK_NUMBER, src + start, len, line, *col);
     *col += len;
 }

--- a/src/opt_fold.c
+++ b/src/opt_fold.c
@@ -38,15 +38,24 @@ static int eval_int_op(ir_op_t op, int a, int b)
 /* Evaluate a binary floating point op for constant folding */
 static int eval_float_op(ir_op_t op, int a, int b)
 {
-    union { float f; int i; } fa = {.i = a}, fb = {.i = b}, res;
+    float fa = 0.0f;
+    float fb = 0.0f;
+    float res;
+
+    memcpy(&fa, &a, sizeof(fa));
+    memcpy(&fb, &b, sizeof(fb));
+
     switch (op) {
-    case IR_FADD: res.f = fa.f + fb.f; break;
-    case IR_FSUB: res.f = fa.f - fb.f; break;
-    case IR_FMUL: res.f = fa.f * fb.f; break;
-    case IR_FDIV: res.f = fb.f != 0.0f ? fa.f / fb.f : 0.0f; break;
-    default: res.i = 0; break;
+    case IR_FADD: res = fa + fb; break;
+    case IR_FSUB: res = fa - fb; break;
+    case IR_FMUL: res = fa * fb; break;
+    case IR_FDIV: res = fb != 0.0f ? fa / fb : 0.0f; break;
+    default:      res = 0.0f; break;
     }
-    return res.i;
+
+    int out = 0;
+    memcpy(&out, &res, sizeof(out));
+    return out;
 }
 
 /* Evaluate a binary long double op for constant folding */

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -43,8 +43,10 @@ rm -f strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
 "$DIR/unit_tests"
 "$DIR/cli_tests"
 "$DIR/ir_core_tests"
+# last unit test binary
 "$DIR/cond_expr_tests"
-=======
+# separator for clarity
+echo "======="
 # regression test for strbuf overflow handling
 err=$(mktemp)
 set +e

--- a/tests/unit/test_strbuf_overflow.c
+++ b/tests/unit/test_strbuf_overflow.c
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <stdint.h>
 #include "strbuf.h"
 
 int main(void)


### PR DESCRIPTION
## Summary
- parse floating point literals with decimals and exponents
- reset getopt state and reorder source checks in `cli_parse_args`
- comment separator line in run.sh so tests continue

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860e3a2a5a0832492a55e2df90e504f