### PR TITLE
Enforce macro depth limit exactly

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -37,8 +37,8 @@ any argument list and calls `expand_macro_call` so expansion remains recursive.
 lookup, handle the `#` stringize operator and manage `##` token pasting.
 Macro expansion is recursive so macro bodies may reference other macros. To
 avoid infinite loops a hard limit of 100 nested expansions is enforced. The
-compiler aborts preprocessing with an error message when this depth is
-exceeded.
+compiler aborts preprocessing with an error message as soon as this depth is
+reached.
 
 Conditional expressions in `#if` directives are parsed by the small recursive
 descent parser in `preproc_expr.c`.  The `defined` operator queries the current

--- a/src/preproc_macros.c
+++ b/src/preproc_macros.c
@@ -312,7 +312,7 @@ static int parse_macro_invocation(const char *line, size_t *pos,
                                   vector_t *macros, strbuf_t *out,
                                   size_t column, int depth)
 {
-    if (depth > MAX_MACRO_DEPTH) {
+    if (depth >= MAX_MACRO_DEPTH) {
         fprintf(stderr, "Macro expansion limit exceeded\n");
         return 0;
     }
@@ -406,7 +406,7 @@ static int parse_macro_invocation(const char *line, size_t *pos,
  */
 void expand_line(const char *line, vector_t *macros, strbuf_t *out, size_t column, int depth)
 {
-    if (depth > MAX_MACRO_DEPTH) {
+    if (depth >= MAX_MACRO_DEPTH) {
         fprintf(stderr, "Macro expansion limit exceeded\n");
         return;
     }


### PR DESCRIPTION
## Summary
- stop macro expansion when recursion depth reaches `MAX_MACRO_DEPTH`
- document that reaching 100 nested expansions triggers the error

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861b54a48bc8324b0f5102dcf427191