### PR TITLE
Fix inline check error handling

### DIFF
--- a/src/opt_inline.c
+++ b/src/opt_inline.c
@@ -28,11 +28,13 @@ typedef struct {
  */
 static int is_inline_def(const char *file, const char *name)
 {
-    FILE *f = fopen(file, "r");
-    if (!f)
-        return -1;
-
     char *line = NULL;
+    FILE *f = fopen(file, "r");
+    if (!f) {
+        free(line);
+        return -1;
+    }
+
     size_t len = 0;
     ssize_t nread;
     int in_comment = 0;
@@ -110,6 +112,12 @@ static int is_inline_def(const char *file, const char *name)
             }
         }
         break; /* processed definition line */
+    }
+
+    if (ferror(f)) {
+        free(line);
+        fclose(f);
+        return -1;
     }
 
     free(line);


### PR DESCRIPTION
## Summary
- make is_inline_def free its line buffer on all exits
- detect getline errors using ferror and propagate the failure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861cffefa448324b1e4d6856ae22cff