### PR TITLE
Handle signaled child processes in run_command

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -668,6 +668,11 @@ static int run_command(char *const argv[])
         perror("waitpid");
         return 0;
     }
+    if (WIFSIGNALED(status)) {
+        fprintf(stderr, "%s terminated by signal %d\n", argv[0],
+                WTERMSIG(status));
+        return 0;
+    }
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
         return 0;
     return 1;


### PR DESCRIPTION
## Summary
- improve run_command error handling
- report terminating signals and fail when commands exit via signal

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861d00643a483248d7da831820d6a74