### PR TITLE
Fix object cleanup for invalid compile in link mode

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -647,7 +647,7 @@ static int compile_source_files(const cli_options_t *cli, vector_t *objs)
             unlink(((char **)objs->data)[j]);
             free(((char **)objs->data)[j]);
         }
-        vector_free(objs);
+        objs->count = 0;
     }
 
     return ok;
@@ -761,7 +761,7 @@ int link_sources(const cli_options_t *cli)
         unlink(((char **)objs.data)[i]);
         free(((char **)objs.data)[i]);
     }
-    free(objs.data);
+    vector_free(&objs);
 
     return ok;
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -394,6 +394,19 @@ if ! diff -u "$DIR/fixtures/simple_add.s" "${stdin_out}" > /dev/null; then
 fi
 rm -f "${stdin_out}"
 
+# regression test for invalid source with --link (double free)
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" --link -o "${out}" "$DIR/invalid/parse_error.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || grep -qi "double free" "${err}"; then
+    echo "Test link_invalid_double_free failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 if [ $fail -eq 0 ]; then
     echo "All tests passed"
 else


### PR DESCRIPTION
## Summary
- adjust compile_source_files() cleanup to let caller free the vector
- free temporary object list once in link_sources()
- add regression test ensuring invalid files with --link do not crash

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861d74f243c832490cfe28cf3323e61