### PR TITLE
Fix param list cleanup on alloc failure

### DIFF
--- a/src/parser_core.c
+++ b/src/parser_core.c
@@ -213,6 +213,8 @@ static int parse_param_list(parser_t *p,
                 !vector_push(&types_v, &pt) ||
                 !vector_push(&sizes_v, &ps) ||
                 !vector_push(&restrict_v, &is_restrict)) {
+                for (size_t i = 0; i < names_v.count; i++)
+                    free(((char **)names_v.data)[i]);
                 vector_free(&names_v);
                 vector_free(&types_v);
                 vector_free(&sizes_v);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,6 +19,28 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_test.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_test.o
 cc -o "$DIR/cli_tests" cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
 rm -f cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
+# build parser alloc failure unit test with vector_push wrapper
+cc -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push -c src/parser_core.c -o parser_core_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_init.c -o parser_init_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_decl.c -o parser_decl_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_flow.c -o parser_flow_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_toplevel.c -o parser_toplevel_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_expr.c -o parser_expr_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_stmt.c -o parser_stmt_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_types.c -o parser_types_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/symtable_core.c -o symtable_core_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/symtable_globals.c -o symtable_globals_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/symtable_struct.c -o symtable_struct_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/ast_clone.c -o ast_clone_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/ast_expr.c -o ast_expr_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/ast_stmt.c -o ast_stmt_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/lexer.c -o lexer_alloc.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_alloc.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_alloc.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_alloc.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_parser_alloc_fail.c" -o "$DIR/test_parser_alloc_fail.o"
+cc -o "$DIR/parser_alloc_tests" parser_core_fail.o parser_init_fail.o parser_decl_fail.o parser_flow_fail.o parser_toplevel_fail.o parser_expr_fail.o parser_stmt_fail.o parser_types_fail.o symtable_core_fail.o symtable_globals_fail.o symtable_struct_fail.o ast_clone_fail.o ast_expr_fail.o ast_stmt_fail.o lexer_alloc.o vector_alloc.o util_alloc.o error_alloc.o "$DIR/test_parser_alloc_fail.o"
+rm -f parser_core_fail.o parser_init_fail.o parser_decl_fail.o parser_flow_fail.o parser_toplevel_fail.o parser_expr_fail.o parser_stmt_fail.o parser_types_fail.o symtable_core_fail.o symtable_globals_fail.o symtable_struct_fail.o ast_clone_fail.o ast_expr_fail.o ast_stmt_fail.o lexer_alloc.o vector_alloc.o util_alloc.o error_alloc.o "$DIR/test_parser_alloc_fail.o"
 # build ir_core unit test binary with malloc wrapper
 cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c src/ir_core.c -o ir_core_test.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_ircore.o
@@ -42,6 +64,7 @@ rm -f strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
 # run unit tests
 "$DIR/unit_tests"
 "$DIR/cli_tests"
+"$DIR/parser_alloc_tests"
 "$DIR/ir_core_tests"
 # last unit test binary
 "$DIR/cond_expr_tests"

--- a/tests/unit/test_parser_alloc_fail.c
+++ b/tests/unit/test_parser_alloc_fail.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <string.h>
+#include "parser_core.h"
+#include "token.h"
+#include "vector.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+extern int vector_push(vector_t *vec, const void *elem); /* real impl */
+static int fail_push = 0;
+int test_vector_push(vector_t *vec, const void *elem)
+{
+    if (fail_push)
+        return 0;
+    return vector_push(vec, elem);
+}
+
+static void test_param_alloc_fail(void)
+{
+    const char *src = "int f(int a)"; /* body not needed, param push will fail */
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    fail_push = 1;
+    func_t *fn = parser_parse_func(&p, 0);
+    ASSERT(fn == NULL);
+    fail_push = 0;
+    lexer_free_tokens(toks, count);
+}
+
+int main(void)
+{
+    test_param_alloc_fail();
+    if (failures == 0)
+        printf("All parser alloc tests passed\n");
+    else
+        printf("%d parser alloc test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- free parameter name strings when allocation fails in `parse_param_list`
- test parser failure path using `vector_push` injection

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861d76f7d08832491fe474f3f0175bd