### PR TITLE
Check snprintf return in label formatting

### DIFF
--- a/include/label.h
+++ b/include/label.h
@@ -17,10 +17,16 @@ int label_next_id(void);
 /* Reset label numbering back to zero. */
 void label_reset(void);
 
-/* Format a label as prefix followed by id. */
+/*
+ * Format a label as prefix followed by id.  Returns NULL and reports an
+ * error if the result would exceed 31 characters.
+ */
 const char *label_format(const char *prefix, int id, char buf[32]);
 
-/* Format a label as prefix + id + suffix. */
+/*
+ * Format a label as prefix + id + suffix.  Returns NULL and reports an error
+ * if the result would exceed 31 characters.
+ */
 const char *label_format_suffix(const char *prefix, int id, const char *suffix,
                                 char buf[32]);
 

--- a/src/codegen_arith.c
+++ b/src/codegen_arith.c
@@ -233,8 +233,9 @@ static void emit_logand(strbuf_t *sb, ir_instr_t *ins,
     int id = label_next_id();
     char fl[32];
     char end[32];
-    label_format_suffix("L", id, "_false", fl);
-    label_format_suffix("L", id, "_end", end);
+    if (!label_format_suffix("L", id, "_false", fl) ||
+        !label_format_suffix("L", id, "_end", end))
+        return;
     strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
                    loc_str(b1, ra, ins->src1, x64),
                    loc_str(b2, ra, ins->dest, x64));
@@ -266,8 +267,9 @@ static void emit_logor(strbuf_t *sb, ir_instr_t *ins,
     int id = label_next_id();
     char tl[32];
     char end[32];
-    label_format_suffix("L", id, "_true", tl);
-    label_format_suffix("L", id, "_end", end);
+    if (!label_format_suffix("L", id, "_true", tl) ||
+        !label_format_suffix("L", id, "_end", end))
+        return;
     strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
                    loc_str(b1, ra, ins->src1, x64),
                    loc_str(b2, ra, ins->dest, x64));

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -139,7 +139,12 @@ ir_value_t ir_build_string(ir_builder_t *b, const char *str)
     ins->op = IR_GLOB_STRING;
     ins->dest = alloc_value_id(b);
     char label[32];
-    ins->name = vc_strdup(label_format("Lstr", ins->dest, label));
+    const char *fmt = label_format("Lstr", ins->dest, label);
+    if (!fmt) {
+        remove_instr(b, ins);
+        return (ir_value_t){0};
+    }
+    ins->name = vc_strdup(fmt);
     ins->data = vc_strdup(str ? str : "");
     return (ir_value_t){ins->dest};
 }
@@ -156,7 +161,12 @@ ir_value_t ir_build_wstring(ir_builder_t *b, const char *str)
     ins->op = IR_GLOB_WSTRING;
     ins->dest = alloc_value_id(b);
     char label[32];
-    ins->name = vc_strdup(label_format("LWstr", ins->dest, label));
+    const char *fmt = label_format("LWstr", ins->dest, label);
+    if (!fmt) {
+        remove_instr(b, ins);
+        return (ir_value_t){0};
+    }
+    ins->name = vc_strdup(fmt);
     size_t len = strlen(str ? str : "");
     long long *vals = malloc((len + 1) * sizeof(long long));
     if (!vals) {

--- a/src/label.c
+++ b/src/label.c
@@ -7,6 +7,7 @@
 
 #include "label.h"
 #include <stdio.h>
+#include "error.h"
 
 /* Next label identifier to issue. */
 static int next_label_id = 0;
@@ -38,7 +39,13 @@ void label_reset(void)
 /* Format a label combining prefix and id.  "buf" must have space for 32 bytes. */
 const char *label_format(const char *prefix, int id, char buf[32])
 {
-    snprintf(buf, 32, "%s%d", prefix, id);
+    int n = snprintf(buf, 32, "%s%d", prefix, id);
+    if (n < 0 || n >= 32) {
+        error_set(0, 0, error_current_file, error_current_function);
+        error_print("Generated label name too long");
+        buf[31] = '\0';
+        return NULL;
+    }
     return buf;
 }
 
@@ -46,6 +53,12 @@ const char *label_format(const char *prefix, int id, char buf[32])
 const char *label_format_suffix(const char *prefix, int id, const char *suffix,
                                 char buf[32])
 {
-    snprintf(buf, 32, "%s%d%s", prefix, id, suffix);
+    int n = snprintf(buf, 32, "%s%d%s", prefix, id, suffix);
+    if (n < 0 || n >= 32) {
+        error_set(0, 0, error_current_file, error_current_function);
+        error_print("Generated label name too long");
+        buf[31] = '\0';
+        return NULL;
+    }
     return buf;
 }

--- a/src/semantic_expr.c
+++ b/src/semantic_expr.c
@@ -152,9 +152,13 @@ static type_kind_t check_cond_expr(expr_t *expr, symtable_t *vars,
 
     char flabel[32], endlabel[32], tmp[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_false", flabel);
-    label_format_suffix("L", id, "_end", endlabel);
-    label_format("tmp", id, tmp);
+    if (!label_format_suffix("L", id, "_false", flabel) ||
+        !label_format_suffix("L", id, "_end", endlabel) ||
+        !label_format("tmp", id, tmp)) {
+        if (out)
+            *out = (ir_value_t){0};
+        return TYPE_UNKNOWN;
+    }
     ir_build_bcond(ir, cond_val, flabel);
 
     ir_value_t tval;

--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -32,8 +32,9 @@ int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     char start_label[32];
     char end_label[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_start", start_label);
-    label_format_suffix("L", id, "_end", end_label);
+    if (!label_format_suffix("L", id, "_start", start_label) ||
+        !label_format_suffix("L", id, "_end", end_label))
+        return 0;
     ir_build_label(ir, start_label);
     if (check_expr(stmt->while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
@@ -61,9 +62,10 @@ int check_do_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     char cond_label[32];
     char end_label[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_start", start_label);
-    label_format_suffix("L", id, "_cond", cond_label);
-    label_format_suffix("L", id, "_end", end_label);
+    if (!label_format_suffix("L", id, "_start", start_label) ||
+        !label_format_suffix("L", id, "_cond", cond_label) ||
+        !label_format_suffix("L", id, "_end", end_label))
+        return 0;
     ir_build_label(ir, start_label);
     if (!check_stmt(stmt->do_while_stmt.body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cond_label))
@@ -92,8 +94,9 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     char start_label[32];
     char end_label[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_start", start_label);
-    label_format_suffix("L", id, "_end", end_label);
+    if (!label_format_suffix("L", id, "_start", start_label) ||
+        !label_format_suffix("L", id, "_end", end_label))
+        return 0;
     symbol_t *old_head = vars->head;
     if (stmt->for_stmt.init_decl) {
         if (!check_stmt(stmt->for_stmt.init_decl, vars, funcs, labels, ir,
@@ -114,7 +117,10 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     }
     ir_build_bcond(ir, cond_val, end_label);
     char cont_label[32];
-    label_format_suffix("L", id, "_cont", cont_label);
+    if (!label_format_suffix("L", id, "_cont", cont_label)) {
+        symtable_pop_scope(vars, old_head);
+        return 0;
+    }
     if (!check_stmt(stmt->for_stmt.body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cont_label)) {
         symtable_pop_scope(vars, old_head);


### PR DESCRIPTION
## Summary
- validate `snprintf` results in `label_format` and `label_format_suffix`
- document possible failure in `label.h`
- propagate errors to callers across the codebase

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861e4ba89a48324bf447fa0460a2ee9