### PR TITLE
Handle snprintf truncation in label generation

### DIFF
--- a/include/label.h
+++ b/include/label.h
@@ -17,10 +17,16 @@ int label_next_id(void);
 /* Reset label numbering back to zero. */
 void label_reset(void);
 
-/* Format a label as prefix followed by id. */
+/*
+ * Format a label as prefix followed by id.
+ * Returns NULL if the text does not fit in the buffer.
+ */
 const char *label_format(const char *prefix, int id, char buf[32]);
 
-/* Format a label as prefix + id + suffix. */
+/*
+ * Format a label as prefix + id + suffix.
+ * Returns NULL if the text does not fit in the buffer.
+ */
 const char *label_format_suffix(const char *prefix, int id, const char *suffix,
                                 char buf[32]);
 

--- a/src/codegen_arith.c
+++ b/src/codegen_arith.c
@@ -233,8 +233,9 @@ static void emit_logand(strbuf_t *sb, ir_instr_t *ins,
     int id = label_next_id();
     char fl[32];
     char end[32];
-    label_format_suffix("L", id, "_false", fl);
-    label_format_suffix("L", id, "_end", end);
+    if (!label_format_suffix("L", id, "_false", fl) ||
+        !label_format_suffix("L", id, "_end", end))
+        return;
     strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
                    loc_str(b1, ra, ins->src1, x64),
                    loc_str(b2, ra, ins->dest, x64));
@@ -266,8 +267,9 @@ static void emit_logor(strbuf_t *sb, ir_instr_t *ins,
     int id = label_next_id();
     char tl[32];
     char end[32];
-    label_format_suffix("L", id, "_true", tl);
-    label_format_suffix("L", id, "_end", end);
+    if (!label_format_suffix("L", id, "_true", tl) ||
+        !label_format_suffix("L", id, "_end", end))
+        return;
     strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
                    loc_str(b1, ra, ins->src1, x64),
                    loc_str(b2, ra, ins->dest, x64));

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -139,7 +139,12 @@ ir_value_t ir_build_string(ir_builder_t *b, const char *str)
     ins->op = IR_GLOB_STRING;
     ins->dest = alloc_value_id(b);
     char label[32];
-    ins->name = vc_strdup(label_format("Lstr", ins->dest, label));
+    const char *fmt = label_format("Lstr", ins->dest, label);
+    if (!fmt) {
+        remove_instr(b, ins);
+        return (ir_value_t){0};
+    }
+    ins->name = vc_strdup(fmt);
     ins->data = vc_strdup(str ? str : "");
     return (ir_value_t){ins->dest};
 }
@@ -156,7 +161,12 @@ ir_value_t ir_build_wstring(ir_builder_t *b, const char *str)
     ins->op = IR_GLOB_WSTRING;
     ins->dest = alloc_value_id(b);
     char label[32];
-    ins->name = vc_strdup(label_format("LWstr", ins->dest, label));
+    const char *fmtw = label_format("LWstr", ins->dest, label);
+    if (!fmtw) {
+        remove_instr(b, ins);
+        return (ir_value_t){0};
+    }
+    ins->name = vc_strdup(fmtw);
     size_t len = strlen(str ? str : "");
     long long *vals = malloc((len + 1) * sizeof(long long));
     if (!vals) {

--- a/src/label.c
+++ b/src/label.c
@@ -38,7 +38,9 @@ void label_reset(void)
 /* Format a label combining prefix and id.  "buf" must have space for 32 bytes. */
 const char *label_format(const char *prefix, int id, char buf[32])
 {
-    snprintf(buf, 32, "%s%d", prefix, id);
+    int n = snprintf(buf, 32, "%s%d", prefix, id);
+    if (n < 0 || n >= 32)
+        return NULL;
     return buf;
 }
 
@@ -46,6 +48,8 @@ const char *label_format(const char *prefix, int id, char buf[32])
 const char *label_format_suffix(const char *prefix, int id, const char *suffix,
                                 char buf[32])
 {
-    snprintf(buf, 32, "%s%d%s", prefix, id, suffix);
+    int n = snprintf(buf, 32, "%s%d%s", prefix, id, suffix);
+    if (n < 0 || n >= 32)
+        return NULL;
     return buf;
 }

--- a/src/semantic_expr.c
+++ b/src/semantic_expr.c
@@ -152,9 +152,13 @@ static type_kind_t check_cond_expr(expr_t *expr, symtable_t *vars,
 
     char flabel[32], endlabel[32], tmp[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_false", flabel);
-    label_format_suffix("L", id, "_end", endlabel);
-    label_format("tmp", id, tmp);
+    if (!label_format_suffix("L", id, "_false", flabel) ||
+        !label_format_suffix("L", id, "_end", endlabel) ||
+        !label_format("tmp", id, tmp)) {
+        if (out)
+            *out = (ir_value_t){0};
+        return TYPE_UNKNOWN;
+    }
     ir_build_bcond(ir, cond_val, flabel);
 
     ir_value_t tval;

--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -32,8 +32,9 @@ int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     char start_label[32];
     char end_label[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_start", start_label);
-    label_format_suffix("L", id, "_end", end_label);
+    if (!label_format_suffix("L", id, "_start", start_label) ||
+        !label_format_suffix("L", id, "_end", end_label))
+        return 0;
     ir_build_label(ir, start_label);
     if (check_expr(stmt->while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
@@ -61,9 +62,10 @@ int check_do_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     char cond_label[32];
     char end_label[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_start", start_label);
-    label_format_suffix("L", id, "_cond", cond_label);
-    label_format_suffix("L", id, "_end", end_label);
+    if (!label_format_suffix("L", id, "_start", start_label) ||
+        !label_format_suffix("L", id, "_cond", cond_label) ||
+        !label_format_suffix("L", id, "_end", end_label))
+        return 0;
     ir_build_label(ir, start_label);
     if (!check_stmt(stmt->do_while_stmt.body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cond_label))
@@ -92,8 +94,9 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     char start_label[32];
     char end_label[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_start", start_label);
-    label_format_suffix("L", id, "_end", end_label);
+    if (!label_format_suffix("L", id, "_start", start_label) ||
+        !label_format_suffix("L", id, "_end", end_label))
+        return 0;
     symbol_t *old_head = vars->head;
     if (stmt->for_stmt.init_decl) {
         if (!check_stmt(stmt->for_stmt.init_decl, vars, funcs, labels, ir,
@@ -114,7 +117,10 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     }
     ir_build_bcond(ir, cond_val, end_label);
     char cont_label[32];
-    label_format_suffix("L", id, "_cont", cont_label);
+    if (!label_format_suffix("L", id, "_cont", cont_label)) {
+        symtable_pop_scope(vars, old_head);
+        return 0;
+    }
     if (!check_stmt(stmt->for_stmt.body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cont_label)) {
         symtable_pop_scope(vars, old_head);

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -272,8 +272,11 @@ static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
 {
     char ir_name_buf[32];
     const char *ir_name = stmt->var_decl.name;
-    if (stmt->var_decl.is_static)
+    if (stmt->var_decl.is_static) {
         ir_name = label_format("__static", label_next_id(), ir_name_buf);
+        if (!ir_name)
+            return NULL;
+    }
 
     compute_var_layout(stmt);
     if (stmt->var_decl.is_const && !stmt->var_decl.init &&
@@ -539,8 +542,9 @@ static int check_if_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     char else_label[32];
     char end_label[32];
     int id = label_next_id();
-    label_format_suffix("L", id, "_else", else_label);
-    label_format_suffix("L", id, "_end", end_label);
+    if (!label_format_suffix("L", id, "_else", else_label) ||
+        !label_format_suffix("L", id, "_end", end_label))
+        return 0;
     const char *target = stmt->if_stmt.else_branch ? else_label : end_label;
     ir_build_bcond(ir, cond_val, target);
     if (!check_stmt(stmt->if_stmt.then_branch, vars, funcs, labels, ir,


### PR DESCRIPTION
## Summary
- detect truncation when formatting labels
- propagate NULL on truncation and handle it at call sites

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861e4e75304832488deacf4cc7cb602