### PR TITLE
Fix waitpid EINTR handling in run_command

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -691,7 +691,9 @@ static int run_command(char *const argv[])
         strbuf_free(&cmd);
         return 0;
     }
-    if (waitpid(pid, &status, 0) < 0) {
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR)
+            continue;
         perror("waitpid");
         return 0;
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -61,13 +61,20 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strbuf.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_strbuf_overflow.c" -o "$DIR/test_strbuf_overflow.o"
 cc -o "$DIR/strbuf_overflow" strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
 rm -f strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
+# build waitpid EINTR regression test
+cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_eintr_impl.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_eintr.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_waitpid_retry.c" -o "$DIR/test_waitpid_retry.o"
+cc -o "$DIR/waitpid_retry" strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
+rm -f strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
 # run unit tests
 "$DIR/unit_tests"
 "$DIR/cli_tests"
 "$DIR/parser_alloc_tests"
 "$DIR/ir_core_tests"
-# last unit test binary
+# remaining unit test binaries
 "$DIR/cond_expr_tests"
+"$DIR/waitpid_retry"
 # separator for clarity
 echo "======="
 # regression test for strbuf overflow handling

--- a/tests/unit/test_waitpid_retry.c
+++ b/tests/unit/test_waitpid_retry.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include "strbuf.h"
+
+extern char **environ;
+
+static int run_command(char *const argv[])
+{
+    pid_t pid;
+    int status;
+    int ret = posix_spawnp(&pid, argv[0], NULL, NULL, argv, environ);
+    if (ret != 0) {
+        strbuf_t cmd;
+        strbuf_init(&cmd);
+        for (size_t i = 0; argv[i]; i++) {
+            if (i > 0)
+                strbuf_append(&cmd, " ");
+            strbuf_append(&cmd, argv[i]);
+        }
+        fprintf(stderr, "posix_spawnp %s: %s\n", cmd.data, strerror(ret));
+        strbuf_free(&cmd);
+        return 0;
+    }
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR)
+            continue;
+        perror("waitpid");
+        return 0;
+    }
+    if (WIFSIGNALED(status))
+        return -1;
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return 0;
+    return 1;
+}
+
+static void handle_alarm(int sig)
+{
+    (void)sig;
+}
+
+int main(void)
+{
+    signal(SIGALRM, handle_alarm);
+    alarm(1);
+    char *cmd[] = {"sleep", "2", NULL};
+    int rc = run_command(cmd);
+    if (rc != 1) {
+        printf("waitpid retry failed\n");
+        return 1;
+    }
+    printf("All waitpid_retry tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- retry waitpid when interrupted by a signal
- add regression test for waitpid EINTR handling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861faa86b288324acf804528fb176e5