### PR TITLE
Handle allocation failure in vector_push

### DIFF
--- a/include/vector.h
+++ b/include/vector.h
@@ -21,7 +21,10 @@ typedef struct {
 /* Initialize vector for elements of given size (must be non-zero) */
 void vector_init(vector_t *vec, size_t elem_size);
 
-/* Append an element, returns 0 on failure */
+/*
+ * Append an element to the end of the vector.  Returns 1 on success and
+ * 0 on failure, including when memory allocation fails.
+ */
 int vector_push(vector_t *vec, const void *elem);
 
 /* Free vector data */

--- a/src/vector.c
+++ b/src/vector.c
@@ -11,7 +11,6 @@
 #include <stdint.h>
 #include <assert.h>
 #include "vector.h"
-#include "util.h"
 
 /*
  * Prepare a vector to hold elements of "elem_size" bytes.  The vector
@@ -43,19 +42,17 @@ int vector_push(vector_t *vec, const void *elem)
     if (vec->count >= vec->cap) {
         size_t new_cap;
         if (vec->cap) {
-            if (vec->cap > SIZE_MAX / 2) {
-                fprintf(stderr, "vc: vector too large\n");
-                exit(1);
-            }
+            if (vec->cap > SIZE_MAX / 2)
+                return 0;
             new_cap = vec->cap * 2;
         } else {
             new_cap = 16;
         }
-        if (new_cap > SIZE_MAX / vec->elem_size) {
-            fprintf(stderr, "vc: vector too large\n");
-            exit(1);
-        }
-        void *tmp = vc_realloc_or_exit(vec->data, new_cap * vec->elem_size);
+        if (new_cap > SIZE_MAX / vec->elem_size)
+            return 0;
+        void *tmp = realloc(vec->data, new_cap * vec->elem_size);
+        if (!tmp)
+            return 0;
         vec->data = tmp;
         vec->cap = new_cap;
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -45,9 +45,10 @@ rm -f parser_core_fail.o parser_init_fail.o parser_decl_fail.o parser_flow_fail.
 cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c src/ir_core.c -o ir_core_test.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/label.c -o label_ircore.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_ir_core.c" -o "$DIR/test_ir_core.o"
-cc -o "$DIR/ir_core_tests" ir_core_test.o util_ircore.o label_ircore.o "$DIR/test_ir_core.o"
-rm -f ir_core_test.o util_ircore.o label_ircore.o "$DIR/test_ir_core.o"
+cc -o "$DIR/ir_core_tests" ir_core_test.o util_ircore.o label_ircore.o error_ircore.o "$DIR/test_ir_core.o"
+rm -f ir_core_test.o util_ircore.o label_ircore.o error_ircore.o "$DIR/test_ir_core.o"
 # build conditional expression regression test
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/cond_expr_tests" "$DIR/unit/test_cond_expr.c" \


### PR DESCRIPTION
## Summary
- avoid aborting when vector_push allocation fails
- document failure conditions in vector.h
- link error.c when building ir_core unit tests

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861fe5514488324b9017baa0f0e6e6c