### PR TITLE
Add include depth limit

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -40,6 +40,11 @@ avoid infinite loops a hard limit of 100 nested expansions is enforced. The
 compiler aborts preprocessing with an error message as soon as this depth is
 reached.
 
+File inclusion works the same way and may recurse when headers themselves
+contain `#include` directives.  To guard against unbounded recursion the
+preprocessor enforces a maximum include depth of 20 files.  If this limit is
+exceeded the build stops with an "Include depth limit exceeded" error.
+
 Conditional expressions in `#if` directives are parsed by the small recursive
 descent parser in `preproc_expr.c`.  The `defined` operator queries the current
 macro table so feature tests work as expected.

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -29,6 +29,8 @@
 #include "vector.h"
 #include "strbuf.h"
 
+#define MAX_INCLUDE_DEPTH 20
+
 /* Default system include search paths */
 static const char *std_include_dirs[] = {
     "/usr/local/include",
@@ -820,6 +822,10 @@ static int process_file(const char *path, vector_t *macros,
                         vector_t *conds, strbuf_t *out,
                         const vector_t *incdirs, vector_t *stack)
 {
+    if (stack->count >= MAX_INCLUDE_DEPTH) {
+        fprintf(stderr, "Include depth limit exceeded\n");
+        return 0;
+    }
     char **lines;
     char *dir;
     char *text;

--- a/tests/invalid/depth01.h
+++ b/tests/invalid/depth01.h
@@ -1,0 +1,1 @@
+#include "depth02.h"

--- a/tests/invalid/depth02.h
+++ b/tests/invalid/depth02.h
@@ -1,0 +1,1 @@
+#include "depth03.h"

--- a/tests/invalid/depth03.h
+++ b/tests/invalid/depth03.h
@@ -1,0 +1,1 @@
+#include "depth04.h"

--- a/tests/invalid/depth04.h
+++ b/tests/invalid/depth04.h
@@ -1,0 +1,1 @@
+#include "depth05.h"

--- a/tests/invalid/depth05.h
+++ b/tests/invalid/depth05.h
@@ -1,0 +1,1 @@
+#include "depth06.h"

--- a/tests/invalid/depth06.h
+++ b/tests/invalid/depth06.h
@@ -1,0 +1,1 @@
+#include "depth07.h"

--- a/tests/invalid/depth07.h
+++ b/tests/invalid/depth07.h
@@ -1,0 +1,1 @@
+#include "depth08.h"

--- a/tests/invalid/depth08.h
+++ b/tests/invalid/depth08.h
@@ -1,0 +1,1 @@
+#include "depth09.h"

--- a/tests/invalid/depth09.h
+++ b/tests/invalid/depth09.h
@@ -1,0 +1,1 @@
+#include "depth10.h"

--- a/tests/invalid/depth10.h
+++ b/tests/invalid/depth10.h
@@ -1,0 +1,1 @@
+#include "depth11.h"

--- a/tests/invalid/depth11.h
+++ b/tests/invalid/depth11.h
@@ -1,0 +1,1 @@
+#include "depth12.h"

--- a/tests/invalid/depth12.h
+++ b/tests/invalid/depth12.h
@@ -1,0 +1,1 @@
+#include "depth13.h"

--- a/tests/invalid/depth13.h
+++ b/tests/invalid/depth13.h
@@ -1,0 +1,1 @@
+#include "depth14.h"

--- a/tests/invalid/depth14.h
+++ b/tests/invalid/depth14.h
@@ -1,0 +1,1 @@
+#include "depth15.h"

--- a/tests/invalid/depth15.h
+++ b/tests/invalid/depth15.h
@@ -1,0 +1,1 @@
+#include "depth16.h"

--- a/tests/invalid/depth16.h
+++ b/tests/invalid/depth16.h
@@ -1,0 +1,1 @@
+#include "depth17.h"

--- a/tests/invalid/depth17.h
+++ b/tests/invalid/depth17.h
@@ -1,0 +1,1 @@
+#include "depth18.h"

--- a/tests/invalid/depth18.h
+++ b/tests/invalid/depth18.h
@@ -1,0 +1,1 @@
+#include "depth19.h"

--- a/tests/invalid/depth19.h
+++ b/tests/invalid/depth19.h
@@ -1,0 +1,1 @@
+#include "depth20.h"

--- a/tests/invalid/depth20.h
+++ b/tests/invalid/depth20.h
@@ -1,0 +1,1 @@
+#include "depth21.h"

--- a/tests/invalid/include_depth.c
+++ b/tests/invalid/include_depth.c
@@ -1,0 +1,2 @@
+#include "depth01.h"
+int main() { return 0; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -246,6 +246,19 @@ if [ $ret -eq 0 ] || ! grep -q "Macro expansion limit exceeded" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# negative test for include depth limit
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "${out}" "$DIR/invalid/include_depth.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Include depth limit exceeded" "${err}"; then
+    echo "Test include_depth failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 # negative test for duplicate switch cases
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- introduce `MAX_INCLUDE_DEPTH` constant
- enforce include nesting limit in `process_file`
- document the new limit in the preprocessor docs
- regression test covering include depth handling

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861ffa6f3fc8324afaaa89c136df551