### PR TITLE
Handle fflush errors and disk full test

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -393,6 +393,13 @@ static int emit_output_file(ir_builder_t *ir, const char *output,
             return 0;
         }
         codegen_emit_x86(tmpf, ir, use_x86_64);
+        if (fflush(tmpf) == EOF) {
+            perror("fflush");
+            fclose(tmpf);
+            unlink(tmpname);
+            free(tmpname);
+            return 0;
+        }
         if (fclose(tmpf) == EOF) {
             perror("fclose");
             unlink(tmpname);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -396,6 +396,21 @@ if [ $ret -eq 0 ] || ! grep -q "Invalid optimization level" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# simulate disk full during assembly generation
+lib="$DIR/libfail_fflush.so"
+cc -shared -fPIC -o "$lib" "$DIR/unit/fail_fflush.c"
+out=$(mktemp)
+err=$(mktemp)
+set +e
+LD_PRELOAD="$lib" "$BINARY" -c -o "$out" "$DIR/fixtures/simple_add.c" 2> "$err"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "No space left on device" "$err"; then
+    echo "Test disk_full_flush failed"
+    fail=1
+fi
+rm -f "$out" "$err" "$lib"
+
 # regression test for long command error message
 long_tmpdir=$(mktemp -d)
 long_out="$long_tmpdir/$(printf 'a%.0s' {1..50})/$(printf 'b%.0s' {1..50})/$(printf 'c%.0s' {1..50})/$(printf 'd%.0s' {1..50})/$(printf 'e%.0s' {1..50})/out.o"

--- a/tests/unit/fail_fflush.c
+++ b/tests/unit/fail_fflush.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <errno.h>
+
+int fflush(FILE *stream)
+{
+    (void)stream;
+    errno = ENOSPC;
+    return EOF;
+}


### PR DESCRIPTION
## Summary
- detect `fflush` failure when writing assembly and abort
- provide a test helper to simulate a disk-full error
- add regression test to ensure disk-full conditions are handled

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686208c5b9c08324b2be20169d7f0309