### PR TITLE
Fix macro parameter parsing on failure

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -270,9 +270,10 @@ static char *parse_macro_params(char *p, vector_t *out)
             p++; /* skip ')' */
         } else {
             p = start - 1; /* restore '(' position */
+            *p = '('; /* undo temporary termination */
             for (size_t i = 0; i < out->count; i++)
                 free(((char **)out->data)[i]);
-            free(out->data);
+            vector_free(out);
             vector_init(out, sizeof(char *));
         }
     } else if (*p) {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -71,6 +71,12 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_eintr.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_waitpid_retry.c" -o "$DIR/test_waitpid_retry.o"
 cc -o "$DIR/waitpid_retry" strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
 rm -f strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
+# build invalid macro parse test
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_invalid_macro.c" -o "$DIR/test_invalid_macro.o"
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_invalid.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_invalid.o
+cc -o "$DIR/invalid_macro_tests" "$DIR/test_invalid_macro.o" vector_invalid.o util_invalid.o
+rm -f "$DIR/test_invalid_macro.o" vector_invalid.o util_invalid.o
 # build create_temp_file path length regression test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
@@ -85,6 +91,7 @@ rm -f compile_temp.o "$DIR/test_temp_file.o"
 "$DIR/cond_expr_tests"
 "$DIR/waitpid_retry"
 "$DIR/temp_file_tests"
+"$DIR/invalid_macro_tests"
 # separator for clarity
 echo "======="
 # regression test for strbuf overflow handling

--- a/tests/unit/test_invalid_macro.c
+++ b/tests/unit/test_invalid_macro.c
@@ -1,0 +1,80 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "vector.h"
+#include "util.h"
+
+/* Minimal helpers from preproc_file.c needed for testing */
+static void tokenize_param_list(char *list, vector_t *out)
+{
+    char *tok; char *sp;
+    tok = strtok_r(list, ",", &sp);
+    while (tok) {
+        while (*tok == ' ' || *tok == '\t')
+            tok++;
+        char *end = tok + strlen(tok);
+        while (end > tok && (end[-1] == ' ' || end[-1] == '\t'))
+            end--;
+        char *dup = vc_strndup(tok, (size_t)(end - tok));
+        vector_push(out, &dup);
+        tok = strtok_r(NULL, ",", &sp);
+    }
+}
+
+static char *parse_macro_params(char *p, vector_t *out)
+{
+    vector_init(out, sizeof(char *));
+    if (*p == '(') {
+        *p++ = '\0';
+        char *start = p;
+        while (*p && *p != ')')
+            p++;
+        if (*p == ')') {
+            char *plist = vc_strndup(start, (size_t)(p - start));
+            tokenize_param_list(plist, out);
+            free(plist);
+            p++; /* skip ')' */
+        } else {
+            p = start - 1; /* restore '(' position */
+            *p = '('; /* undo temporary termination */
+            for (size_t i = 0; i < out->count; i++)
+                free(((char **)out->data)[i]);
+            vector_free(out);
+            vector_init(out, sizeof(char *));
+        }
+    } else if (*p) {
+        *p++ = '\0';
+    }
+    return p;
+}
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void test_invalid_params(void)
+{
+    char line[] = "(x, y"; /* missing closing parenthesis */
+    vector_t v;
+    char *res = parse_macro_params(line, &v);
+    ASSERT(res == line);         /* pointer should reset to '(' */
+    ASSERT(line[0] == '(');      /* '(' restored */
+    ASSERT(v.count == 0);        /* vector reset */
+    ASSERT(v.cap == 0);
+    vector_free(&v);
+}
+
+int main(void)
+{
+    test_invalid_params();
+    if (failures == 0)
+        printf("All invalid macro tests passed\n");
+    else
+        printf("%d invalid macro test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- fix parse_macro_params restoration and clean up vector state
- test invalid macro definitions
- run unit tests via test harness

## Testing
- `make test`
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862099be3788324888a0e682da52f62