### PR TITLE
Mark unused helper functions static

### DIFF
--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -175,13 +175,6 @@ void ir_build_store_idx(ir_builder_t *b, const char *name, ir_value_t idx,
 void ir_build_store_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx,
                             ir_value_t val);
 
-/* Load a bit-field using IR_BFLOAD (shift and width encoded in imm). */
-ir_value_t ir_build_bfload(ir_builder_t *b, const char *name,
-                           int shift, int width);
-
-/* Store `val` into a bit-field using IR_BFSTORE. */
-void ir_build_bfstore(ir_builder_t *b, const char *name, int shift,
-                      int width, ir_value_t val);
 
 /* Emit IR_ALLOCA reserving `size` bytes on the stack. */
 ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size);

--- a/include/symtable.h
+++ b/include/symtable.h
@@ -93,7 +93,6 @@ int symtable_add_enum(symtable_t *table, const char *name, int value);
 int symtable_add_enum_global(symtable_t *table, const char *name, int value);
 int symtable_add_enum_tag(symtable_t *table, const char *tag);
 int symtable_add_enum_tag_global(symtable_t *table, const char *tag);
-symbol_t *symtable_lookup_enum_tag(symtable_t *table, const char *tag);
 int symtable_add_typedef(symtable_t *table, const char *name, type_kind_t type,
                          size_t array_size, size_t elem_size);
 int symtable_add_typedef_global(symtable_t *table, const char *name,
@@ -103,7 +102,6 @@ int symtable_add_union(symtable_t *table, const char *tag,
                        union_member_t *members, size_t member_count);
 int symtable_add_union_global(symtable_t *table, const char *tag,
                               union_member_t *members, size_t member_count);
-symbol_t *symtable_lookup_union(symtable_t *table, const char *tag);
 int symtable_add_struct(symtable_t *table, const char *tag,
                         struct_member_t *members, size_t member_count);
 int symtable_add_struct_global(symtable_t *table, const char *tag,

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -390,8 +390,8 @@ void ir_build_store_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx,
 }
 
 /* Load a bit-field from `name` shifted by `shift` and masked by `width`. */
-ir_value_t ir_build_bfload(ir_builder_t *b, const char *name,
-                           int shift, int width)
+static ir_value_t ir_build_bfload(ir_builder_t *b, const char *name,
+                                  int shift, int width)
 {
     ir_instr_t *ins = append_instr(b);
     if (!ins)
@@ -404,8 +404,8 @@ ir_value_t ir_build_bfload(ir_builder_t *b, const char *name,
 }
 
 /* Store `val` into a bit-field at `name`. */
-void ir_build_bfstore(ir_builder_t *b, const char *name, int shift,
-                      int width, ir_value_t val)
+static void ir_build_bfstore(ir_builder_t *b, const char *name, int shift,
+                             int width, ir_value_t val)
 {
     ir_instr_t *ins = append_instr(b);
     if (!ins)

--- a/src/symtable_struct.c
+++ b/src/symtable_struct.c
@@ -78,7 +78,7 @@ int symtable_add_enum_tag_global(symtable_t *table, const char *tag)
  * Search for an enum tag in both the local and global lists.
  * Returns NULL if no matching tag exists.
  */
-symbol_t *symtable_lookup_enum_tag(symtable_t *table, const char *tag)
+static symbol_t *symtable_lookup_enum_tag(symtable_t *table, const char *tag)
 {
     for (symbol_t *sym = table->head; sym; sym = sym->next) {
         if (sym->type == TYPE_ENUM && strcmp(sym->name, tag) == 0)
@@ -173,7 +173,7 @@ int symtable_add_union_global(symtable_t *table, const char *tag,
  * Look up a union type definition by tag by scanning both lists.
  * Returns NULL if the tag is not defined.
  */
-symbol_t *symtable_lookup_union(symtable_t *table, const char *tag)
+static symbol_t *symtable_lookup_union(symtable_t *table, const char *tag)
 {
     for (symbol_t *sym = table->head; sym; sym = sym->next) {
         if (sym->type == TYPE_UNION && sym->member_count > 0 &&


### PR DESCRIPTION
## Summary
- remove extern declarations for bit-field helpers and enum/union lookups
- mark these helper functions `static` since they aren't used outside their files

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862119d6fbc8324bafa218db7fa53e1