### PR TITLE
Fix temporary file allocation size

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -536,13 +536,13 @@ static int create_temp_file(const cli_options_t *cli, const char *prefix,
         errno = ENAMETOOLONG;
         return -1;
     }
-    char *tmpl = malloc(len);
+    char *tmpl = malloc(len + 1);
     if (!tmpl) {
         *out_path = NULL;
         return -1;
     }
-    int n = snprintf(tmpl, len, "%s/%sXXXXXX", dir, prefix);
-    if (n < 0 || (size_t)n >= len) {
+    int n = snprintf(tmpl, len + 1, "%s/%sXXXXXX", dir, prefix);
+    if (n < 0 || (size_t)n >= len + 1) {
         free(tmpl);
         *out_path = NULL;
         errno = ENAMETOOLONG;


### PR DESCRIPTION
## Summary
- allocate one extra byte for `create_temp_file` templates
- update snprintf bounds checks accordingly

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68621326f1ac8324b5ad79a8a99a9488