### PR TITLE
Use fwrite for preprocessor output

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -786,12 +786,12 @@ int run_preprocessor(const cli_options_t *cli)
             perror("preproc_run");
             return 1;
         }
-        if (printf("%s", text) < 0) {
-            perror("printf");
+        size_t len = strlen(text);
+        if (fwrite(text, 1, len, stdout) != len) {
+            perror("fwrite");
             free(text);
             return 1;
         }
-        size_t len = strlen(text);
         if (len == 0 || text[len - 1] != '\n') {
             if (putchar('\n') == EOF) {
                 perror("putchar");
@@ -800,7 +800,7 @@ int run_preprocessor(const cli_options_t *cli)
             }
         }
         if (fflush(stdout) == EOF) {
-            perror("printf");
+            perror("fflush");
             free(text);
             return 1;
         }


### PR DESCRIPTION
## Summary
- use `fwrite` to emit preprocessor output in `run_preprocessor`
- ensure the number of bytes written matches the text length
- update error messages for `fwrite` and `fflush`

## Testing
- `make`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686214439aec83248307c87e738825bb