### PR TITLE
Fix waitpid retry test

### DIFF
--- a/tests/unit/test_waitpid_retry.c
+++ b/tests/unit/test_waitpid_retry.c
@@ -45,10 +45,11 @@ static void handle_alarm(int sig)
 
 int main(void)
 {
-    signal(SIGALRM, handle_alarm);
+    void (*prev)(int) = signal(SIGALRM, handle_alarm);
     alarm(1);
     char *cmd[] = {"sleep", "2", NULL};
     int rc = run_command(cmd);
+    signal(SIGALRM, prev);
     if (rc != 1) {
         printf("waitpid retry failed\n");
         return 1;


### PR DESCRIPTION
## Summary
- restore SIGALRM handler in `test_waitpid_retry`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68621558eea883248fdc1a473a7ce38e