### PR TITLE
Fix errno handling in create_temp_file

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -543,9 +543,9 @@ static int create_temp_file(const cli_options_t *cli, const char *prefix,
     }
     int n = snprintf(tmpl, len + 1, "%s/%sXXXXXX", dir, prefix);
     if (n < 0 || (size_t)n >= len + 1) {
+        /* Propagate errno from snprintf if it set one; do not overwrite it */
         free(tmpl);
         *out_path = NULL;
-        errno = ENAMETOOLONG;
         return -1;
     }
     int fd = mkstemp(tmpl);


### PR DESCRIPTION
## Summary
- avoid overriding `errno` if `snprintf` truncates the path in `create_temp_file`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68621563f20c8324b74ad591f247cb25