### PR TITLE
Handle conditional push allocation failures

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -379,7 +379,8 @@ static void cond_push_ifdef_common(char *line, vector_t *macros,
     } else {
         st.taking = 0;
     }
-    vector_push(conds, &st);
+    if (!vector_push(conds, &st))
+        fprintf(stderr, "Out of memory\n");
 }
 
 /* Push a new state for an #ifdef directive */
@@ -407,7 +408,8 @@ static void cond_push_ifexpr(char *line, vector_t *macros, vector_t *conds)
     } else {
         st.taking = 0;
     }
-    vector_push(conds, &st);
+    if (!vector_push(conds, &st))
+        fprintf(stderr, "Out of memory\n");
 }
 
 /* Handle an #elif directive */


### PR DESCRIPTION
## Summary
- check for allocation failure when pushing new conditional state
- emit an out of memory message on failure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68621b3abfb88324937736c301e5e92b