### PR TITLE
Fix vector_push validations

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -8,6 +8,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "token.h"
 #include "vector.h"
@@ -106,8 +107,11 @@ static void append_token(vector_t *vec, token_type_t type, const char *lexeme,
 {
     char *text = vc_strndup(lexeme, len);
     token_t tok = { type, text, line, column };
-    if (!vector_push(vec, &tok))
+    if (!vector_push(vec, &tok)) {
+        free(text);
+        fprintf(stderr, "Out of memory\n");
         exit(1);
+    }
 }
 
 /* Parse a line marker of the form '# <num> "file"' and update counters */


### PR DESCRIPTION
## Summary
- validate vector_push in the preprocessor conditional helpers
- free duplicated token text before exiting on lexer push failure

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68621c7b13908324b999b93320f1cb2c