### PR TITLE
Fix run_tests broken pipe invocation with spaces

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -337,7 +337,8 @@ tmp_big=$(mktemp)
 # create a large temporary source exceeding the pipe capacity
 yes "int x = 0;" | head -n 7000 > "$tmp_big"
 set +e
-bash -c "set -o pipefail; trap \"\" PIPE; \"$BINARY\" -E \"$tmp_big\" 2> \"$err\" | head -c 1 >/dev/null"
+# use positional parameters so the compiler path can contain spaces
+bash -c 'set -o pipefail; trap "" PIPE; "$1" -E "$2" 2> "$3" | head -c 1 >/dev/null' _ "$BINARY" "$tmp_big" "$err"
 ret=$?
 set -e
 rm -f "$tmp_big"


### PR DESCRIPTION
## Summary
- protect compiler path with spaces in run_tests.sh by using positional parameters

## Testing
- `make test`
- manual check that the broken pipe test still reports "Broken pipe"


------
https://chatgpt.com/codex/tasks/task_e_6862ad558900832499980f4480e840cd