### PR TITLE
Add comment to reveal depth21 filename in diagnostics

### DIFF
--- a/tests/invalid/depth21.h
+++ b/tests/invalid/depth21.h
@@ -1,1 +1,1 @@
-
+/* trigger include depth diagnostic */


### PR DESCRIPTION
## Summary
- keep the last header in the include-depth test non-empty so its name
  appears in error output

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862b09266448324a4aa319c868960a4