### PR TITLE
Fix PATH_MAX portability

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -12,6 +12,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#ifndef PATH_MAX
+# include <sys/param.h>
+#endif
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>

--- a/tests/unit/test_temp_file.c
+++ b/tests/unit/test_temp_file.c
@@ -2,7 +2,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
-#include <linux/limits.h>
+#ifndef PATH_MAX
+# include <sys/param.h>
+#endif
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
 #include <errno.h>
 #include "cli.h"
 


### PR DESCRIPTION
## Summary
- avoid `<linux/limits.h>` in unit tests
- add a POSIX fallback for `PATH_MAX`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862b61f297883248495a8861081355d