### PR TITLE
Reset optreset in CLI test

### DIFF
--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -41,6 +41,9 @@ static void test_parse_failure(void)
     char *argv[] = {"vc", "-o", "out.s", "file.c", NULL};
     /* reset getopt state before reusing cli_parse_args */
     optind = 1;
+#ifdef __BSD_VISIBLE
+    optreset = 1;
+#endif
     fail_push = 1;
     FILE *tmp = tmpfile();
     int saved = dup(fileno(stderr));


### PR DESCRIPTION
## Summary
- reset `optreset` when reusing `getopt` in the CLI unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862b970a4748324b2e414a340541b4a