### PR TITLE
Fix snprintf truncation handling

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -548,11 +548,14 @@ static int create_temp_file(const cli_options_t *cli, const char *prefix,
         *out_path = NULL;
         return -1;
     }
+    errno = 0;
     int n = snprintf(tmpl, len + 1, "%s/%sXXXXXX", dir, prefix);
+    int err = errno;
     if (n < 0 || (size_t)n >= len + 1) {
         /* Propagate errno from snprintf if it set one; do not overwrite it */
         free(tmpl);
         *out_path = NULL;
+        errno = err;
         return -1;
     }
     int fd = mkstemp(tmpl);


### PR DESCRIPTION
## Summary
- reset `errno` before calling `snprintf`
- keep the errno value from `snprintf` on failure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862c22d231c832491296a4218c72d9d