### PR TITLE
Ensure failed label_format clears buffer

### DIFF
--- a/include/label.h
+++ b/include/label.h
@@ -19,13 +19,15 @@ void label_reset(void);
 
 /*
  * Format a label as prefix followed by id.  Returns NULL and reports an
- * error if the result would exceed 31 characters.
+ * error if the result would exceed 31 characters.  On failure, the
+ * provided buffer's first byte is set to '\0'.
  */
 const char *label_format(const char *prefix, int id, char buf[32]);
 
 /*
  * Format a label as prefix + id + suffix.  Returns NULL and reports an error
- * if the result would exceed 31 characters.
+ * if the result would exceed 31 characters.  On failure, the provided
+ * buffer's first byte is set to '\0'.
  */
 const char *label_format_suffix(const char *prefix, int id, const char *suffix,
                                 char buf[32]);

--- a/src/label.c
+++ b/src/label.c
@@ -44,6 +44,7 @@ const char *label_format(const char *prefix, int id, char buf[32])
         error_set(0, 0, error_current_file, error_current_function);
         error_print("Generated label name too long");
         buf[31] = '\0';
+        buf[0] = '\0';
         return NULL;
     }
     return buf;
@@ -58,6 +59,7 @@ const char *label_format_suffix(const char *prefix, int id, const char *suffix,
         error_set(0, 0, error_current_file, error_current_function);
         error_print("Generated label name too long");
         buf[31] = '\0';
+        buf[0] = '\0';
         return NULL;
     }
     return buf;


### PR DESCRIPTION
## Summary
- prevent stale data in label buffers
- document new label_format behaviour in header

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862c8539f8483248d67542f7b3d3863