### PR TITLE
Add tmpfile() failure check in test_cli

### DIFF
--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <stdlib.h>
 #include "cli.h"
 #include "vector.h"
 
@@ -46,6 +47,10 @@ static void test_parse_failure(void)
 #endif
     fail_push = 1;
     FILE *tmp = tmpfile();
+    if (!tmp) {
+        perror("tmpfile");
+        exit(1);
+    }
     int saved = dup(fileno(stderr));
     dup2(fileno(tmp), fileno(stderr));
 


### PR DESCRIPTION
## Summary
- verify `tmpfile()` call succeeded in the CLI tests
- exit the test with an error if a temporary file can't be created

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862c848118483249d38921b28776979