### PR TITLE
Fix fixture loop quoting in test script

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,7 +6,7 @@ BINARY="$DIR/../vc"
 fail=0
 # compile each fixture, including vla.c which exercises
 # variable length array support
-for cfile in $(ls "$DIR"/fixtures/*.c | sort); do
+for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
 
     case "$base" in


### PR DESCRIPTION
## Summary
- simplify test fixture loop
- ensure `$cfile` is always quoted

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862cdb18a74832480819f8f98502946