### PR TITLE
Fix realloc failure path in collect_funcs

### DIFF
--- a/src/opt_inline.c
+++ b/src/opt_inline.c
@@ -209,7 +209,6 @@ static int collect_funcs(ir_builder_t *ir, inline_func_t **out, size_t *count)
             inline_func_t *tmp = realloc(*out, new_cap * sizeof(**out));
             if (!tmp) {
                 opt_error("out of memory");
-                free(*out);
                 return 0;
             }
             *out = tmp;


### PR DESCRIPTION
## Summary
- avoid losing inline function array on realloc failure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862cdaaff708324ab022ba07b25fb5e