### PR TITLE
Add Intel syntax option to CLI

### DIFF
--- a/include/cli.h
+++ b/include/cli.h
@@ -19,6 +19,11 @@ typedef enum {
     STD_GNU99
 } c_std_t;
 
+typedef enum {
+    ASM_ATT = 0,
+    ASM_INTEL
+} asm_syntax_t;
+
 /* Command line options parsed from argv */
 typedef struct {
     char *output;       /* output file path */
@@ -30,6 +35,7 @@ typedef struct {
     int dump_ir;        /* dump IR to stdout */
     int preprocess;     /* run preprocessor only and print to stdout */
     int debug;          /* emit debug directives */
+    asm_syntax_t asm_syntax; /* assembly syntax flavor */
     c_std_t std;        /* language standard */
     char *obj_dir;      /* directory for temporary object files */
     vector_t include_dirs; /* additional include directories */

--- a/src/cli.c
+++ b/src/cli.c
@@ -42,6 +42,7 @@ static void print_usage(const char *prog)
     printf("      --no-inline      Disable inline expansion\n");
     printf("      --debug          Emit .file/.loc directives\n");
     printf("      --x86-64         Generate 64-bit x86 assembly\n");
+    printf("      --intel-syntax    Use Intel assembly syntax\n");
     printf("  -S, --dump-asm       Print assembly to stdout and exit\n");
     printf("      --dump-ir        Print IR to stdout and exit\n");
     printf("  -E, --preprocess     Run only the preprocessor and print the result\n");
@@ -70,6 +71,7 @@ static void init_default_opts(cli_options_t *opts)
     opts->dump_ir = 0;
     opts->preprocess = 0;
     opts->debug = 0;
+    opts->asm_syntax = ASM_ATT;
     opts->std = STD_C99;
     opts->obj_dir = "/tmp";
     vector_init(&opts->include_dirs, sizeof(char *));
@@ -214,6 +216,13 @@ static int enable_x86(const char *arg, const char *prog, cli_options_t *opts)
     return 0;
 }
 
+static int enable_intel_syntax(const char *arg, const char *prog, cli_options_t *opts)
+{
+    (void)arg; (void)prog;
+    opts->asm_syntax = ASM_INTEL;
+    return 0;
+}
+
 static int enable_dump(const char *arg, const char *prog, cli_options_t *opts)
 {
     (void)arg; (void)prog;
@@ -297,6 +306,7 @@ static int handle_option(int opt, const char *arg, const char *prog,
         {1,   disable_fold},
         {2,   disable_dce},
         {3,   enable_x86},
+        {12,  enable_intel_syntax},
         {'S', enable_dump},
         {4,   enable_dump},
         {5,   disable_cprop},
@@ -340,6 +350,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"no-fold", no_argument,       0, 1},
         {"no-dce",  no_argument,       0, 2},
         {"x86-64", no_argument,       0, 3},
+        {"intel-syntax", no_argument, 0, 12},
         {"dump-asm", no_argument,     0, 4},
         {"no-cprop", no_argument,     0, 5},
         {"no-inline", no_argument,   0, 11},

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -32,6 +32,18 @@ static void test_parse_success(void)
     ASSERT(ret == 0);
     ASSERT(opts.sources.count == 1);
     ASSERT(strcmp(((char **)opts.sources.data)[0], "file.c") == 0);
+    ASSERT(opts.asm_syntax == ASM_ATT);
+    vector_free(&opts.sources);
+    vector_free(&opts.include_dirs);
+}
+
+static void test_intel_syntax_option(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "--intel-syntax", "-o", "out.s", "file.c", NULL};
+    int ret = cli_parse_args(5, argv, &opts);
+    ASSERT(ret == 0);
+    ASSERT(opts.asm_syntax == ASM_INTEL);
     vector_free(&opts.sources);
     vector_free(&opts.include_dirs);
 }
@@ -74,6 +86,7 @@ static void test_parse_failure(void)
 int main(void)
 {
     test_parse_success();
+    test_intel_syntax_option();
     test_parse_failure();
     if (failures == 0)
         printf("All cli tests passed\n");


### PR DESCRIPTION
## Summary
- extend CLI options with `asm_syntax`
- provide `--intel-syntax` flag
- update help text
- cover new argument in CLI unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68630637270c8324a4427c23cb2af9ed