### PR TITLE
Pass asm syntax to codegen functions

### DIFF
--- a/include/codegen.h
+++ b/include/codegen.h
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include "ir_core.h"
+#include "cli.h"
 
 /*
  * Emit the full x86 assembly for `ir` to `out`.
@@ -25,7 +26,8 @@
  * Passing a non-zero `x86_64` enables 64-bit register names and pointer
  * sizes.
  */
-void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x86_64);
+void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x86_64,
+                      asm_syntax_t syntax);
 
 /*
  * Convert the IR to an assembly string.
@@ -34,7 +36,8 @@ void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x86_64);
  * caller owns the returned buffer and must free it.  The `x86_64` flag
  * selects whether 32- or 64-bit mnemonics are produced.
  */
-char *codegen_ir_to_string(ir_builder_t *ir, int x86_64);
+char *codegen_ir_to_string(ir_builder_t *ir, int x86_64,
+                           asm_syntax_t syntax);
 
 /*
  * Set whether function symbols should be exported.

--- a/include/codegen_arith.h
+++ b/include/codegen_arith.h
@@ -15,6 +15,7 @@
 #include "strbuf.h"
 #include "ir_core.h"
 #include "regalloc.h"
+#include "cli.h"
 
 /*
  * Emit assembly for an arithmetic instruction.
@@ -23,6 +24,7 @@
  * 64-bit instruction encodings.
  */
 void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
-                      regalloc_t *ra, int x64);
+                      regalloc_t *ra, int x64,
+                      asm_syntax_t syntax);
 
 #endif /* VC_CODEGEN_ARITH_H */

--- a/include/codegen_branch.h
+++ b/include/codegen_branch.h
@@ -14,6 +14,7 @@
 #include "strbuf.h"
 #include "ir_core.h"
 #include "regalloc.h"
+#include "cli.h"
 
 /*
  * Emit assembly for branching and function control flow instructions.
@@ -22,6 +23,7 @@
  * 64-bit encodings according to `x64`.
  */
 void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
-                       regalloc_t *ra, int x64);
+                       regalloc_t *ra, int x64,
+                       asm_syntax_t syntax);
 
 #endif /* VC_CODEGEN_BRANCH_H */

--- a/include/codegen_mem.h
+++ b/include/codegen_mem.h
@@ -15,6 +15,7 @@
 #include "strbuf.h"
 #include "ir_core.h"
 #include "regalloc.h"
+#include "cli.h"
 
 /*
  * Emit assembly for a memory-related instruction.
@@ -23,6 +24,7 @@
  * pointer size used in addressing modes.
  */
 void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
-                       regalloc_t *ra, int x64);
+                       regalloc_t *ra, int x64,
+                       asm_syntax_t syntax);
 
 #endif /* VC_CODEGEN_MEM_H */

--- a/src/codegen_arith.c
+++ b/src/codegen_arith.c
@@ -300,7 +300,8 @@ static void emit_logor(strbuf_t *sb, ir_instr_t *ins,
  * names.
  */
 void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
-                      regalloc_t *ra, int x64)
+                      regalloc_t *ra, int x64,
+                      asm_syntax_t syntax)
 {
     switch (ins->op) {
     case IR_PTR_ADD:

--- a/src/codegen_branch.c
+++ b/src/codegen_branch.c
@@ -151,7 +151,8 @@ static void emit_alloca(strbuf_t *sb, ir_instr_t *ins,
  * and stack pointer registers.
  */
 void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
-                       regalloc_t *ra, int x64)
+                       regalloc_t *ra, int x64,
+                       asm_syntax_t syntax)
 {
     const char *sfx = x64 ? "q" : "l";
     const char *ax = x64 ? "%rax" : "%eax";

--- a/src/codegen_mem.c
+++ b/src/codegen_mem.c
@@ -336,7 +336,8 @@ static void emit_glob_string(strbuf_t *sb, ir_instr_t *ins,
  * register names so that either 32- or 64-bit code can be produced.
  */
 void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
-                       regalloc_t *ra, int x64)
+                       regalloc_t *ra, int x64,
+                       asm_syntax_t syntax)
 {
     switch (ins->op) {
     case IR_CONST:

--- a/src/compile.c
+++ b/src/compile.c
@@ -369,7 +369,8 @@ static int compile_output(ir_builder_t *ir, const char *output,
         return 1;
     }
     if (dump_asm) {
-        char *text = codegen_ir_to_string(ir, use_x86_64);
+        char *text = codegen_ir_to_string(ir, use_x86_64,
+                                          cli->asm_syntax);
         if (text) {
             printf("%s", text);
             free(text);
@@ -399,7 +400,8 @@ static int emit_output_file(ir_builder_t *ir, const char *output,
             free(tmpname);
             return 0;
         }
-        codegen_emit_x86(tmpf, ir, use_x86_64);
+        codegen_emit_x86(tmpf, ir, use_x86_64,
+                        cli->asm_syntax);
         if (fflush(tmpf) == EOF) {
             perror("fflush");
             fclose(tmpf);
@@ -435,7 +437,8 @@ static int emit_output_file(ir_builder_t *ir, const char *output,
         perror("fopen");
         return 0;
     }
-    codegen_emit_x86(outf, ir, use_x86_64);
+    codegen_emit_x86(outf, ir, use_x86_64,
+                    cli->asm_syntax);
     if (fclose(outf) == EOF) {
         perror("fclose");
         unlink(output);


### PR DESCRIPTION
## Summary
- extend `codegen_emit_x86` and `codegen_ir_to_string` with an `asm_syntax` parameter
- thread `asm_syntax` option through compile routines
- update memory, arithmetic and branch emitters to accept the syntax argument

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68630942107c832488e3d5edc94cf4e0