### PR TITLE
Document Intel syntax option

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -19,6 +19,7 @@ The compiler supports the following options:
 - `--no-inline` – disable inline expansion of small functions.
 - `--debug` – emit `.file` and `.loc` directives in the assembly output.
 - `--x86-64` – generate 64‑bit x86 assembly.
+- `--intel-syntax` – enable Intel-style x86 assembly output.
 - `-c`, `--compile` – assemble the output into an object file using `cc -c`.
 - `--link` – build an executable by assembling and linking with `cc`.
 - `--obj-dir <path>` – directory for temporary object files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ provides an overview of all available documentation.
 - [Supported language features](language_features.md) – syntax and semantics
   currently implemented, including variadic functions.
 - [Command-line usage](command_line.md) – available options and example
-  invocations.
+  invocations, including the `--intel-syntax` flag for Intel-style assembly.
 - [Optimization passes](optimization.md) – constant folding, propagation and
   dead code elimination.
 - [Development roadmap](roadmap.md) – planned milestones and compatibility


### PR DESCRIPTION
## Summary
- document the `--intel-syntax` flag in command_line docs
- mention the flag in the docs index

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68630f68070c8324a68893b796dcf646