### PR TITLE
Add asm syntax selection for register names

### DIFF
--- a/include/regalloc_x86.h
+++ b/include/regalloc_x86.h
@@ -14,6 +14,8 @@
 #ifndef VC_REGALLOC_X86_H
 #define VC_REGALLOC_X86_H
 
+#include "cli.h"
+
 /*
  * Number of allocatable general purpose registers.
  *
@@ -31,5 +33,8 @@ const char *regalloc_reg_name(int idx);
 
 /* Enable or disable 64-bit register naming. */
 void regalloc_set_x86_64(int enable);
+
+/* Select assembly syntax flavor for register names. */
+void regalloc_set_asm_syntax(asm_syntax_t syntax);
 
 #endif /* VC_REGALLOC_X86_H */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -107,6 +107,7 @@ char *codegen_ir_to_string(ir_builder_t *ir, int x64,
         return NULL;
     regalloc_t ra;
     regalloc_set_x86_64(x64);
+    regalloc_set_asm_syntax(syntax);
     regalloc_run(ir, &ra);
 
     strbuf_t sb;

--- a/src/regalloc_x86.c
+++ b/src/regalloc_x86.c
@@ -14,6 +14,8 @@
 
 /* Current register naming mode: 0 for 32-bit, 1 for 64-bit. */
 static int use_x86_64 = 0;
+/* Assembly syntax flavor for register names. */
+static asm_syntax_t current_syntax = ASM_ATT;
 
 /* register names for 32-bit mode */
 static const char *phys_regs_32[REGALLOC_NUM_REGS] = {
@@ -37,9 +39,14 @@ static const char *phys_regs_64[REGALLOC_NUM_REGS] = {
 const char *regalloc_reg_name(int idx)
 {
     const char **regs = use_x86_64 ? phys_regs_64 : phys_regs_32;
+    const char *name;
     if (idx >= 0 && idx < REGALLOC_NUM_REGS)
-        return regs[idx];
-    return use_x86_64 ? "%rax" : "%eax";
+        name = regs[idx];
+    else
+        name = use_x86_64 ? "%rax" : "%eax";
+    if (current_syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
 }
 
 /*
@@ -49,4 +56,10 @@ const char *regalloc_reg_name(int idx)
 void regalloc_set_x86_64(int enable)
 {
     use_x86_64 = enable ? 1 : 0;
+}
+
+/* Set the assembly syntax style used for register names. */
+void regalloc_set_asm_syntax(asm_syntax_t syntax)
+{
+    current_syntax = syntax;
 }


### PR DESCRIPTION
## Summary
- allow regalloc to track assembly syntax
- expose `regalloc_set_asm_syntax` API
- use selected syntax when formatting register names
- set syntax in `codegen_ir_to_string`

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863389ea6b48324a236320e2fcdcc7d