### PR TITLE
Add Intel syntax fixtures and tests

### DIFF
--- a/tests/fixtures/const_load_intel.s
+++ b/tests/fixtures/const_load_intel.s
@@ -1,0 +1,13 @@
+main:
+    pushl ebp
+    movl ebp, esp
+    movl eax, 5
+    movl x, eax
+    movl eax, 5
+    movl y, eax
+    movl eax, 5
+    movl eax, eax
+    ret
+    movl esp, ebp
+    popl ebp
+    ret

--- a/tests/fixtures/simple_add_intel.s
+++ b/tests/fixtures/simple_add_intel.s
@@ -1,0 +1,9 @@
+main:
+    pushl ebp
+    movl ebp, esp
+    movl eax, 7
+    movl eax, eax
+    ret
+    movl esp, ebp
+    popl ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -65,6 +65,19 @@ for asm64 in "$DIR"/fixtures/*_x86-64.s; do
     rm -f "${out}"
 done
 
+# verify Intel syntax assembly for selected fixtures
+for intelasm in "$DIR"/fixtures/*_intel.s; do
+    base=$(basename "$intelasm" _intel.s)
+    cfile="$DIR/fixtures/$base.c"
+    out=$(mktemp)
+    "$BINARY" --intel-syntax -o "${out}" "$cfile"
+    if ! diff -u "$intelasm" "${out}"; then
+        echo "Test intel_${base} failed"
+        fail=1
+    fi
+    rm -f "${out}"
+done
+
 # verify include search path option
 inc_out=$(mktemp)
 "$BINARY" -I "$DIR/includes" -o "${inc_out}" "$DIR/fixtures/include_search.c"


### PR DESCRIPTION
## Summary
- add Intel assembly fixtures for `simple_add.c` and `const_load.c`
- test `--intel-syntax` output in `tests/run_tests.sh`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68634cd6dc808324b8f4c8bc7b517157