### PR TITLE
Document nasm requirement for intel syntax

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -40,6 +40,9 @@ To dump the generated assembly to stdout instead of creating a file, use
 To assemble the output directly into an object file, pass `-c` or
 `--compile` along with an output path ending in `.o`. The compiler will
 invoke `cc -c` on the generated assembly to produce the object file.
+When the `--intel-syntax` flag is used together with `--compile` or the
+`--link` option, the build requires `nasm` to assemble the Intel-style
+output.
 
 ## Additional build steps
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -19,7 +19,8 @@ The compiler supports the following options:
 - `--no-inline` – disable inline expansion of small functions.
 - `--debug` – emit `.file` and `.loc` directives in the assembly output.
 - `--x86-64` – generate 64‑bit x86 assembly.
-- `--intel-syntax` – enable Intel-style x86 assembly output.
+- `--intel-syntax` – enable Intel-style x86 assembly output. When used
+  together with `--compile` or `--link`, the assembler must be `nasm`.
 - `-c`, `--compile` – assemble the output into an object file using `cc -c`.
 - `--link` – build an executable by assembling and linking with `cc`.
 - `--obj-dir <path>` – directory for temporary object files.

--- a/man/vc.1
+++ b/man/vc.1
@@ -11,6 +11,8 @@ It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Intel-style assembly output may be selected with \fB--intel-syntax\fR.
+When this mode is combined with \fB--compile\fR or \fB--link\fR the
+\fInasm\fR assembler must be available.
 Supported constructs include arrays (including variable length arrays inside functions with sizes determined at runtime, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers with standard escape sequences such as \n, \t, \r, \b, \f, \v and numeric forms like \e123 or \ex7F, complete \fBstruct\fR and \fBunion\fR declarations with bit-field members, enum variables, typedef declarations, the
 Wide character and string literals may be written using L'c' and L"text".
@@ -77,7 +79,9 @@ Emit .file and .loc directives for debugging.
 Generate x86-64 assembly instead of 32-bit.
 .TP
 .B --intel-syntax
-Use Intel-style x86 assembly output.
+Use Intel-style x86 assembly output. When combined with
+\fB--compile\fR or \fB--link\fR this option requires \fInasm\fR to
+assemble the generated code.
 .TP
 .BR -c "," \fB--compile\fR
 Assemble the output into an object file using \fBcc -c\fR.


### PR DESCRIPTION
## Summary
- mention nasm when using `--intel-syntax` with `--compile` or `--link`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863677636448324a5df0d761ea743cf