### PR TITLE
Fix bit-field load braces

### DIFF
--- a/src/codegen_mem.c
+++ b/src/codegen_mem.c
@@ -333,11 +333,12 @@ static void emit_bfload(strbuf_t *sb, ir_instr_t *ins,
     unsigned long long mask = (width == 64) ? 0xffffffffffffffffULL
                                             : ((1ULL << width) - 1ULL);
     emit_move_with_spill(sb, sfx, ins->name, dest, slot, 0, syntax);
-    if (shift)
+    if (shift) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    shr%s %s, %u\n", sfx, dest, shift);
         else
             strbuf_appendf(sb, "    shr%s $%u, %s\n", sfx, shift, dest);
+    }
     if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    and%s %s, %llu\n", sfx, dest, mask);
     else


### PR DESCRIPTION
## Summary
- add braces to the `if (shift)` block in `emit_bfload`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68636bdc6e38832485087494b7b3f2fa