### PR TITLE
Support pointer-size mode in consteval

### DIFF
--- a/include/consteval.h
+++ b/include/consteval.h
@@ -13,6 +13,8 @@
 
 int is_intlike(type_kind_t t);
 int is_floatlike(type_kind_t t);
-int eval_const_expr(expr_t *expr, symtable_t *vars, long long *out);
+/* Evaluate a constant expression using the given pointer size. */
+int eval_const_expr(expr_t *expr, symtable_t *vars,
+                    int use_x86_64, long long *out);
 
 #endif /* VC_CONSTEVAL_H */

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -176,7 +176,7 @@ static int check_enum_decl_global(stmt_t *decl, symtable_t *globals)
         enumerator_t *e = &decl->enum_decl.items[i];
         long long val = next;
         if (e->value) {
-            if (!eval_const_expr(e->value, globals, &val)) {
+            if (!eval_const_expr(e->value, globals, 0, &val)) {
                 error_set(e->value->line, e->value->column, error_current_file, error_current_function);
                 return 0;
             }
@@ -423,7 +423,7 @@ static int emit_global_initializer(stmt_t *decl, symbol_t *sym,
 
     long long value = 0;
     if (decl->var_decl.init) {
-        if (!eval_const_expr(decl->var_decl.init, globals, &value)) {
+        if (!eval_const_expr(decl->var_decl.init, globals, 0, &value)) {
             error_set(decl->var_decl.init->line, decl->var_decl.init->column, error_current_file, error_current_function);
             return 0;
         }

--- a/src/semantic_init.c
+++ b/src/semantic_init.c
@@ -35,7 +35,7 @@ static int validate_array_entry(init_entry_t *ent, size_t array_size,
     size_t i = *cur;
     if (ent->kind == INIT_INDEX) {
         long long cidx;
-        if (!eval_const_expr(ent->index, vars, &cidx) || cidx < 0 ||
+        if (!eval_const_expr(ent->index, vars, 0, &cidx) || cidx < 0 ||
             (size_t)cidx >= array_size) {
             error_set(ent->index->line, ent->index->column, error_current_file, error_current_function);
             return 0;
@@ -119,7 +119,7 @@ int expand_array_initializer(init_entry_t *entries, size_t count,
                                   &cur, &idx))
             return cleanup_and_return(vals);
         long long val;
-        if (!eval_const_expr(ent->value, vars, &val)) {
+        if (!eval_const_expr(ent->value, vars, 0, &val)) {
             error_set(ent->value->line, ent->value->column, error_current_file, error_current_function);
             return cleanup_and_return(vals);
         }
@@ -154,7 +154,7 @@ int expand_struct_initializer(init_entry_t *entries, size_t count,
         if (!resolve_struct_field(ent, sym, line, column, &cur, &idx))
             return cleanup_and_return(vals);
         long long val;
-        if (!eval_const_expr(ent->value, vars, &val)) {
+        if (!eval_const_expr(ent->value, vars, 0, &val)) {
             error_set(ent->value->line, ent->value->column, error_current_file, error_current_function);
             return cleanup_and_return(vals);
         }

--- a/src/semantic_mem.c
+++ b/src/semantic_mem.c
@@ -87,7 +87,8 @@ type_kind_t check_index_expr(expr_t *expr, symtable_t *vars,
         return TYPE_UNKNOWN;
     }
     long long cval;
-    if (sym->array_size && eval_const_expr(expr->index.index, vars, &cval)) {
+    if (sym->array_size &&
+        eval_const_expr(expr->index.index, vars, 0, &cval)) {
         if (cval < 0 || (size_t)cval >= sym->array_size) {
             error_set(expr->index.index->line, expr->index.index->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
@@ -140,7 +141,8 @@ type_kind_t check_assign_index_expr(expr_t *expr, symtable_t *vars,
         return TYPE_UNKNOWN;
     }
     long long cval;
-    if (sym->array_size && eval_const_expr(expr->assign_index.index, vars, &cval)) {
+    if (sym->array_size &&
+        eval_const_expr(expr->assign_index.index, vars, 0, &cval)) {
         if (cval < 0 || (size_t)cval >= sym->array_size) {
             error_set(expr->assign_index.index->line, expr->assign_index.index->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -53,7 +53,7 @@ static int check_enum_decl_stmt(stmt_t *stmt, symtable_t *vars)
         enumerator_t *e = &stmt->enum_decl.items[i];
         long long val = next;
         if (e->value) {
-            if (!eval_const_expr(e->value, vars, &val)) {
+            if (!eval_const_expr(e->value, vars, 0, &val)) {
                 error_set(e->value->line, e->value->column, error_current_file, error_current_function);
                 return 0;
             }
@@ -366,7 +366,7 @@ static int emit_static_initializer(stmt_t *stmt, symbol_t *sym,
                                    symtable_t *vars, ir_builder_t *ir)
 {
     long long cval;
-    if (!eval_const_expr(stmt->var_decl.init, vars, &cval)) {
+    if (!eval_const_expr(stmt->var_decl.init, vars, 0, &cval)) {
         error_set(stmt->var_decl.init->line, stmt->var_decl.init->column, error_current_file, error_current_function);
         return 0;
     }

--- a/src/semantic_switch.c
+++ b/src/semantic_switch.c
@@ -126,7 +126,7 @@ static char **emit_case_branches(stmt_t *stmt, symtable_t *vars,
         snprintf(buf, sizeof(buf), "L%d_case%zu", id, i);
         labels[i] = vc_strdup(buf);
         long long cval;
-        if (!eval_const_expr(stmt->switch_stmt.cases[i].expr, vars, &cval)) {
+        if (!eval_const_expr(stmt->switch_stmt.cases[i].expr, vars, 0, &cval)) {
             for (size_t j = 0; j <= i; j++)
                 free(labels[j]);
             free(labels);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -56,6 +56,10 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/semantic_call.c src/consteval.c src/symtable_core.c \
     src/ast_expr.c src/vector.c src/util.c src/ir_core.c \
     src/error.c src/label.c
+# build sizeof pointer evaluation test
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/eval_sizeof_tests" "$DIR/unit/test_eval_sizeof.c" \
+    src/ast_expr.c src/consteval.c src/util.c
 # build strbuf overflow regression test
 cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_overflow_impl.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strbuf.o
@@ -100,6 +104,7 @@ rm -f compile_temp.o "$DIR/test_temp_file.o"
 "$DIR/ir_core_tests"
 # remaining unit test binaries
 "$DIR/cond_expr_tests"
+"$DIR/eval_sizeof_tests"
 "$DIR/waitpid_retry"
 "$DIR/temp_file_tests"
 "$DIR/preproc_alloc_tests"

--- a/tests/unit/test_eval_sizeof.c
+++ b/tests/unit/test_eval_sizeof.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include "ast_expr.h"
+#include "consteval.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void test_sizeof_ptr_32(void)
+{
+    expr_t *e = ast_make_sizeof_type(TYPE_PTR, 0, 0, 1, 1);
+    long long val = 0;
+    ASSERT(eval_const_expr(e, NULL, 0, &val));
+    ASSERT(val == 4);
+    ast_free_expr(e);
+}
+
+static void test_sizeof_ptr_64(void)
+{
+    expr_t *e = ast_make_sizeof_type(TYPE_PTR, 0, 0, 1, 1);
+    long long val = 0;
+    ASSERT(eval_const_expr(e, NULL, 1, &val));
+    ASSERT(val == 8);
+    ast_free_expr(e);
+}
+
+int main(void)
+{
+    test_sizeof_ptr_32();
+    test_sizeof_ptr_64();
+    if (failures == 0)
+        printf("All eval_sizeof tests passed\n");
+    else
+        printf("%d eval_sizeof test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- allow `eval_sizeof` to adjust pointer size based on the code generation mode
- propagate mode through `eval_const_expr`
- update semantic callers
- add regression test for sizeof on pointers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68636d7293f48324ad95716155276a75