### PR TITLE
Fix run_command buffer allocation error path

### DIFF
--- a/tests/unit/test_waitpid_retry.c
+++ b/tests/unit/test_waitpid_retry.c
@@ -4,7 +4,6 @@
 #include <errno.h>
 #include <spawn.h>
 #include <sys/wait.h>
-#include "strbuf.h"
 
 extern char **environ;
 
@@ -14,15 +13,29 @@ static int run_command(char *const argv[])
     int status;
     int ret = posix_spawnp(&pid, argv[0], NULL, NULL, argv, environ);
     if (ret != 0) {
-        strbuf_t cmd;
-        strbuf_init(&cmd);
-        for (size_t i = 0; argv[i]; i++) {
-            if (i > 0)
-                strbuf_append(&cmd, " ");
-            strbuf_append(&cmd, argv[i]);
+        char cmd[256];
+        size_t len = 0;
+        cmd[0] = '\0';
+        for (size_t i = 0; argv[i] && len < sizeof(cmd) - 1; i++) {
+            if (i > 0 && len < sizeof(cmd) - 1)
+                cmd[len++] = ' ';
+            if (len >= sizeof(cmd) - 1)
+                break;
+            int n = snprintf(cmd + len, sizeof(cmd) - len, "%s", argv[i]);
+            if (n < 0)
+                break;
+            if ((size_t)n >= sizeof(cmd) - len) {
+                len = sizeof(cmd) - 1;
+                break;
+            }
+            len += (size_t)n;
         }
-        fprintf(stderr, "posix_spawnp %s: %s\n", cmd.data, strerror(ret));
-        strbuf_free(&cmd);
+        cmd[len] = '\0';
+        if (len == sizeof(cmd) - 1 && sizeof(cmd) > 4) {
+            memcpy(cmd + sizeof(cmd) - 4, "...", 3);
+            cmd[sizeof(cmd) - 1] = '\0';
+        }
+        fprintf(stderr, "posix_spawnp %s: %s\n", cmd, strerror(ret));
         return 0;
     }
     while (waitpid(pid, &status, 0) < 0) {


### PR DESCRIPTION
## Summary
- avoid dynamic strbuf allocation in `run_command`
- adjust unit test helper to match new behavior

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68636fb9051c83249c20710febbc7f93