### PR TITLE
Handle strtoll overflow

### DIFF
--- a/src/consteval.c
+++ b/src/consteval.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdlib.h>
+#include <errno.h>
 #include "consteval.h"
 #include "symtable.h"
 
@@ -47,8 +48,12 @@ int is_floatlike(type_kind_t t)
  */
 static int eval_number(expr_t *expr, long long *out)
 {
+    errno = 0;
+    long long val = strtoll(expr->number.value, NULL, 0);
+    if (errno != 0)
+        return 0;
     if (out)
-        *out = strtoll(expr->number.value, NULL, 0);
+        *out = val;
     return 1;
 }
 

--- a/src/semantic_expr.c
+++ b/src/semantic_expr.c
@@ -20,6 +20,7 @@
 #include "label.h"
 #include "error.h"
 #include <limits.h>
+#include <errno.h>
 
 /*
  * Validate a numeric literal and emit a constant IR value.  The returned
@@ -30,7 +31,15 @@ static type_kind_t check_number_expr(expr_t *expr, symtable_t *vars,
                                      ir_value_t *out)
 {
     (void)vars; (void)funcs;
+    errno = 0;
     long long val = strtoll(expr->number.value, NULL, 0);
+    if (errno != 0) {
+        error_set(expr->line, expr->column, error_current_file,
+                  error_current_function);
+        if (out)
+            *out = (ir_value_t){0};
+        return TYPE_UNKNOWN;
+    }
     if (out)
         *out = ir_build_const(ir, val);
     if (val > INT_MAX || val < INT_MIN)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -57,9 +57,14 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/ast_expr.c src/vector.c src/util.c src/ir_core.c \
     src/error.c src/label.c
 # build sizeof pointer evaluation test
+# eval sizeof with small helper modules
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/eval_sizeof_tests" "$DIR/unit/test_eval_sizeof.c" \
-    src/ast_expr.c src/consteval.c src/util.c
+    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c
+# build numeric constant overflow regression test
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/number_overflow" "$DIR/unit/test_number_overflow.c" \
+    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c
 # build strbuf overflow regression test
 cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_overflow_impl.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strbuf.o
@@ -105,6 +110,7 @@ rm -f compile_temp.o "$DIR/test_temp_file.o"
 # remaining unit test binaries
 "$DIR/cond_expr_tests"
 "$DIR/eval_sizeof_tests"
+"$DIR/number_overflow"
 "$DIR/waitpid_retry"
 "$DIR/temp_file_tests"
 "$DIR/preproc_alloc_tests"

--- a/tests/unit/test_number_overflow.c
+++ b/tests/unit/test_number_overflow.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include "ast_expr.h"
+#include "consteval.h"
+
+int main(void)
+{
+    /* LLONG_MAX + 1 */
+    expr_t *e = ast_make_number("9223372036854775808", 1, 1);
+    long long val = 0;
+    if (eval_const_expr(e, NULL, 0, &val)) {
+        printf("overflow not detected\n");
+        ast_free_expr(e);
+        return 1;
+    }
+    ast_free_expr(e);
+    printf("All number_overflow tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate `strtoll` results in constant evaluation code
- propagate overflow failure when parsing numeric literals
- compile and run new overflow regression test
- ensure tests build with required modules

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68636fa9b9b4832482eb8f52d52e4b9d