### PR TITLE
Use vc_strdup for stdin path allocation

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -195,8 +195,9 @@ static int compile_tokenize(const char *source, const vector_t *incdirs,
             unlink(tmpl);
             return 0;
         }
-        char *stdin_path = strdup(tmpl);
+        char *stdin_path = vc_strdup(tmpl);
         if (!stdin_path) {
+            fprintf(stderr, "Out of memory\n");
             unlink(tmpl);
             return 0;
         }


### PR DESCRIPTION
## Summary
- replace `strdup` with `vc_strdup` in `compile_tokenize`
- report allocation failure and return error

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863f2d0397883249bc5ac6453f3bfab