### PR TITLE
Fix regression test exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ make test            # builds vc and runs tests/run_tests.sh
 tests/run.sh         # builds vc, compiles unit tests and runs everything
 ```
 
-When all checks succeed the output ends with `All tests passed`.
+Both scripts exit with status 0 when all checks pass. The output ends with
+`All tests passed` on success.
 
 ## Documentation
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -67,7 +67,7 @@ tests/run.sh
 
 This script builds the compiler, compiles the unit test harness for the lexer
 and parser, and then runs both the unit tests and the integration tests found
-under `tests/`.
+under `tests/`. It returns a non-zero status if any test fails.
 
 ## Improved diagnostics
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
+# exit on unhandled errors
 set -e
 DIR=$(dirname "$0")
+# track failing regression tests
+fail=0
 # build the compiler
 make
 # build unit test binary
@@ -142,3 +145,4 @@ fi
 rm -f "$err" "$DIR/collect_funcs_overflow"
 # run integration tests
 "$DIR/run_tests.sh"
+exit $fail


### PR DESCRIPTION
## Summary
- initialize a `fail` flag in `tests/run.sh`
- return the failure status from the script
- document the script's exit behavior

## Testing
- `tests/run.sh` *(fails: 4 ir_core test(s) failed)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa93f9b483249144744dc1e281e1