### PR TITLE
Add error message for temporary object failure

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -89,8 +89,13 @@ int compile_unit(const char *source, const cli_options_t *cli,
                  const char *output, int compile_obj);
 
 /* Compile one source file into a temporary object file. */
+#ifdef UNIT_TESTING
+int compile_source_obj(const char *source, const cli_options_t *cli,
+                       char **out_path);
+#else
 static int compile_source_obj(const char *source, const cli_options_t *cli,
                               char **out_path);
+#endif
 
 /* Build and run the final linker command. */
 static int run_link_command(const vector_t *objs, const char *output,
@@ -498,6 +503,7 @@ static void cleanup_compile_unit(vector_t *funcs_v, vector_t *globs_v,
 }
 
 /* Compile a single translation unit */
+#ifndef UNIT_TESTING
 int compile_unit(const char *source, const cli_options_t *cli,
                  const char *output, int compile_obj)
 {
@@ -561,6 +567,7 @@ int compile_unit(const char *source, const cli_options_t *cli,
 
     return ok;
 }
+#endif /* !UNIT_TESTING */
 
 /* Create a temporary file and return its descriptor. */
 #ifdef UNIT_TESTING
@@ -720,13 +727,20 @@ static int create_startup_object(const cli_options_t *cli, int use_x86_64,
 }
 
 /* Compile a single source file to a temporary object. */
+#ifdef UNIT_TESTING
+int compile_source_obj(const char *source, const cli_options_t *cli,
+                       char **out_path)
+#else
 static int compile_source_obj(const char *source, const cli_options_t *cli,
                               char **out_path)
+#endif
 {
     char *objname = NULL;
     int fd = create_temp_file(cli, "vcobj", &objname);
-    if (fd < 0)
+    if (fd < 0) {
+        perror("mkstemp");
         return 0;
+    }
     close(fd);
 
     int ok = compile_unit(source, cli, objname, 1);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -45,8 +45,8 @@ cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_parser_alloc_fail.c" -o "
 cc -o "$DIR/parser_alloc_tests" parser_core_fail.o parser_init_fail.o parser_decl_fail.o parser_flow_fail.o parser_toplevel_fail.o parser_expr_fail.o parser_stmt_fail.o parser_types_fail.o symtable_core_fail.o symtable_globals_fail.o symtable_struct_fail.o ast_clone_fail.o ast_expr_fail.o ast_stmt_fail.o lexer_alloc.o vector_alloc.o util_alloc.o error_alloc.o "$DIR/test_parser_alloc_fail.o"
 rm -f parser_core_fail.o parser_init_fail.o parser_decl_fail.o parser_flow_fail.o parser_toplevel_fail.o parser_expr_fail.o parser_stmt_fail.o parser_types_fail.o symtable_core_fail.o symtable_globals_fail.o symtable_struct_fail.o ast_clone_fail.o ast_expr_fail.o ast_stmt_fail.o lexer_alloc.o vector_alloc.o util_alloc.o error_alloc.o "$DIR/test_parser_alloc_fail.o"
 # build ir_core unit test binary with malloc wrapper
-cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c src/ir_core.c -o ir_core_test.o
-cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c src/util.c -o util_ircore.o
+cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -c src/ir_core.c -o ir_core_test.o
+cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -c src/util.c -o util_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/label.c -o label_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_ir_core.c" -o "$DIR/test_ir_core.o"
@@ -95,8 +95,7 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_preproc.o
 cc -o "$DIR/preproc_alloc_tests" "$DIR/test_preproc_alloc_fail.o" vector_preproc.o
 rm -f "$DIR/test_preproc_alloc_fail.o" vector_preproc.o
 # build add_macro push failure test
-cc -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push \
-    -c "$DIR/unit/test_add_macro_fail.c" -o "$DIR/test_add_macro_fail.o"
+cc -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push -c "$DIR/unit/test_add_macro_fail.c" -o "$DIR/test_add_macro_fail.o"
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_addmacro.o
 cc -o "$DIR/add_macro_fail_tests" "$DIR/test_add_macro_fail.o" vector_addmacro.o
 rm -f "$DIR/test_add_macro_fail.o" vector_addmacro.o
@@ -105,6 +104,11 @@ cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-se
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
 cc -Wl,--gc-sections -o "$DIR/temp_file_tests" compile_temp.o "$DIR/test_temp_file.o"
 rm -f compile_temp.o "$DIR/test_temp_file.o"
+# build compile_source_obj temp file failure test
+cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -Dcompile_unit=test_compile_unit -ffunction-sections -fdata-sections -c src/compile.c -o compile_obj_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_compile_obj_fail.c" -o "$DIR/test_compile_obj_fail.o"
+cc -Wl,--gc-sections -o "$DIR/compile_obj_fail" compile_obj_fail.o "$DIR/test_compile_obj_fail.o"
+rm -f compile_obj_fail.o "$DIR/test_compile_obj_fail.o"
 # run unit tests
 "$DIR/unit_tests"
 "$DIR/cli_tests"
@@ -116,6 +120,7 @@ rm -f compile_temp.o "$DIR/test_temp_file.o"
 "$DIR/number_overflow"
 "$DIR/waitpid_retry"
 "$DIR/temp_file_tests"
+"$DIR/compile_obj_fail"
 "$DIR/preproc_alloc_tests"
 "$DIR/add_macro_fail_tests"
 "$DIR/invalid_macro_tests"

--- a/tests/unit/test_add_macro_fail.c
+++ b/tests/unit/test_add_macro_fail.c
@@ -14,6 +14,7 @@ static int failures = 0;
 
 extern int vector_push(vector_t *vec, const void *elem); /* real impl */
 static int fail_push = 0;
+#undef vector_push
 int test_vector_push(vector_t *vec, const void *elem)
 {
     if (fail_push)

--- a/tests/unit/test_compile_obj_fail.c
+++ b/tests/unit/test_compile_obj_fail.c
@@ -1,0 +1,33 @@
+#include <string.h>
+#include <errno.h>
+#include "cli.h"
+
+int compile_source_obj(const char *source, const cli_options_t *cli,
+                       char **out_path);
+
+/* provide stub so compile_source_obj can link but is never called */
+int test_compile_unit(const char *src, const cli_options_t *cli,
+                      const char *out, int compile_obj)
+{
+    (void)src; (void)cli; (void)out; (void)compile_obj;
+    return 1;
+}
+
+/* force mkstemp failure */
+int mkstemp(char *template)
+{
+    (void)template;
+    errno = EACCES;
+    return -1;
+}
+
+int main(void)
+{
+    cli_options_t cli;
+    memset(&cli, 0, sizeof(cli));
+    char *path = (char *)0x1;
+    int ok = compile_source_obj("dummy.c", &cli, &path);
+    if (ok || path != (char *)0x1)
+        return 1;
+    return 0;
+}

--- a/tests/unit/test_ir_core.c
+++ b/tests/unit/test_ir_core.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
 #include <limits.h>
 #include <unistd.h>
 #include <sys/wait.h>
@@ -24,6 +26,16 @@ void *test_malloc(size_t size)
         fail_after--;
     }
     return malloc(size);
+}
+
+void *test_calloc(size_t nmemb, size_t size)
+{
+    if (size && nmemb > SIZE_MAX / size)
+        return NULL;
+    void *ptr = test_malloc(nmemb * size);
+    if (ptr)
+        memset(ptr, 0, nmemb * size);
+    return ptr;
 }
 
 static void test_wstring_alloc_fail(void)


### PR DESCRIPTION
## Summary
- expose `compile_source_obj` for testing and print temp file creation errors
- use custom calloc wrapper to test ir_core
- avoid vector_push recursion in add_macro regression test

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6863fde5528083248866b3417294a51e