### PR TITLE
Handle wide-string label strdup failure

### DIFF
--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -170,17 +170,6 @@ ir_value_t ir_build_wstring(ir_builder_t *b, const char *str)
         return (ir_value_t){0};
     ins->op = IR_GLOB_WSTRING;
     ins->dest = alloc_value_id(b);
-    char label[32];
-    const char *fmt = label_format("LWstr", ins->dest, label);
-    if (!fmt) {
-        remove_instr(b, ins);
-        return (ir_value_t){0};
-    }
-    ins->name = vc_strdup(fmt);
-    if (!ins->name) {
-        remove_instr(b, ins);
-        return (ir_value_t){0};
-    }
     size_t len = strlen(str ? str : "");
     if (len + 1 > SIZE_MAX / sizeof(long long)) {
         error_set(b->cur_line, b->cur_column, b->cur_file, error_current_function);
@@ -196,6 +185,19 @@ ir_value_t ir_build_wstring(ir_builder_t *b, const char *str)
     for (size_t i = 0; i < len; i++)
         vals[i] = (unsigned char)str[i];
     vals[len] = 0;
+    char label[32];
+    const char *fmt = label_format("LWstr", ins->dest, label);
+    if (!fmt) {
+        free(vals);
+        remove_instr(b, ins);
+        return (ir_value_t){0};
+    }
+    ins->name = vc_strdup(fmt);
+    if (!ins->name) {
+        free(vals);
+        remove_instr(b, ins);
+        return (ir_value_t){0};
+    }
     ins->imm = (long long)(len + 1);
     ins->data = (char *)vals;
     return (ir_value_t){ins->dest};

--- a/tests/unit/test_ir_core.c
+++ b/tests/unit/test_ir_core.c
@@ -115,6 +115,19 @@ static void test_strdup_fail_string(void)
     ir_builder_free(&b);
 }
 
+static void test_strdup_fail_wstring(void)
+{
+    ir_builder_t b;
+    ir_builder_init(&b);
+    fail_malloc = 1;
+    fail_after = 2; /* fail duplicating label after buffer alloc */
+    ir_value_t v = ir_build_wstring(&b, "abc");
+    ASSERT(v.id == 0);
+    ASSERT(b.head == NULL && b.tail == NULL);
+    fail_malloc = 0;
+    ir_builder_free(&b);
+}
+
 int main(void)
 {
     test_wstring_alloc_fail();
@@ -122,6 +135,7 @@ int main(void)
     test_id_overflow();
     test_strdup_fail_load();
     test_strdup_fail_string();
+    test_strdup_fail_wstring();
     if (failures == 0)
         printf("All ir_core tests passed\n");
     else


### PR DESCRIPTION
## Summary
- guard against `vc_strdup` failure in `ir_build_wstring`
- add unit test for label duplication failure in wide string builder

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68640303855c832483749ef5b7e4e264