### PR TITLE
Fix include stack ENOENT warning

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -61,7 +61,8 @@ static int include_stack_contains(vector_t *stack, const char *path)
 {
     char *canon = realpath(path, NULL);
     if (!canon) {
-        perror(path);
+        if (errno != ENOENT)
+            perror(path);
         return 0;
     }
     for (size_t i = 0; i < stack->count; i++) {


### PR DESCRIPTION
## Summary
- suppress `perror` when `realpath` fails with `ENOENT`
- only print an error for other failures

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68641e7fafd483249fd89f5fe99e65a3