### PR TITLE
Move run_command into shared module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc
 # Core compiler sources
 
-CORE_SRC = src/main.c src/compile.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_init.c \
+CORE_SRC = src/main.c src/compile.c src/command.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_init.c \
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
@@ -22,7 +22,7 @@ SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_global.h include/ir_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
-    include/util.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
+    include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
@@ -52,6 +52,8 @@ src/main.o: src/main.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/main.c -o src/main.o
 src/compile.o: src/compile.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile.c -o src/compile.o
+src/command.o: src/command.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/command.c -o src/command.o
 
 
 src/cli.o: src/cli.c $(HDR)

--- a/include/command.h
+++ b/include/command.h
@@ -1,0 +1,25 @@
+/*
+ * Command execution helpers.
+ *
+ * Provides routines for running external programs and formatting
+ * command strings for debugging.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_COMMAND_H
+#define VC_COMMAND_H
+
+/* Convert an argument vector into a single string for debugging.
+ * The returned buffer is heap allocated and must be freed by the caller.
+ */
+char *command_to_string(char *const argv[]);
+
+/* Spawn a command and wait for completion.
+ * Returns 1 on success, 0 on failure and -1 if the child was terminated
+ * by a signal.
+ */
+int command_run(char *const argv[]);
+
+#endif /* VC_COMMAND_H */

--- a/src/command.c
+++ b/src/command.c
@@ -1,0 +1,84 @@
+#define _POSIX_C_SOURCE 200809L
+/*
+ * Command execution utilities.
+ *
+ * Implementation of command_run using posix_spawnp and helpers to
+ * convert argument vectors into printable strings.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "command.h"
+#include "util.h"
+
+extern char **environ;
+
+/* Build a printable string representation of an argv array. */
+char *command_to_string(char *const argv[])
+{
+    size_t cap = 256;
+    char *cmd = vc_alloc_or_exit(cap);
+    size_t len = 0;
+    cmd[0] = '\0';
+
+    for (size_t i = 0; argv[i] && len < cap - 1; i++) {
+        if (i > 0 && len < cap - 1)
+            cmd[len++] = ' ';
+        if (len >= cap - 1)
+            break;
+        int n = snprintf(cmd + len, cap - len, "%s", argv[i]);
+        if (n < 0)
+            break;
+        if ((size_t)n >= cap - len) {
+            len = cap - 1;
+            break;
+        }
+        len += (size_t)n;
+    }
+    cmd[len] = '\0';
+    if (len == cap - 1 && cap > 4) {
+        memcpy(cmd + cap - 4, "...", 3);
+        cmd[cap - 1] = '\0';
+    }
+    return cmd;
+}
+
+/*
+ * Spawn a command using posix_spawnp and wait for it to finish.
+ */
+int command_run(char *const argv[])
+{
+    pid_t pid;
+    int status;
+    int ret = posix_spawnp(&pid, argv[0], NULL, NULL, argv, environ);
+    if (ret != 0) {
+        char *cmd = command_to_string(argv);
+        fprintf(stderr, "posix_spawnp %s: %s\n", cmd, strerror(ret));
+        free(cmd);
+        return 0;
+    }
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR)
+            continue;
+        perror("waitpid");
+        return 0;
+    }
+    if (WIFSIGNALED(status)) {
+        fprintf(stderr, "%s terminated by signal %d\n", argv[0],
+                WTERMSIG(status));
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return 0;
+    return 1;
+}
+


### PR DESCRIPTION
## Summary
- extract command execution helpers into new `command` module
- update compile logic to use `command_run`
- build new module in Makefile

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864a8eca23c8324bccbd3802b5f55ec