### PR TITLE
Move startup helpers into separate module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc
 # Core compiler sources
 
-CORE_SRC = src/main.c src/compile.c src/command.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_init.c \
+CORE_SRC = src/main.c src/compile.c src/startup.c src/command.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_init.c \
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
@@ -23,7 +23,7 @@ OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_global.h include/ir_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
-    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h
+    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h include/startup.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man
@@ -54,6 +54,9 @@ src/compile.o: src/compile.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile.c -o src/compile.o
 src/command.o: src/command.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/command.c -o src/command.o
+
+src/startup.o: src/startup.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/startup.c -o src/startup.o
 
 
 src/cli.o: src/cli.c $(HDR)

--- a/include/startup.h
+++ b/include/startup.h
@@ -1,0 +1,21 @@
+/*
+ * Startup stub helpers.
+ *
+ * Provides helpers for generating the program entry stub used during
+ * linking.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_STARTUP_H
+#define VC_STARTUP_H
+
+#include "cli.h"
+
+int write_startup_asm(int use_x86_64, asm_syntax_t syntax,
+                      const cli_options_t *cli, char **out_path);
+int assemble_startup_obj(const char *asm_path, int use_x86_64,
+                         const cli_options_t *cli, char **out_path);
+
+#endif /* VC_STARTUP_H */

--- a/src/startup.c
+++ b/src/startup.c
@@ -1,0 +1,118 @@
+#define _POSIX_C_SOURCE 200809L
+/*
+ * Startup helper routines.
+ *
+ * Contains helpers for emitting and assembling the program entry stub.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "cli.h"
+#include "command.h"
+#include "startup.h"
+
+/* Use binary mode for temporary files on platforms that require it */
+#if defined(_WIN32)
+# define TEMP_FOPEN_MODE "wb"
+#else
+# define TEMP_FOPEN_MODE "w"
+#endif
+
+int create_temp_file(const cli_options_t *cli, const char *prefix,
+                     char **out_path);
+
+/* Write the entry stub assembly to a temporary file. */
+int write_startup_asm(int use_x86_64, asm_syntax_t syntax,
+                      const cli_options_t *cli, char **out_path)
+{
+    char *asmname = NULL;
+    int asmfd = create_temp_file(cli, "vcstub", &asmname);
+    if (asmfd < 0)
+        return 0;
+    FILE *stub = fdopen(asmfd, TEMP_FOPEN_MODE);
+    if (!stub) {
+        perror("fdopen");
+        close(asmfd);
+        unlink(asmname);
+        free(asmname);
+        return 0;
+    }
+    int rc;
+    if (syntax == ASM_INTEL) {
+        if (use_x86_64) {
+            rc = fputs("global _start\n_start:\n    call main\n    mov rdi, rax\n    mov rax, 60\n    syscall\n", stub);
+        } else {
+            rc = fputs("global _start\n_start:\n    call main\n    mov ebx, eax\n    mov eax, 1\n    int 0x80\n", stub);
+        }
+    } else {
+        if (use_x86_64) {
+            rc = fputs(".globl _start\n_start:\n    call main\n    mov %rax, %rdi\n    mov $60, %rax\n    syscall\n", stub);
+        } else {
+            rc = fputs(".globl _start\n_start:\n    call main\n    mov %eax, %ebx\n    mov $1, %eax\n    int $0x80\n", stub);
+        }
+    }
+    if (rc == EOF) {
+        perror("fputs");
+        fclose(stub);
+        unlink(asmname);
+        free(asmname);
+        return 0;
+    }
+    if (fclose(stub) == EOF) {
+        perror("fclose");
+        unlink(asmname);
+        free(asmname);
+        return 0;
+    }
+
+    *out_path = asmname;
+    return 1;
+}
+
+/* Assemble the entry stub into an object file. */
+int assemble_startup_obj(const char *asm_path, int use_x86_64,
+                         const cli_options_t *cli, char **out_path)
+{
+    char *objname = NULL;
+    int objfd = create_temp_file(cli, "vcobj", &objname);
+    if (objfd < 0)
+        return 0;
+    close(objfd);
+
+    int rc;
+    if (cli->asm_syntax == ASM_INTEL) {
+        const char *fmt = use_x86_64 ? "elf64" : "elf32";
+        char *argv[] = {"nasm", "-f", (char *)fmt, (char *)asm_path,
+                        "-o", objname, NULL};
+        rc = command_run(argv);
+    } else {
+        const char *arch_flag = use_x86_64 ? "-m64" : "-m32";
+        char *argv[] = {"cc", "-x", "assembler", (char *)arch_flag, "-c",
+                        (char *)asm_path, "-o", objname, NULL};
+        rc = command_run(argv);
+    }
+    if (rc != 1) {
+        if (rc == 0) {
+            if (cli->asm_syntax == ASM_INTEL)
+                fprintf(stderr, "assembly failed\n");
+            else
+                fprintf(stderr, "cc failed\n");
+        } else if (rc == -1) {
+            if (cli->asm_syntax == ASM_INTEL)
+                fprintf(stderr, "nasm terminated by signal\n");
+            else
+                fprintf(stderr, "cc terminated by signal\n");
+        }
+        unlink(objname);
+        free(objname);
+        return 0;
+    }
+
+    *out_path = objname;
+    return 1;
+}


### PR DESCRIPTION
## Summary
- introduce `startup.c` and `startup.h` for entry stub helpers
- remove inlined implementations from `compile.c`
- export `create_temp_file` for use by startup helpers
- build the new module in Makefile

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864b580ffd88324a0333da813b8324e