### PR TITLE
Improve macro memory documentation

### DIFF
--- a/include/preproc_macros.h
+++ b/include/preproc_macros.h
@@ -15,11 +15,20 @@
 #include "vector.h"
 #include "strbuf.h"
 
-/* Stored macro definition */
+/*
+ * Stored macro definition.
+ *
+ * The strings pointed to by "name" and "value" as well as each entry in
+ * the "params" vector are allocated on the heap.  Ownership of these
+ * allocations belongs to the macro instance and they are released by
+ * macro_free().  add_macro() creates a fully self-contained macro_t by
+ * duplicating the provided name and value strings and taking ownership of
+ * the parameter names supplied in the vector.
+ */
 typedef struct {
-    char *name;
-    vector_t params; /* vector of char* parameter names */
-    char *value;
+    char *name;       /* malloc'd name string */
+    vector_t params;  /* vector of malloc'd char* parameter names */
+    char *value;      /* malloc'd macro body */
 } macro_t;
 
 /* Free memory used by a macro */

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -318,10 +318,18 @@ static char *parse_macro_params(char *p, vector_t *out)
     return p;
 }
 
-/** Create a macro definition and append it to the macro table.
+/**
+ * Create a macro definition and append it to the macro table.
  *
- * Ownership of any parameter strings is transferred from "params" to
- * the new macro entry.  Returns non-zero on success. */
+ * The strings contained in the supplied "params" vector must be
+ * heap allocated.  add_macro() duplicates "name" and "value" and
+ * takes ownership of all parameter strings.  On success the newly
+ * created macro is stored in "macros" and becomes the caller's
+ * responsibility to free using macro_free().
+ *
+ * Any allocation failure results in all intermediate resources
+ * being released and zero being returned.
+ */
 static int add_macro(const char *name, const char *value, vector_t *params,
                      vector_t *macros)
 {
@@ -632,7 +640,10 @@ static int load_and_register_file(const char *path, vector_t *stack,
 
 /*
  * Free all macros stored in a vector.
- * Each macro's resources are released and the vector itself is freed.
+ *
+ * Each macro must have been created by add_macro() so that macro_free()
+ * can correctly release the heap allocated strings.  The vector itself
+ * is also freed.
  */
 static void free_macro_vector(vector_t *v)
 {

--- a/src/preproc_macros.c
+++ b/src/preproc_macros.c
@@ -46,8 +46,11 @@ void preproc_set_function(const char *name)
 
 /*
  * Release all memory associated with a macro definition.
- * Frees the name string, parameter list and value.  Safe to
- * call with a NULL pointer.
+ *
+ * The macro must have been created by add_macro() which allocates
+ * the name and value strings and takes ownership of all parameter
+ * names.  macro_free() disposes of these heap allocations and resets
+ * the internal vector.  It is safe to pass NULL.
  */
 void macro_free(macro_t *m)
 {
@@ -452,7 +455,9 @@ int is_macro_defined(vector_t *macros, const char *name)
 
 /*
  * Delete all macros matching the given name from the macro list.
- * The order of remaining entries is preserved.
+ *
+ * Each removed entry is cleaned up with macro_free().  The order of the
+ * remaining macros is preserved.
  */
 void remove_macro(vector_t *macros, const char *name)
 {


### PR DESCRIPTION
## Summary
- clarify ownership of strings in `macro_t`
- expand `add_macro` and `macro_free` documentation
- note cleanup behaviour in macro helper functions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864b987f05c8324a6e5bfb71bb18a44