### PR TITLE
Improve codegen flag documentation

### DIFF
--- a/include/codegen.h
+++ b/include/codegen.h
@@ -50,4 +50,9 @@ void codegen_set_export(int flag);
 /* Toggle emission of .file and .loc directives */
 void codegen_set_debug(int flag);
 
+/*
+ * These flags are global variables defined in codegen.c so that other
+ * code generation modules can inspect them.
+ */
+
 #endif /* VC_CODEGEN_H */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -26,6 +26,16 @@
 #include "codegen_arith.h"
 #include "codegen_branch.h"
 
+/*
+ * Global flags controlling optional assembly output.
+ *
+ * `export_syms` determines whether function labels are emitted with
+ * `.globl` so that they can be linked from other objects.  Valid values
+ * are 0 (do not export) or 1 (export all functions).
+ *
+ * `debug_info` toggles emission of `.file` and `.loc` directives used by
+ * debuggers.  Set to 1 to enable them or 0 to omit the directives.
+ */
 int export_syms = 0;
 static int debug_info = 0;
 


### PR DESCRIPTION
## Summary
- document the `export_syms` and `debug_info` globals in `codegen.c`
- mention in `codegen.h` that codegen flags are defined in `codegen.c`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864bc9c4d4c83249f32fe056c7483e8