### PR TITLE
Fix temp file cleanup on fcntl failure

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -675,6 +675,7 @@ int create_temp_file(const cli_options_t *cli, const char *prefix,
     if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) {
         int err = errno;
         close(fd);
+        unlink(tmpl);
         free(tmpl);
         *out_path = NULL;
         errno = err;


### PR DESCRIPTION
## Summary
- ensure `create_temp_file` removes the temp file when `fcntl` fails

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865b4ca6afc8324b80953a8c547b0b8