### PR TITLE
Check strbuf append results in handle_line_directive

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -715,10 +715,18 @@ static int handle_line_directive(char *line, const char *dir, vector_t *macros,
             fname = vc_strndup(fstart, (size_t)(p - fstart));
     }
     if (stack_active(conds)) {
-        strbuf_appendf(out, "# %d", lineno);
-        if (fname)
-            strbuf_appendf(out, " \"%s\"", fname);
-        strbuf_append(out, "\n");
+        if (strbuf_appendf(out, "# %d", lineno) < 0) {
+            free(fname);
+            return 0;
+        }
+        if (fname && strbuf_appendf(out, " \"%s\"", fname) < 0) {
+            free(fname);
+            return 0;
+        }
+        if (strbuf_append(out, "\n") < 0) {
+            free(fname);
+            return 0;
+        }
     }
     free(fname);
     return 1;


### PR DESCRIPTION
## Summary
- ensure `handle_line_directive` checks all `strbuf_append*` calls
- return failure when any append fails

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865cfd51af08324b7a6048e95ad8363