### PR TITLE
Fix directory allocation failure handling

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -598,6 +598,11 @@ static int load_file_lines(const char *path, char ***out_lines,
     if (slash) {
         size_t len = (size_t)(slash - path) + 1;
         dir = vc_strndup(path, len);
+        if (!dir) {
+            free(lines);
+            free(text);
+            return 0;
+        }
     }
 
     *out_lines = lines;


### PR DESCRIPTION
## Summary
- detect `vc_strndup` failure when computing directory path in `load_file_lines`
- clean up resources and signal failure instead of returning a NULL directory

## Testing
- `make`
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6865e647edc08324b25cdadc20b496fe