### PR TITLE
Fix lexer token cleanup for NULL inputs

### DIFF
--- a/include/token.h
+++ b/include/token.h
@@ -114,7 +114,8 @@ typedef struct {
  * number of tokens returned. */
 token_t *lexer_tokenize(const char *src, size_t *out_count);
 
-/* Free an array of tokens returned by lexer_tokenize(). */
+/* Free an array of tokens returned by lexer_tokenize().  If \a tokens is NULL
+ * or \a count is zero the function does nothing. */
 void lexer_free_tokens(token_t *tokens, size_t count);
 
 #endif /* VC_TOKEN_H */

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -592,6 +592,9 @@ token_t *lexer_tokenize(const char *src, size_t *out_count)
 /* Free an array of tokens produced by lexer_tokenize */
 void lexer_free_tokens(token_t *tokens, size_t count)
 {
+    if (!tokens || count == 0)
+        return;
+
     for (size_t i = 0; i < count; i++)
         free(tokens[i].lexeme);
     free(tokens);


### PR DESCRIPTION
## Summary
- handle NULL or zero-length token arrays in `lexer_free_tokens`
- document the behavior in `token.h`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865e88647648324aac98a325fdfc7b3