### PR TITLE
Add CLI macro definitions

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -29,6 +29,7 @@ The compiler supports the following options:
 - `--std=<c99|gnu99>` – select the language standard (default is `c99`).
 - `-E`, `--preprocess` – print the preprocessed source to stdout and exit.
 - `-I`, `--include <dir>` – add directory to the `#include` search path.
+- `-Dname[=val]` – define a preprocessor macro before compilation.
 - `-O<N>` – set optimization level (0 disables all passes).
 
 Temporary object and assembly files are written to `/tmp` by default. Use the

--- a/include/cli.h
+++ b/include/cli.h
@@ -38,7 +38,8 @@ typedef enum {
     CLI_OPT_OBJ_DIR,
     CLI_OPT_DEBUG = 10,
     CLI_OPT_NO_INLINE,
-    CLI_OPT_INTEL_SYNTAX = 12
+    CLI_OPT_INTEL_SYNTAX = 12,
+    CLI_OPT_DEFINE
 } cli_opt_id;
 
 /* Command line options parsed from argv */
@@ -57,6 +58,7 @@ typedef struct {
     char *obj_dir;      /* directory for temporary object files */
     vector_t include_dirs; /* additional include directories */
     vector_t sources;      /* input source files */
+    vector_t defines;      /* command line macro definitions */
 } cli_options_t;
 
 /* Parse command line arguments. Returns 0 on success, non-zero on error. */

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -20,6 +20,7 @@
  * The returned string must be freed by the caller.
  * Returns NULL on failure.
  */
-char *preproc_run(const char *path, const vector_t *include_dirs);
+char *preproc_run(const char *path, const vector_t *include_dirs,
+                  const vector_t *defines);
 
 #endif /* VC_PREPROC_FILE_H */

--- a/man/vc.1
+++ b/man/vc.1
@@ -60,6 +60,10 @@ directories, then any paths from the \fBVCPATH\fR environment variable,
 followed by the standard locations such as \fI/usr/include\fR. Quoted
 includes also consult directories from \fBVCINC\fR.
 .TP
+.B \-D\fIname[=val]\fR
+Define a preprocessor macro before compilation. When no value is given,
+the macro is set to \fB1\fR.
+.TP
 .B --no-fold
 Disable constant folding optimization.
 .TP

--- a/tests/fixtures/macro_cli.c
+++ b/tests/fixtures/macro_cli.c
@@ -1,0 +1,3 @@
+int main() {
+    return FLAG + VAL;
+}

--- a/tests/fixtures/macro_cli.s
+++ b/tests/fixtures/macro_cli.s
@@ -1,0 +1,9 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $5, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -10,7 +10,7 @@ for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
 
     case "$base" in
-        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank)
+        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli)
             continue;;
     esac
     expect="$DIR/fixtures/$base.s"
@@ -126,6 +126,15 @@ if ! diff -u "$DIR/fixtures/include_search.s" "${inc_env_out}"; then
     fail=1
 fi
 rm -f "${inc_env_out}"
+
+# verify command-line macro definitions
+macro_out=$(mktemp)
+"$BINARY" -DVAL=4 -DFLAG -o "${macro_out}" "$DIR/fixtures/macro_cli.c"
+if ! diff -u "$DIR/fixtures/macro_cli.s" "${macro_out}"; then
+    echo "Test define_option failed"
+    fail=1
+fi
+rm -f "${macro_out}"
 
 # negative test for parse error message
 err=$(mktemp)


### PR DESCRIPTION
## Summary
- add CLI_OPT_DEFINE enum and `defines` vector to CLI options
- support `-D`/`--define` in option parser
- pass command-line macros to the preprocessor
- inject macros before preprocessing begins
- document new option in docs and man page
- test macro expansion via command line

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865ea5d6d5083248fa2a44b79ff3acd