### PR TITLE
Add -U option for undefining macros

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -30,6 +30,7 @@ The compiler supports the following options:
 - `-E`, `--preprocess` – print the preprocessed source to stdout and exit.
 - `-I`, `--include <dir>` – add directory to the `#include` search path.
 - `-Dname[=val]` – define a preprocessor macro before compilation.
+- `-Uname` – undefine a macro before compilation.
 - `-O<N>` – set optimization level (0 disables all passes).
 
 Temporary object and assembly files are written to `/tmp` by default. Use the

--- a/include/cli.h
+++ b/include/cli.h
@@ -39,7 +39,8 @@ typedef enum {
     CLI_OPT_DEBUG = 10,
     CLI_OPT_NO_INLINE,
     CLI_OPT_INTEL_SYNTAX = 12,
-    CLI_OPT_DEFINE
+    CLI_OPT_DEFINE,
+    CLI_OPT_UNDEFINE
 } cli_opt_id;
 
 /* Command line options parsed from argv */
@@ -59,6 +60,7 @@ typedef struct {
     vector_t include_dirs; /* additional include directories */
     vector_t sources;      /* input source files */
     vector_t defines;      /* command line macro definitions */
+    vector_t undefines;    /* macros to undefine before compilation */
 } cli_options_t;
 
 /* Parse command line arguments. Returns 0 on success, non-zero on error. */

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -21,6 +21,6 @@
  * Returns NULL on failure.
  */
 char *preproc_run(const char *path, const vector_t *include_dirs,
-                  const vector_t *defines);
+                  const vector_t *defines, const vector_t *undefines);
 
 #endif /* VC_PREPROC_FILE_H */

--- a/man/vc.1
+++ b/man/vc.1
@@ -64,6 +64,9 @@ includes also consult directories from \fBVCINC\fR.
 Define a preprocessor macro before compilation. When no value is given,
 the macro is set to \fB1\fR.
 .TP
+.B \-U\fIname\fR
+Remove any definition of \fIname\fR before preprocessing begins.
+.TP
 .B --no-fold
 Disable constant folding optimization.
 .TP

--- a/src/cli.c
+++ b/src/cli.c
@@ -32,6 +32,7 @@ static void print_usage(const char *prog)
     printf("  -O<N>               Optimization level (0-3)\n");
     printf("  -I, --include <dir> Add directory to include search path\n");
     printf("  -Dname[=val]       Define a macro\n");
+    printf("  -Uname             Undefine a macro\n");
     printf("      --std=<std>      Language standard (c99 or gnu99)\n");
     printf("  -h, --help           Display this help and exit\n");
     printf("  -v, --version        Print version information and exit\n");
@@ -79,6 +80,7 @@ static void init_default_opts(cli_options_t *opts)
     vector_init(&opts->include_dirs, sizeof(char *));
     vector_init(&opts->sources, sizeof(char *));
     vector_init(&opts->defines, sizeof(char *));
+    vector_init(&opts->undefines, sizeof(char *));
 }
 
 /*
@@ -282,6 +284,20 @@ static int add_define_opt(const char *arg, const char *prog, cli_options_t *opts
     return 0;
 }
 
+static int add_undef_opt(const char *arg, const char *prog, cli_options_t *opts)
+{
+    (void)prog;
+    if (!arg || !*arg) {
+        fprintf(stderr, "Missing argument for -U option\n");
+        return 1;
+    }
+    if (!vector_push(&opts->undefines, &arg)) {
+        fprintf(stderr, "Out of memory\n");
+        return 1;
+    }
+    return 0;
+}
+
 static int enable_link_opt(const char *arg, const char *prog, cli_options_t *opts)
 {
     (void)arg; (void)prog;
@@ -319,6 +335,7 @@ static int handle_option(int opt, const char *arg, const char *prog,
         {'o', set_output_path},
         {'c', enable_compile},
         {'D', add_define_opt},
+        {'U', add_undef_opt},
         {'I', add_include},
         {'O', set_level},
         {CLI_OPT_NO_FOLD,      disable_fold},
@@ -333,6 +350,7 @@ static int handle_option(int opt, const char *arg, const char *prog,
         {CLI_OPT_NO_INLINE,    disable_inline_opt},
         {'E', enable_preproc},
         {CLI_OPT_DEFINE,       add_define_opt},
+        {CLI_OPT_UNDEFINE,     add_undef_opt},
         {CLI_OPT_LINK,         enable_link_opt},
         {CLI_OPT_STD,          handle_std},
         {CLI_OPT_OBJ_DIR,      set_obj_dir_opt},
@@ -379,6 +397,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"dump-ir", no_argument,      0, CLI_OPT_DUMP_IR},
         {"debug", no_argument,       0, CLI_OPT_DEBUG},
         {"define", required_argument, 0, CLI_OPT_DEFINE},
+        {"undefine", required_argument, 0, CLI_OPT_UNDEFINE},
         {"preprocess", no_argument,  0, 'E'},
         {"link", no_argument,        0, CLI_OPT_LINK},
         {"std", required_argument,   0, CLI_OPT_STD},
@@ -389,7 +408,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
     init_default_opts(opts);
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hvo:O:cD:I:ES", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hvo:O:cD:U:I:ES", long_opts, NULL)) != -1) {
         if (handle_option(opt, optarg, argv[0], opts))
             return 1;
     }

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -1027,7 +1027,7 @@ static void cleanup_preproc_vectors(vector_t *macros, vector_t *conds,
  * invokes the file processor and returns the resulting text.
  */
 char *preproc_run(const char *path, const vector_t *include_dirs,
-                  const vector_t *defines)
+                  const vector_t *defines, const vector_t *undefines)
 {
     vector_t search_dirs, macros, conds, stack;
     strbuf_t out;
@@ -1055,6 +1055,13 @@ char *preproc_run(const char *path, const vector_t *include_dirs,
                 return NULL;
             }
             free(name);
+        }
+    }
+
+    if (undefines) {
+        for (size_t i = 0; i < undefines->count; i++) {
+            const char *name = ((const char **)undefines->data)[i];
+            remove_macro(&macros, name);
         }
     }
 

--- a/tests/fixtures/macro_cli_undef.c
+++ b/tests/fixtures/macro_cli_undef.c
@@ -1,0 +1,5 @@
+#ifdef FLAG
+int main() { return 1; }
+#else
+int main() { return 0; }
+#endif

--- a/tests/fixtures/macro_cli_undef.s
+++ b/tests/fixtures/macro_cli_undef.s
@@ -1,0 +1,9 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $0, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -136,6 +136,15 @@ if ! diff -u "$DIR/fixtures/macro_cli.s" "${macro_out}"; then
 fi
 rm -f "${macro_out}"
 
+# verify command-line macro undefinition
+macro_u_out=$(mktemp)
+"$BINARY" -DFLAG -UFLAG -o "${macro_u_out}" "$DIR/fixtures/macro_cli_undef.c"
+if ! diff -u "$DIR/fixtures/macro_cli_undef.s" "${macro_u_out}"; then
+    echo "Test undef_option failed"
+    fail=1
+fi
+rm -f "${macro_u_out}"
+
 # negative test for parse error message
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- extend `cli_options_t` with a list of macros to undefine
- parse `-Uname`/`--undefine` in the command line interface
- remove requested macros before preprocessing begins
- document the new option and add regression tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865f4692de483249b1e1c517e872004