### PR TITLE
Add ir_insert_after helper

### DIFF
--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -112,6 +112,9 @@ void ir_builder_set_loc(ir_builder_t *b, const char *file, size_t line, size_t c
 /* Release all memory owned by the builder, including instruction nodes. */
 void ir_builder_free(ir_builder_t *b);
 
+/* Allocate and insert a blank instruction after `pos`. */
+ir_instr_t *ir_insert_after(ir_builder_t *b, ir_instr_t *pos);
+
 /* Emit IR_CONST for `value` and return the resulting value id. */
 ir_value_t ir_build_const(ir_builder_t *b, long long value);
 

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -114,6 +114,38 @@ static void remove_instr(ir_builder_t *b, ir_instr_t *ins)
     free(cur);
 }
 
+/* Allocate a blank instruction after `pos` and insert it into the list */
+ir_instr_t *ir_insert_after(ir_builder_t *b, ir_instr_t *pos)
+{
+    if (!b)
+        return NULL;
+
+    ir_instr_t *ins = calloc(1, sizeof(*ins));
+    if (!ins)
+        return NULL;
+    ins->dest = -1;
+    ins->name = NULL;
+    ins->data = NULL;
+    ins->is_volatile = 0;
+    ins->file = b->cur_file;
+    ins->line = b->cur_line;
+    ins->column = b->cur_column;
+
+    if (!pos) {
+        ins->next = b->head;
+        b->head = ins;
+        if (!b->tail)
+            b->tail = ins;
+    } else {
+        ins->next = pos->next;
+        pos->next = ins;
+        if (b->tail == pos)
+            b->tail = ins;
+    }
+
+    return ins;
+}
+
 /*
  * Emit IR_CONST. dest gets a fresh id and imm stores the constant
  * value.


### PR DESCRIPTION
## Summary
- expose new IR utility to insert instructions after a given node
- update builder to allocate and link instruction after a specified node

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865febea0248324b073705e5319478a