### PR TITLE
Add inline fixtures

### DIFF
--- a/tests/fixtures/inline_multi.c
+++ b/tests/fixtures/inline_multi.c
@@ -1,0 +1,4 @@
+inline int multi(int a, int b, int c) {
+    return a * b + c - a;
+}
+int main() { return multi(2, 3, 4); }

--- a/tests/fixtures/inline_multi.s
+++ b/tests/fixtures/inline_multi.s
@@ -1,0 +1,27 @@
+multi:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %eax
+    movl 12(%ebp), %ebx
+    movl %eax, %ecx
+    imull %ebx, %ecx
+    movl 16(%ebp), %ebx
+    movl %ecx, %eax
+    addl %ebx, %eax
+    movl 8(%ebp), %ebx
+    movl %eax, %ecx
+    subl %ebx, %ecx
+    movl %ecx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $10, %ecx
+    movl %ecx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/inline_return.c
+++ b/tests/fixtures/inline_return.c
@@ -1,0 +1,4 @@
+inline int identity(int x) {
+    return x;
+}
+int main() { return identity(7); }

--- a/tests/fixtures/inline_return.s
+++ b/tests/fixtures/inline_return.s
@@ -1,0 +1,18 @@
+identity:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $7, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -429,6 +429,23 @@ if ! grep -q "call add" "${inline_out}"; then
 fi
 rm -f "${inline_out}"
 
+# verify additional inline fixtures
+multi_out=$(mktemp)
+"$BINARY" -o "${multi_out}" "$DIR/fixtures/inline_multi.c"
+if ! diff -u "$DIR/fixtures/inline_multi.s" "${multi_out}"; then
+    echo "Test inline_multi failed"
+    fail=1
+fi
+rm -f "${multi_out}"
+
+return_out=$(mktemp)
+"$BINARY" -o "${return_out}" "$DIR/fixtures/inline_return.c"
+if ! diff -u "$DIR/fixtures/inline_return.s" "${return_out}"; then
+    echo "Test inline_return failed"
+    fail=1
+fi
+rm -f "${return_out}"
+
 # test --debug option
 debug_out=$(mktemp)
 "$BINARY" --debug -S "$DIR/fixtures/simple_add.c" > "${debug_out}"


### PR DESCRIPTION
## Summary
- add inline_multi fixture demonstrating arithmetic in an inline function
- add inline_return fixture for returning a parameter
- generate expected assembly for both
- reference the new fixtures in run_tests.sh

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866948f87cc8324b829d1c53c83918d