### PR TITLE
Add unreachable block elimination pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CORE_SRC = src/main.c src/compile.c src/startup.c src/command.c src/cli.c src/le
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
 
 # Optional optimization sources
-OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_dce.c src/opt_inline.c
+OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_dce.c src/opt_inline.c src/opt_unreachable.c
 # Additional sources can be specified by the user
 EXTRA_SRC ?=
 # Final source list
@@ -206,3 +206,6 @@ src/opt_dce.o: src/opt_dce.c $(HDR)
 src/opt_inline.o: src/opt_inline.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt_inline.c -o src/opt_inline.o
 
+
+src/opt_unreachable.o: src/opt_unreachable.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt_unreachable.c -o src/opt_unreachable.o

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -3,7 +3,7 @@
 See the [documentation index](index.md) for a list of all available pages.
 
 The optimizer in **vc** operates on the intermediate representation (IR).
-Five passes are currently available and are executed in order:
+Six passes are currently available and are executed in order:
 1. **Constant propagation** – replaces loads of variables whose values are
    known constants with immediate constants.
 2. **Common subexpression elimination** – reuses results of identical
@@ -12,7 +12,9 @@ Five passes are currently available and are executed in order:
    instructions or just a `return` when they are marked `inline`.
 4. **Constant folding** – evaluates arithmetic instructions whose operands are
    constants and replaces them with a single constant.
-5. **Dead code elimination** – removes instructions that produce values which
+5. **Unreachable block elimination** – removes instructions that cannot be
+   executed from the start of the function.
+6. **Dead code elimination** – removes instructions that produce values which
    are never used and have no side effects.
 
 Constant propagation tracks variables written with constants. When a later
@@ -41,6 +43,11 @@ includes the long double operations `IR_LFADD`, `IR_LFSUB`, `IR_LFMUL` and
 arithmetic.
 For example, an expression such as `1.0L + 2.0L` is folded to a single
 constant at compile time.
+
+The unreachable block pass scans each function and removes any instructions
+that cannot be reached from its `IR_FUNC_BEGIN`.  Blocks that follow an
+unconditional branch or `IR_RETURN` are pruned even when they contain side
+effects.
 
 Dead code elimination scans the instruction stream and removes operations that
 have no side effects and whose results are never referenced.

--- a/include/opt.h
+++ b/include/opt.h
@@ -29,7 +29,8 @@ void opt_error(const char *msg);
  * 2. Common subexpression elimination
  * 3. Inline expansion
  * 4. Constant folding
- * 5. Dead code elimination
+ * 5. Unreachable block elimination
+ * 6. Dead code elimination
  */
 void opt_run(ir_builder_t *ir, const opt_config_t *cfg);
 

--- a/src/opt.c
+++ b/src/opt.c
@@ -13,6 +13,7 @@ void propagate_load_consts(ir_builder_t *ir);
 void common_subexpr_elim(ir_builder_t *ir);
 void inline_small_funcs(ir_builder_t *ir);
 void fold_constants(ir_builder_t *ir);
+void remove_unreachable_blocks(ir_builder_t *ir);
 void dead_code_elim(ir_builder_t *ir);
 
 /* Print an optimization error message */
@@ -33,6 +34,7 @@ void opt_run(ir_builder_t *ir, const opt_config_t *cfg)
         inline_small_funcs(ir);
     if (c->fold_constants)
         fold_constants(ir);
+    remove_unreachable_blocks(ir);
     if (c->dead_code)
         dead_code_elim(ir);
 }

--- a/src/opt_unreachable.c
+++ b/src/opt_unreachable.c
@@ -1,0 +1,139 @@
+/*
+ * Unreachable block elimination pass.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "opt.h"
+#include "util.h"
+
+/* Simple array for storing referenced labels */
+typedef struct label_ref {
+    char *name;
+    struct label_ref *next;
+} label_ref_t;
+
+static int label_referenced(label_ref_t *list, const char *name)
+{
+    for (; list; list = list->next)
+        if (strcmp(list->name, name) == 0)
+            return 1;
+    return 0;
+}
+
+static void free_label_refs(label_ref_t *list)
+{
+    while (list) {
+        label_ref_t *n = list->next;
+        free(list->name);
+        free(list);
+        list = n;
+    }
+}
+
+/* Remove unreachable instructions within functions */
+void remove_unreachable_blocks(ir_builder_t *ir)
+{
+    if (!ir)
+        return;
+
+    label_ref_t *labels = NULL;
+    label_ref_t **label_tail = &labels;
+
+    /* collect all branch target labels */
+    for (ir_instr_t *ins = ir->head; ins; ins = ins->next) {
+        if (ins->op == IR_BR || ins->op == IR_BCOND) {
+            label_ref_t *e = malloc(sizeof(*e));
+            if (!e) {
+                opt_error("out of memory");
+                free_label_refs(labels);
+                return;
+            }
+            e->name = vc_strdup(ins->name ? ins->name : "");
+            if (!e->name) {
+                opt_error("out of memory");
+                free(e);
+                free_label_refs(labels);
+                return;
+            }
+            e->next = NULL;
+            *label_tail = e;
+            label_tail = &e->next;
+        }
+    }
+
+    int in_func = 0;
+    int reachable = 1;
+    ir_instr_t *prev = NULL;
+    ir_instr_t *cur = ir->head;
+
+    while (cur) {
+        ir_instr_t *next = cur->next;
+
+        switch (cur->op) {
+        case IR_FUNC_BEGIN:
+            in_func = 1;
+            reachable = 1;
+            prev = cur;
+            break;
+        case IR_FUNC_END:
+            in_func = 0;
+            reachable = 1;
+            prev = cur;
+            break;
+        case IR_BR:
+            reachable = 0;
+            prev = cur;
+            break;
+        case IR_RETURN:
+            reachable = 0;
+            prev = cur;
+            break;
+        case IR_BCOND:
+            /* record already done */
+            prev = cur;
+            break;
+        case IR_LABEL:
+            if (label_referenced(labels, cur->name))
+                reachable = 1;
+            if (!reachable) {
+                if (prev)
+                    prev->next = next;
+                else
+                    ir->head = next;
+                if (ir->tail == cur)
+                    ir->tail = prev;
+                free(cur->name);
+                free(cur->data);
+                free(cur);
+                cur = prev; /* compensate for increment */
+            } else {
+                prev = cur;
+            }
+            break;
+        default:
+            if (in_func && !reachable) {
+                if (prev)
+                    prev->next = next;
+                else
+                    ir->head = next;
+                if (ir->tail == cur)
+                    ir->tail = prev;
+                free(cur->name);
+                free(cur->data);
+                free(cur);
+                cur = prev; /* stay */
+            } else {
+                prev = cur;
+            }
+            break;
+        }
+
+        cur = next;
+    }
+
+    free_label_refs(labels);
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -109,11 +109,31 @@ cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -Dcompile_unit=test_compile_u
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_compile_obj_fail.c" -o "$DIR/test_compile_obj_fail.o"
 cc -Wl,--gc-sections -o "$DIR/compile_obj_fail" compile_obj_fail.o "$DIR/test_compile_obj_fail.o"
 rm -f compile_obj_fail.o "$DIR/test_compile_obj_fail.o"
+# build unreachable block elimination test
+cc -Iinclude -Wall -Wextra -std=c99 -c src/ir_core.c -o ir_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/label.c -o label_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt.c -o opt_main.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_constprop.c -o opt_constprop_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_cse.c -o opt_cse_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_fold.c -o opt_fold_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_dce.c -o opt_dce_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_inline.c -o opt_inline_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_unreachable.c -o opt_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_opt_unreachable.c" -o "$DIR/test_opt_unreachable.o"
+cc -o "$DIR/opt_unreachable_tests" ir_unreach.o util_unreach.o label_unreach.o error_unreach.o \
+    opt_main.o opt_constprop_unreach.o opt_cse_unreach.o opt_fold_unreach.o \
+    opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o "$DIR/test_opt_unreachable.o"
+rm -f ir_unreach.o util_unreach.o label_unreach.o error_unreach.o opt_main.o \
+      opt_constprop_unreach.o opt_cse_unreach.o opt_fold_unreach.o \
+      opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o "$DIR/test_opt_unreachable.o"
 # run unit tests
 "$DIR/unit_tests"
 "$DIR/cli_tests"
 "$DIR/parser_alloc_tests"
 "$DIR/ir_core_tests"
+"$DIR/opt_unreachable_tests"
 # remaining unit test binaries
 "$DIR/cond_expr_tests"
 "$DIR/eval_sizeof_tests"

--- a/tests/unit/test_opt_unreachable.c
+++ b/tests/unit/test_opt_unreachable.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <string.h>
+#include "ir_core.h"
+#include "opt.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void test_remove_blocks(void)
+{
+    ir_builder_t ir;
+    ir_builder_init(&ir);
+    ir_build_func_begin(&ir, "f");
+    ir_value_t v = ir_build_const(&ir, 1);
+    ir_build_br(&ir, "L1");
+    ir_build_store(&ir, "x", v); /* unreachable */
+    ir_build_label(&ir, "L1");
+    ir_build_return(&ir, v);
+    ir_build_store(&ir, "x", v); /* unreachable */
+    ir_build_func_end(&ir);
+
+    opt_run(&ir, NULL);
+
+    int count = 0;
+    for (ir_instr_t *i = ir.head; i; i = i->next)
+        count++;
+    ASSERT(count == 6);
+
+    ir_instr_t *i = ir.head;
+    ASSERT(i && i->op == IR_FUNC_BEGIN); i = i->next;
+    ASSERT(i && i->op == IR_CONST); i = i->next;
+    ASSERT(i && i->op == IR_BR); i = i->next;
+    ASSERT(i && i->op == IR_LABEL && strcmp(i->name, "L1") == 0); i = i->next;
+    ASSERT(i && i->op == IR_RETURN); i = i->next;
+    ASSERT(i && i->op == IR_FUNC_END && i->next == NULL);
+
+    ir_builder_free(&ir);
+}
+
+int main(void)
+{
+    test_remove_blocks();
+    if (failures == 0)
+        printf("All opt_unreachable tests passed\n");
+    else
+        printf("%d opt_unreachable test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- implement opt_unreachable pass to remove unreachable IR blocks
- integrate new pass into optimisation pipeline and Makefile
- document the new pass in optimisation docs
- add unit test verifying elimination of unreachable blocks

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68669a79762083249380f1fa71e8d2c9