### PR TITLE
Add constant overflow checks to consteval

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -43,6 +43,8 @@ includes the long double operations `IR_LFADD`, `IR_LFSUB`, `IR_LFMUL` and
 arithmetic.
 For example, an expression such as `1.0L + 2.0L` is folded to a single
 constant at compile time.
+Intermediate results are checked for overflow; if a computation exceeds the
+range of `long long` the compiler emits a `Constant overflow` diagnostic.
 
 The unreachable block pass scans each function and removes any instructions
 that cannot be reached from its `IR_FUNC_BEGIN`.  Blocks that follow an

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -68,6 +68,10 @@ cc -Iinclude -Wall -Wextra -std=c99 \
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/number_overflow" "$DIR/unit/test_number_overflow.c" \
     src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c
+# build constant arithmetic overflow regression test
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/consteval_overflow" "$DIR/unit/test_consteval_overflow.c" \
+    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c src/error.c
 # build strbuf overflow regression test
 cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_overflow_impl.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strbuf.o
@@ -157,6 +161,17 @@ if [ $ret -ne 0 ] || ! grep -q "string buffer too large" "$err"; then
     fail=1
 fi
 rm -f "$err" "$DIR/strbuf_overflow"
+# regression test for constant expression overflow handling
+err=$(mktemp)
+set +e
+"$DIR/consteval_overflow" 2> "$err"
+ret=$?
+set -e
+if [ $ret -ne 0 ] || ! grep -q "Constant overflow" "$err"; then
+    echo "Test consteval_overflow failed"
+    fail=1
+fi
+rm -f "$err" "$DIR/consteval_overflow"
 # regression test for collect_funcs overflow handling
 err=$(mktemp)
 set +e

--- a/tests/unit/test_consteval_overflow.c
+++ b/tests/unit/test_consteval_overflow.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include "ast_expr.h"
+#include "consteval.h"
+
+int main(void)
+{
+    /* LLONG_MAX + 1 */
+    expr_t *lhs = ast_make_number("9223372036854775807", 1, 1);
+    expr_t *rhs = ast_make_number("1", 1, 1);
+    expr_t *add = ast_make_binary(BINOP_ADD, lhs, rhs, 1, 1);
+    long long val = 0;
+    if (eval_const_expr(add, NULL, 0, &val)) {
+        printf("add overflow not detected\n");
+        ast_free_expr(add);
+        return 1;
+    }
+    ast_free_expr(add);
+
+    /* -LLONG_MIN */
+    expr_t *min = ast_make_number("-9223372036854775808", 1, 1);
+    expr_t *neg = ast_make_unary(UNOP_NEG, min, 1, 1);
+    if (eval_const_expr(neg, NULL, 0, &val)) {
+        printf("neg overflow not detected\n");
+        ast_free_expr(neg);
+        return 1;
+    }
+    ast_free_expr(neg);
+
+    printf("All consteval_overflow tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- detect arithmetic overflow when evaluating constant expressions
- add regression test for constant expression overflow
- run constant overflow test in harness
- document overflow diagnostics under constant folding

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866a29c86988324b2f8b7fc29065fa8