### PR TITLE
Add IR_RETURN_AGG opcode

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -48,7 +48,7 @@ range of `long long` the compiler emits a `Constant overflow` diagnostic.
 
 The unreachable block pass scans each function and removes any instructions
 that cannot be reached from its `IR_FUNC_BEGIN`.  Blocks that follow an
-unconditional branch or `IR_RETURN` are pruned even when they contain side
+unconditional branch or `IR_RETURN`/`IR_RETURN_AGG` are pruned even when they contain side
 effects.
 
 Dead code elimination scans the instruction stream and removes operations that

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -189,7 +189,7 @@ The IR uses a straightforward three-address format. The operations defined in
 - variable access `IR_LOAD`, `IR_STORE`, `IR_LOAD_PARAM`, `IR_STORE_PARAM`
 - pointer ops `IR_ADDR`, `IR_LOAD_PTR`, `IR_STORE_PTR`, `IR_PTR_ADD`,
   `IR_PTR_DIFF`
-- function and call ops `IR_RETURN`, `IR_CALL`, `IR_FUNC_BEGIN`, `IR_FUNC_END`
+- function and call ops `IR_RETURN`, `IR_RETURN_AGG`, `IR_CALL`, `IR_FUNC_BEGIN`, `IR_FUNC_END`
 - control flow `IR_BR`, `IR_BCOND`, `IR_LABEL`
 
 IR instructions are appended sequentially using the builder API. A tiny

--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -61,6 +61,7 @@ typedef enum {
     IR_ALLOCA,
     IR_ARG,
     IR_RETURN,
+    IR_RETURN_AGG,
     IR_CALL,
     IR_CALL_PTR,
     IR_FUNC_BEGIN,
@@ -184,6 +185,9 @@ ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size);
 
 /* Emit IR_RETURN of `val`. */
 void ir_build_return(ir_builder_t *b, ir_value_t val);
+
+/* Emit IR_RETURN_AGG writing the aggregate pointed to by `ptr`. */
+void ir_build_return_agg(ir_builder_t *b, ir_value_t ptr);
 
 /* Push `val` as an argument via IR_ARG. The argument's type is stored in imm. */
 void ir_build_arg(ir_builder_t *b, ir_value_t val, type_kind_t type);

--- a/src/codegen_branch.c
+++ b/src/codegen_branch.c
@@ -94,6 +94,12 @@ static void emit_return(strbuf_t *sb, ir_instr_t *ins,
     strbuf_append(sb, "    ret\n");
 }
 
+/* Emit a return instruction for aggregate values (IR_RETURN_AGG). */
+static void emit_return_agg(strbuf_t *sb)
+{
+    strbuf_append(sb, "    ret\n");
+}
+
 /* Emit a call instruction (IR_CALL). */
 static void emit_call(strbuf_t *sb, ir_instr_t *ins,
                       regalloc_t *ra, int x64,
@@ -242,6 +248,9 @@ void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
     switch (ins->op) {
     case IR_RETURN:
         emit_return(sb, ins, ra, x64, sfx, ax, syntax);
+        break;
+    case IR_RETURN_AGG:
+        emit_return_agg(sb);
         break;
     case IR_CALL:
         emit_call(sb, ins, ra, x64, sfx, ax, sp, syntax);

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -591,6 +591,16 @@ void ir_build_return(ir_builder_t *b, ir_value_t val)
     ins->src1 = val.id;
 }
 
+/* Emit IR_RETURN_AGG using the supplied pointer id. */
+void ir_build_return_agg(ir_builder_t *b, ir_value_t ptr)
+{
+    ir_instr_t *ins = append_instr(b);
+    if (!ins)
+        return;
+    ins->op = IR_RETURN_AGG;
+    ins->src1 = ptr.id;
+}
+
 /*
  * Emit IR_CALL to `name`. The number of arguments previously pushed by
  * IR_ARG instructions is stored in imm.

--- a/src/ir_dump.c
+++ b/src/ir_dump.c
@@ -70,6 +70,7 @@ static const char *op_name(ir_op_t op)
     case IR_ALLOCA: return "IR_ALLOCA";
     case IR_ARG: return "IR_ARG";
     case IR_RETURN: return "IR_RETURN";
+    case IR_RETURN_AGG: return "IR_RETURN_AGG";
     case IR_CALL: return "IR_CALL";
     case IR_CALL_PTR: return "IR_CALL_PTR";
     case IR_FUNC_BEGIN: return "IR_FUNC_BEGIN";

--- a/src/opt_constprop.c
+++ b/src/opt_constprop.c
@@ -163,6 +163,7 @@ static void propagate_through_instruction(const_track_t *ct, ir_instr_t *ins)
     case IR_ALLOCA:
     case IR_STORE_PARAM:
     case IR_RETURN:
+    case IR_RETURN_AGG:
     case IR_FUNC_BEGIN:
     case IR_FUNC_END:
     case IR_GLOB_STRING:

--- a/src/opt_dce.c
+++ b/src/opt_dce.c
@@ -21,6 +21,7 @@ static int has_side_effect(ir_instr_t *ins)
     case IR_CALL_PTR:
     case IR_ARG:
     case IR_RETURN:
+    case IR_RETURN_AGG:
     case IR_BR:
     case IR_BCOND:
     case IR_FUNC_BEGIN:

--- a/src/opt_fold.c
+++ b/src/opt_fold.c
@@ -207,6 +207,7 @@ void fold_constants(ir_builder_t *ir)
             update_const(ins, 0, 0, max_id, is_const, values);
             break;
         case IR_RETURN:
+        case IR_RETURN_AGG:
             /* nothing to do */
             break;
         case IR_GLOB_STRING:

--- a/src/opt_inline.c
+++ b/src/opt_inline.c
@@ -158,7 +158,7 @@ static int is_simple_op(ir_op_t op)
  * to an IR_FUNC_BEGIN instruction.  On success, a newly allocated array
  * of instructions is stored in `*out` and the number of entries in
  * `*count`.  Only instructions recognised by `is_simple_op`,
- * IR_LOAD_PARAM, IR_CONST and IR_RETURN are permitted.  The total number
+ * IR_LOAD_PARAM, IR_CONST, IR_RETURN and IR_RETURN_AGG are permitted.  The total number
  * of arithmetic operations must not exceed four.
  */
 static int clone_func_body(ir_instr_t *begin, ir_instr_t **out, size_t *count)
@@ -174,7 +174,8 @@ static int clone_func_body(ir_instr_t *begin, ir_instr_t **out, size_t *count)
         if (is_simple_op(it->op)) {
             if (++arith > 4)
                 return 0;
-        } else if (it->op != IR_LOAD_PARAM && it->op != IR_CONST && it->op != IR_RETURN) {
+        } else if (it->op != IR_LOAD_PARAM && it->op != IR_CONST &&
+                   it->op != IR_RETURN && it->op != IR_RETURN_AGG) {
             return 0;
         }
         n++;
@@ -405,7 +406,7 @@ void inline_small_funcs(ir_builder_t *ir)
                 map[mcount++] = (map_entry_t){orig->dest, args[orig->imm], NULL};
                 continue;
             }
-            if (orig->op == IR_RETURN) {
+            if (orig->op == IR_RETURN || orig->op == IR_RETURN_AGG) {
                 ret_val = lookup(map, mcount, orig->src1);
                 for (size_t m = 0; m < mcount; m++) {
                     if (map[m].old_id == orig->src1 && map[m].ins) {

--- a/src/opt_unreachable.c
+++ b/src/opt_unreachable.c
@@ -89,6 +89,7 @@ void remove_unreachable_blocks(ir_builder_t *ir)
             prev = cur;
             break;
         case IR_RETURN:
+        case IR_RETURN_AGG:
             reachable = 0;
             prev = cur;
             break;

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -595,7 +595,7 @@ static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
         }
         ir_value_t ret_ptr = ir_build_load_param(ir, 0);
         ir_build_store_ptr(ir, ret_ptr, val);
-        ir_build_return(ir, ir_build_const(ir, 0));
+        ir_build_return_agg(ir, ret_ptr);
         return 1;
     }
 

--- a/tests/unit/test_ir_core.c
+++ b/tests/unit/test_ir_core.c
@@ -128,6 +128,18 @@ static void test_strdup_fail_wstring(void)
     ir_builder_free(&b);
 }
 
+static void test_return_agg_opcode(void)
+{
+    ir_builder_t b;
+    ir_builder_init(&b);
+    ir_value_t p = ir_build_const(&b, 0);
+    ir_build_return_agg(&b, p);
+    ir_instr_t *i = b.head;
+    ASSERT(i && i->op == IR_CONST); i = i->next;
+    ASSERT(i && i->op == IR_RETURN_AGG && i->src1 == p.id);
+    ir_builder_free(&b);
+}
+
 int main(void)
 {
     test_wstring_alloc_fail();
@@ -136,6 +148,7 @@ int main(void)
     test_strdup_fail_load();
     test_strdup_fail_string();
     test_strdup_fail_wstring();
+    test_return_agg_opcode();
     if (failures == 0)
         printf("All ir_core tests passed\n");
     else


### PR DESCRIPTION
## Summary
- extend IR opcodes with `IR_RETURN_AGG`
- support building and dumping aggregate return instructions
- teach optimizers and code generation about the new opcode
- use `ir_build_return_agg` when returning aggregates
- document new opcode and test it

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866a933152883249f1f6c76f8d877d9