### PR TITLE
Document struct return values

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ provides an overview of all available documentation.
 - Built-in macros – `__FILE__`, `__LINE__`, `__DATE__`, `__TIME__`,
   `__STDC__`, `__STDC_VERSION__` and `__func__` expand automatically.
 - [Supported language features](language_features.md) – syntax and semantics
-  currently implemented, including variadic functions.
+  currently implemented, including variadic functions and struct return values.
 - [Command-line usage](command_line.md) – available options and example
   invocations, including the `--intel-syntax` flag for Intel-style assembly.
 - [Optimization passes](optimization.md) – constant folding, propagation and

--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -12,6 +12,7 @@ See the [documentation index](index.md) for a list of all available pages.
 - [64-bit integers](#64-bit-integers)
 - [Numeric constants](#numeric-constants)
 - [Function calls](#function-calls)
+- [Returning structs](#returning-structs)
 - [Variadic functions](#variadic-functions)
 - [Loops](#loops)
 - [Pointers](#pointers)
@@ -170,6 +171,26 @@ int main() {
 Compile with:
 ```sh
 vc -o call.s call.c
+```
+
+### Returning structs
+```c
+/* struct_ret.c */
+struct pair { int a; int b; };
+
+struct pair make_pair(int x, int y) {
+    struct pair p = { x, y };
+    return p;
+}
+
+int main() {
+    struct pair p = make_pair(1, 2);
+    return p.a + p.b;
+}
+```
+Compile with:
+```sh
+vc -o struct_ret.s struct_ret.c
 ```
 
 ### Variadic functions

--- a/man/vc.1
+++ b/man/vc.1
@@ -13,6 +13,7 @@ The resulting assembly can be written to a file or printed to stdout.
 Intel-style assembly output may be selected with \fB--intel-syntax\fR.
 When this mode is combined with \fB--compile\fR or \fB--link\fR the
 \fInasm\fR assembler must be available.
+Functions may return \fBstruct\fR or \fBunion\fR values via a hidden pointer.
 Supported constructs include arrays (including variable length arrays inside functions with sizes determined at runtime, size inference from initializer lists and designated initializers using \fB[index]\fR or \fB.member\fR designators), pointer arithmetic (including pointer subtraction and pointer increments), loops (\fBfor\fR, \fBwhile\fR and \fBdo\fR\~\fBwhile\fR), global variable declarations, external declarations using \fBextern\fR, floating-point variables including \fBlong double\fR, the
 \fBchar\fR type, support for 64-bit integer constants including hexadecimal and octal literals, string literals usable as \fBchar\fR pointers with standard escape sequences such as \n, \t, \r, \b, \f, \v and numeric forms like \e123 or \ex7F, complete \fBstruct\fR and \fBunion\fR declarations with bit-field members, enum variables, typedef declarations, the
 Wide character and string literals may be written using L'c' and L"text".


### PR DESCRIPTION
## Summary
- document ability to return struct values from a function
- mention hidden pointer mechanism in `vc(1)`
- note struct return values in documentation index

## Testing
- `make vc`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6866b563e3688324beb3f4a196d853a8