### PR TITLE
Add struct tag support in parser

### DIFF
--- a/src/parser_core.c
+++ b/src/parser_core.c
@@ -193,7 +193,7 @@ static int parse_param_list(parser_t *p,
                 vector_free(&restrict_v);
                 return 0;
             }
-            size_t ps = basic_type_size(pt);
+            size_t ps = (pt == TYPE_STRUCT) ? 0 : basic_type_size(pt);
             int is_restrict = 0;
             if (match(p, TOK_STAR)) {
                 pt = TYPE_PTR;

--- a/src/parser_decl.c
+++ b/src/parser_decl.c
@@ -73,6 +73,17 @@ static int parse_decl_specs(parser_t *p, int *is_extern, int *is_static,
         *type = TYPE_UNION;
         if (base_type)
             *base_type = *type;
+    } else if (match(p, TOK_KW_STRUCT)) {
+        token_t *tag = peek(p);
+        if (!tag || tag->type != TOK_IDENT)
+            return 0;
+        p->pos++;
+        *tag_name = vc_strdup(tag->lexeme);
+        if (!*tag_name)
+            return 0;
+        *type = TYPE_STRUCT;
+        if (base_type)
+            *base_type = *type;
     } else {
         if (!parse_basic_type(p, type))
             return 0;

--- a/src/parser_types.c
+++ b/src/parser_types.c
@@ -46,6 +46,15 @@ int parse_basic_type(parser_t *p, type_kind_t *out)
         p->pos++;
         (void)is_unsigned;
         t = TYPE_ENUM;
+    } else if (match(p, TOK_KW_STRUCT)) {
+        token_t *id = peek(p);
+        if (!id || id->type != TOK_IDENT) {
+            p->pos = save;
+            return 0;
+        }
+        p->pos++;
+        (void)is_unsigned;
+        t = TYPE_STRUCT;
     } else {
         if (is_unsigned) {
             t = TYPE_UINT;


### PR DESCRIPTION
## Summary
- extend `parse_decl_specs` to handle `struct` tags
- allow `parse_basic_type` and related helpers to parse `struct` tags
- update function and parameter parsing to recognise struct tags
- support struct-tag variables and functions at the toplevel
- add unit tests for struct-tag variable and function declarations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866bafba9dc83249f661259f031030a