### PR TITLE
Add struct tag tracking for functions

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -351,8 +351,10 @@ struct struct_member {
 struct func {
     char *name;
     type_kind_t return_type;
+    char *return_tag;
     char **param_names;
     type_kind_t *param_types;
+    char **param_tags;
     size_t *param_elem_sizes;
     int *param_is_restrict;
     size_t param_count;

--- a/include/ast_stmt.h
+++ b/include/ast_stmt.h
@@ -70,7 +70,9 @@ stmt_t *ast_make_block(stmt_t **stmts, size_t count,
 
 /* Create a function definition. */
 func_t *ast_make_func(const char *name, type_kind_t ret_type,
+                      const char *ret_tag,
                       char **param_names, type_kind_t *param_types,
+                      char **param_tags,
                       size_t *param_elem_sizes, int *param_is_restrict,
                       size_t param_count, int is_variadic,
                       stmt_t **body, size_t body_count,

--- a/include/parser_core.h
+++ b/include/parser_core.h
@@ -22,6 +22,6 @@ void parser_print_error(parser_t *p,
                         size_t expected_count);
 
 /* Parse a full function definition beginning with its return type */
-func_t *parser_parse_func(parser_t *p, int is_inline);
+func_t *parser_parse_func(parser_t *p, symtable_t *table, int is_inline);
 
 #endif /* VC_PARSER_CORE_H */

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -421,7 +421,7 @@ static void test_parser_func(void)
     size_t count = 0;
     token_t *toks = lexer_tokenize(src, &count);
     parser_t p; parser_init(&p, toks, count);
-    func_t *fn = parser_parse_func(&p, 0);
+    func_t *fn = parser_parse_func(&p, NULL, 0);
     ASSERT(fn);
     ASSERT(strcmp(fn->name, "main") == 0);
     ASSERT(fn->return_type == TYPE_INT);
@@ -502,6 +502,24 @@ static void test_parser_struct_tag_func(void)
     ASSERT(sym->param_count == 1);
     ASSERT(sym->param_types[0] == TYPE_STRUCT);
     symtable_free(&funcs);
+    lexer_free_tokens(toks, count);
+}
+
+/* Parse a function definition using struct tags. */
+static void test_parser_struct_tag_func_def(void)
+{
+    const char *src = "struct S foo(struct S a) { return a; }";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    func_t *fn = parser_parse_func(&p, NULL, 0);
+    ASSERT(fn);
+    ASSERT(fn->return_type == TYPE_STRUCT);
+    ASSERT(strcmp(fn->return_tag, "S") == 0);
+    ASSERT(fn->param_count == 1);
+    ASSERT(fn->param_types[0] == TYPE_STRUCT);
+    ASSERT(strcmp(fn->param_tags[0], "S") == 0);
+    ast_free_func(fn);
     lexer_free_tokens(toks, count);
 }
 
@@ -654,6 +672,7 @@ int main(void)
     test_parser_bitfield();
     test_parser_struct_tag_var();
     test_parser_struct_tag_func();
+    test_parser_struct_tag_func_def();
     test_line_directive();
     test_lexer_escapes();
     test_lexer_char_missing_quote();

--- a/tests/unit/test_parser_alloc_fail.c
+++ b/tests/unit/test_parser_alloc_fail.c
@@ -28,7 +28,7 @@ static void test_param_alloc_fail(void)
     token_t *toks = lexer_tokenize(src, &count);
     parser_t p; parser_init(&p, toks, count);
     fail_push = 1;
-    func_t *fn = parser_parse_func(&p, 0);
+    func_t *fn = parser_parse_func(&p, NULL, 0);
     ASSERT(fn == NULL);
     fail_push = 0;
     lexer_free_tokens(toks, count);


### PR DESCRIPTION
## Summary
- store `return_tag` and `param_tags` in `func` AST nodes
- parse struct/union tags for function parameters and return types
- compute aggregate sizes from the symbol table when available
- pass sizes to `symtable_add_func`
- adjust tests for updated parser interfaces

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866ca038a108324be6af198b1a3bb7a