### PR TITLE
Add colored diagnostics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Enable debug directives with `--debug`:
 vc --debug -S source.c
 ```
 
+Disable colored diagnostics with `--no-color` when capturing output.
+
 ## Testing
 
 The project ships with a small unit and integration test suite. A C99

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -18,6 +18,7 @@ The compiler supports the following options:
 - `--no-cprop` – disable constant propagation.
 - `--no-inline` – disable inline expansion of small functions.
 - `--debug` – emit `.file` and `.loc` directives in the assembly output.
+- `--no-color` – disable ANSI colors in diagnostics.
 - `--x86-64` – generate 64‑bit x86 assembly.
 - `--intel-syntax` – enable Intel-style x86 assembly output. When used
   together with `--compile` or `--link`, the assembler must be `nasm`.

--- a/include/cli.h
+++ b/include/cli.h
@@ -40,7 +40,8 @@ typedef enum {
     CLI_OPT_NO_INLINE,
     CLI_OPT_INTEL_SYNTAX = 12,
     CLI_OPT_DEFINE,
-    CLI_OPT_UNDEFINE
+    CLI_OPT_UNDEFINE,
+    CLI_OPT_NO_COLOR
 } cli_opt_id;
 
 /* Command line options parsed from argv */
@@ -54,6 +55,7 @@ typedef struct {
     bool dump_ir;       /* dump IR to stdout */
     bool preprocess;    /* run preprocessor only and print to stdout */
     bool debug;         /* emit debug directives */
+    bool color_diag;    /* use ANSI colors in diagnostics */
     asm_syntax_t asm_syntax; /* assembly syntax flavor */
     c_std_t std;        /* language standard */
     char *obj_dir;      /* directory for temporary object files */

--- a/include/error.h
+++ b/include/error.h
@@ -9,6 +9,7 @@
 #define VC_ERROR_H
 
 #include <stddef.h>
+#include <stdbool.h>
 
 /*
  * Save the given 1-based line and column so that the next call to
@@ -31,5 +32,6 @@ void error_print(const char *msg);
 /* Current context used by error diagnostics */
 extern const char *error_current_file;
 extern const char *error_current_function;
+extern bool error_use_color;
 
 #endif /* VC_ERROR_H */

--- a/man/vc.1
+++ b/man/vc.1
@@ -91,6 +91,9 @@ Disable inline expansion of small functions.
 .B --debug
 Emit .file and .loc directives for debugging.
 .TP
+.B --no-color
+Disable ANSI colors in diagnostic output.
+.TP
 .B --x86-64
 Generate x86-64 assembly instead of 32-bit.
 .TP

--- a/src/cli.c
+++ b/src/cli.c
@@ -46,6 +46,7 @@ static void print_usage(const char *prog)
     printf("      --no-cprop       Disable constant propagation\n");
     printf("      --no-inline      Disable inline expansion\n");
     printf("      --debug          Emit .file/.loc directives\n");
+    printf("      --no-color       Disable colored diagnostics\n");
     printf("      --x86-64         Generate 64-bit x86 assembly\n");
     printf("      --intel-syntax    Use Intel assembly syntax\n");
     printf("  -S, --dump-asm       Print assembly to stdout and exit\n");
@@ -76,6 +77,7 @@ static void init_default_opts(cli_options_t *opts)
     opts->dump_ir = false;
     opts->preprocess = false;
     opts->debug = false;
+    opts->color_diag = true;
     opts->asm_syntax = ASM_ATT;
     opts->std = STD_C99;
     opts->obj_dir = "/tmp";
@@ -291,6 +293,13 @@ static int enable_debug_opt(const char *arg, const char *prog, cli_options_t *op
     return 0;
 }
 
+static int disable_color_opt(const char *arg, const char *prog, cli_options_t *opts)
+{
+    (void)arg; (void)prog;
+    opts->color_diag = false;
+    return 0;
+}
+
 static int enable_preproc(const char *arg, const char *prog, cli_options_t *opts)
 {
     (void)arg; (void)prog;
@@ -398,6 +407,7 @@ static int handle_option(int opt, const char *arg, const char *prog,
         {CLI_OPT_DUMP_IR,      enable_dump_ir_opt},
         {CLI_OPT_DEBUG,        enable_debug_opt},
         {CLI_OPT_NO_INLINE,    disable_inline_opt},
+        {CLI_OPT_NO_COLOR,     disable_color_opt},
         {'E', enable_preproc},
         {CLI_OPT_DEFINE,       add_define_opt},
         {CLI_OPT_UNDEFINE,     add_undef_opt},
@@ -452,6 +462,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"link", no_argument,        0, CLI_OPT_LINK},
         {"std", required_argument,   0, CLI_OPT_STD},
         {"obj-dir", required_argument, 0, CLI_OPT_OBJ_DIR},
+        {"no-color", no_argument, 0, CLI_OPT_NO_COLOR},
         {0, 0, 0, 0}
     };
 

--- a/src/error.c
+++ b/src/error.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 /*
  * Simple error reporting utilities.
  *
@@ -6,11 +7,14 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
+#include <stdbool.h>
 #include "error.h"
 
 /* Active file and function for diagnostics */
 const char *error_current_file = "";
 const char *error_current_function = NULL;
+bool error_use_color = true;
 
 /* Stored source location for the next error message. */
 static const char *error_file = "";
@@ -38,11 +42,17 @@ void error_set(size_t line, size_t col, const char *file, const char *func)
  */
 void error_print(const char *msg)
 {
+    int color = error_use_color && isatty(fileno(stderr));
+    if (color)
+        fprintf(stderr, "\x1b[1;31m");
     if (error_func)
-        fprintf(stderr, "%s:%zu:%zu: %s: %s\n", error_file, error_line, error_column,
-                error_func, msg);
+        fprintf(stderr, "%s:%zu:%zu: %s: %s", error_file, error_line,
+                error_column, error_func, msg);
     else
-        fprintf(stderr, "%s:%zu:%zu: %s\n", error_file, error_line, error_column,
-                msg);
+        fprintf(stderr, "%s:%zu:%zu: %s", error_file, error_line,
+                error_column, msg);
+    if (color)
+        fprintf(stderr, "\x1b[0m");
+    fputc('\n', stderr);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 
 #include "cli.h"
 #include "compile.h"
+#include "error.h"
 
 /*
  * Program entry point. Parses command line options and coordinates
@@ -27,6 +28,8 @@ int main(int argc, char **argv)
 
     if (cli_parse_args(argc, argv, &cli) != 0)
         goto cleanup;
+
+    error_use_color = cli.color_diag;
 
     if (!cli.link && cli.sources.count != 1) {
         fprintf(stderr, "Error: multiple input files require --link\n");


### PR DESCRIPTION
## Summary
- support --no-color to disable ANSI colors
- colorize error messages when stderr is a tty
- document the new CLI option in README, docs, and man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6866d0c4ecd0832491fa856c0f9e4f29