### PR TITLE
Improve assignment parsing helper

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -53,6 +53,14 @@ Translates raw characters into tokens for the parser.
 ### parser
 Constructs the AST and reports syntax errors.
 
+Assignment parsing relies on `consume_assign_op` which now returns an
+`assign_op_t` enumerator describing the operator token.  The helper
+records the source position so `parse_assignment` can build the
+appropriate AST node.  `create_assignment_node` chooses between
+`EXPR_ASSIGN`, `EXPR_ASSIGN_INDEX` and `EXPR_ASSIGN_MEMBER` based on the
+left-hand expression.  If the left side is not a valid l-value all
+allocated nodes are freed and `NULL` is returned.
+
 ### semantic
 Performs type checking and converts the AST into IR.  The
 implementation in [`src/semantic.c`](../src/semantic.c) relies on a

--- a/src/parser_expr.c
+++ b/src/parser_expr.c
@@ -38,6 +38,23 @@ static expr_t *parse_addr(parser_t *p);
 static expr_t *parse_neg(parser_t *p);
 static expr_t *parse_not(parser_t *p);
 static expr_t *parse_sizeof(parser_t *p);
+
+typedef enum {
+    AOP_NONE,
+    AOP_ASSIGN,
+    AOP_ADD,
+    AOP_SUB,
+    AOP_MUL,
+    AOP_DIV,
+    AOP_MOD,
+    AOP_AND,
+    AOP_OR,
+    AOP_XOR,
+    AOP_SHL,
+    AOP_SHR
+} assign_op_t;
+
+static assign_op_t consume_assign_op(parser_t *p, size_t *line, size_t *column);
 static expr_t *parse_postfix_expr(parser_t *p);
 static expr_t *parse_base_term(parser_t *p);
 static expr_t *parse_literal(parser_t *p);
@@ -53,9 +70,9 @@ static expr_t *parse_logical_and(parser_t *p);
 static expr_t *parse_logical_or(parser_t *p);
 static expr_t *parse_conditional(parser_t *p);
 static int parse_argument_list(parser_t *p, vector_t *out_args);
-static binop_t binop_from_assign(token_type_t type);
-static expr_t *build_assign_expr(expr_t *left, expr_t *right,
-                                 token_t *op_tok);
+static binop_t binop_from_assign(assign_op_t op);
+static expr_t *create_assignment_node(expr_t *left, expr_t *right,
+                                      size_t line, size_t column);
 
 /* Function pointer type used by parse_binop_chain */
 typedef expr_t *(*parse_fn)(parser_t *);
@@ -584,86 +601,95 @@ static expr_t *parse_conditional(parser_t *p)
 }
 
 
-/* Determine if the next token is an assignment operator.  If so the token
- * is consumed, \p compound is set to 1 for "+=", "-=", etc. and 0 for
- * "=".  The consumed token is returned or NULL otherwise. */
-static token_t *consume_assign_op(parser_t *p, int *compound)
+/*
+ * Consume and classify an assignment operator.  When the next token
+ * represents an assignment, the operator kind is returned and the
+ * source location stored in \p line and \p column.  Otherwise
+ * ``AOP_NONE`` is returned and the parser position is unchanged.
+ */
+static assign_op_t consume_assign_op(parser_t *p, size_t *line, size_t *column)
 {
     token_t *tok = peek(p);
     if (!tok)
-        return NULL;
+        return AOP_NONE;
 
+    assign_op_t op;
     switch (tok->type) {
-    case TOK_ASSIGN:
-        if (compound)
-            *compound = 0;
-        p->pos++;
-        return tok;
-    case TOK_PLUSEQ: case TOK_MINUSEQ: case TOK_STAREQ: case TOK_SLASHEQ:
-    case TOK_PERCENTEQ: case TOK_AMPEQ:  case TOK_PIPEEQ:  case TOK_CARETEQ:
-    case TOK_SHLEQ:    case TOK_SHREQ:
-        if (compound)
-            *compound = 1;
-        p->pos++;
-        return tok;
+    case TOK_ASSIGN:      op = AOP_ASSIGN; break;
+    case TOK_PLUSEQ:      op = AOP_ADD;    break;
+    case TOK_MINUSEQ:     op = AOP_SUB;    break;
+    case TOK_STAREQ:      op = AOP_MUL;    break;
+    case TOK_SLASHEQ:     op = AOP_DIV;    break;
+    case TOK_PERCENTEQ:   op = AOP_MOD;    break;
+    case TOK_AMPEQ:       op = AOP_AND;    break;
+    case TOK_PIPEEQ:      op = AOP_OR;     break;
+    case TOK_CARETEQ:     op = AOP_XOR;    break;
+    case TOK_SHLEQ:       op = AOP_SHL;    break;
+    case TOK_SHREQ:       op = AOP_SHR;    break;
     default:
-        return NULL;
+        return AOP_NONE;
     }
+
+    if (line)
+        *line = tok->line;
+    if (column)
+        *column = tok->column;
+    p->pos++;
+    return op;
 }
 
 /* Map an assignment token to the corresponding binary operator. */
-static binop_t binop_from_assign(token_type_t type)
+static binop_t binop_from_assign(assign_op_t op)
 {
-    switch (type) {
-    case TOK_PLUSEQ:   return BINOP_ADD;
-    case TOK_MINUSEQ:  return BINOP_SUB;
-    case TOK_STAREQ:   return BINOP_MUL;
-    case TOK_SLASHEQ:  return BINOP_DIV;
-    case TOK_PERCENTEQ:return BINOP_MOD;
-    case TOK_AMPEQ:    return BINOP_BITAND;
-    case TOK_PIPEEQ:   return BINOP_BITOR;
-    case TOK_CARETEQ:  return BINOP_BITXOR;
-    case TOK_SHLEQ:    return BINOP_SHL;
-    case TOK_SHREQ:    return BINOP_SHR;
+    switch (op) {
+    case AOP_ADD: return BINOP_ADD;
+    case AOP_SUB: return BINOP_SUB;
+    case AOP_MUL: return BINOP_MUL;
+    case AOP_DIV: return BINOP_DIV;
+    case AOP_MOD: return BINOP_MOD;
+    case AOP_AND: return BINOP_BITAND;
+    case AOP_OR:  return BINOP_BITOR;
+    case AOP_XOR: return BINOP_BITXOR;
+    case AOP_SHL: return BINOP_SHL;
+    case AOP_SHR: return BINOP_SHR;
     default:           return (binop_t)-1;
     }
 }
 
 /* Create the appropriate assignment expression node based on \p left. */
-static expr_t *build_assign_expr(expr_t *left, expr_t *right,
-                                 token_t *op_tok)
+static expr_t *create_assignment_node(expr_t *left, expr_t *right,
+                                      size_t line, size_t column)
 {
     expr_t *res = NULL;
     if (left->kind == EXPR_IDENT) {
         char *name = left->ident.name;
         free(left);
-        res = ast_make_assign(name, right, op_tok->line, op_tok->column);
+        res = ast_make_assign(name, right, line, column);
         free(name);
     } else if (left->kind == EXPR_INDEX) {
         expr_t *arr = left->index.array;
         expr_t *idx = left->index.index;
         free(left);
-        res = ast_make_assign_index(arr, idx, right,
-                                    op_tok->line, op_tok->column);
+        res = ast_make_assign_index(arr, idx, right, line, column);
     } else {
         expr_t *obj = left->member.object;
         char *mem = left->member.member;
         int via_ptr = left->member.via_ptr;
         free(left);
         res = ast_make_assign_member(obj, mem, right, via_ptr,
-                                     op_tok->line, op_tok->column);
+                                     line, column);
         free(mem);
     }
 
     return res;
 }
 
-/* Build the AST node for an assignment using \p left and \p right. The
- * operator token is provided via \p op_tok and \p compound indicates if it
- * was a compound operator.  On error all allocated nodes are freed and NULL
- * is returned. */
+/* Build the AST node for an assignment using \p left and \p right.  The
+ * operator kind is provided via \p op along with the source \p line and
+ * \p column.  On error all allocated nodes are freed and NULL is
+ * returned. */
 static expr_t *make_assignment(expr_t *left, expr_t *right,
-                               token_t *op_tok, int compound)
+                               assign_op_t op, size_t line, size_t column)
 {
     if (left->kind != EXPR_IDENT && left->kind != EXPR_INDEX &&
         left->kind != EXPR_MEMBER) {
@@ -672,8 +698,8 @@ static expr_t *make_assignment(expr_t *left, expr_t *right,
         return NULL;
     }
 
-    if (compound) {
-        binop_t bop = binop_from_assign(op_tok->type);
+    if (op != AOP_ASSIGN && op != AOP_NONE) {
+        binop_t bop = binop_from_assign(op);
         if (bop == (binop_t)-1) {
             ast_free_expr(left);
             ast_free_expr(right);
@@ -687,11 +713,10 @@ static expr_t *make_assignment(expr_t *left, expr_t *right,
             return NULL;
         }
 
-        right = ast_make_binary(bop, lhs_copy, right,
-                                op_tok->line, op_tok->column);
+        right = ast_make_binary(bop, lhs_copy, right, line, column);
     }
 
-    return build_assign_expr(left, right, op_tok);
+    return create_assignment_node(left, right, line, column);
 }
 
 /* Assignment has the lowest precedence and recurses to itself for chained
@@ -706,9 +731,9 @@ static expr_t *parse_assignment(parser_t *p)
     if (!left)
         return NULL;
 
-    int compound = 0;
-    token_t *op_tok = consume_assign_op(p, &compound);
-    if (!op_tok)
+    size_t line = 0, column = 0;
+    assign_op_t op = consume_assign_op(p, &line, &column);
+    if (op == AOP_NONE)
         return left;
 
     expr_t *right = parse_assignment(p);
@@ -717,7 +742,7 @@ static expr_t *parse_assignment(parser_t *p)
         return NULL;
     }
 
-    return make_assignment(left, right, op_tok, compound);
+    return make_assignment(left, right, op, line, column);
 }
 
 /* Entry point that parses the full expression grammar. */


### PR DESCRIPTION
## Summary
- return new `assign_op_t` enum from `consume_assign_op`
- centralize assignment node creation via `create_assignment_node`
- document the expected assignment nodes and failure behaviour

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68680e75e7848324beeb63c8d6bfc9e6