### PR TITLE
Add reusable vector cleanup helpers

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -8,6 +8,8 @@
 #ifndef VC_UTIL_H
 #define VC_UTIL_H
 
+#include "vector.h"
+
 /* Duplicate a string using malloc. Returns NULL on allocation failure */
 char *vc_strdup(const char *s);
 
@@ -28,5 +30,11 @@ int vc_strtoul_size(const char *s, size_t *out);
 
 /* Convert string to unsigned, returning 1 on success */
 int vc_strtoul_unsigned(const char *s, unsigned *out);
+
+/* Release a vector of malloc'd strings */
+void free_string_vector(vector_t *v);
+
+/* Release a vector of macro_t elements */
+void free_macro_vector(vector_t *v);
 
 #endif /* VC_UTIL_H */

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -709,30 +709,8 @@ static int load_and_register_file(const char *path, vector_t *stack,
     return 1;
 }
 
-/*
- * Free all macros stored in a vector.
- *
- * Each macro must have been created by add_macro() so that macro_free()
- * can correctly release the heap allocated strings.  The vector itself
- * is also freed.
- */
-static void free_macro_vector(vector_t *v)
-{
-    for (size_t i = 0; i < v->count; i++)
-        macro_free(&((macro_t *)v->data)[i]);
-    vector_free(v);
-}
-
 /* Free a vector of parameter names */
 static void free_param_vector(vector_t *v)
-{
-    for (size_t i = 0; i < v->count; i++)
-        free(((char **)v->data)[i]);
-    vector_free(v);
-}
-
-/* Free a vector of strings */
-static void free_string_vector(vector_t *v)
 {
     for (size_t i = 0; i < v->count; i++)
         free(((char **)v->data)[i]);
@@ -1100,9 +1078,7 @@ static void cleanup_preproc_vectors(vector_t *macros, vector_t *conds,
     vector_free(stack);
     vector_free(conds);
     free_macro_vector(macros);
-    for (size_t i = 0; i < search_dirs->count; i++)
-        free(((char **)search_dirs->data)[i]);
-    vector_free(search_dirs);
+    free_string_vector(search_dirs);
     for (size_t i = 0; i < pragma_once_files.count; i++)
         free(((char **)pragma_once_files.data)[i]);
     vector_free(&pragma_once_files);

--- a/src/util.c
+++ b/src/util.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <limits.h>
 #include "util.h"
+#include "preproc_macros.h"
 
 /*
  * Allocate "size" bytes of memory.  If the allocation fails the process
@@ -141,5 +142,34 @@ int vc_strtoul_unsigned(const char *s, unsigned *out)
         return 0;
     *out = (unsigned)val;
     return 1;
+}
+
+/*
+ * Release all strings stored in a vector and free the vector itself.
+ *
+ * Each element of the vector must be a pointer returned by malloc.
+ */
+void free_string_vector(vector_t *v)
+{
+    if (!v)
+        return;
+    for (size_t i = 0; i < v->count; i++)
+        free(((char **)v->data)[i]);
+    vector_free(v);
+}
+
+/*
+ * Release all macros stored in a vector and free the vector itself.
+ *
+ * Each macro must have been created by add_macro() so that macro_free()
+ * can correctly release the heap allocated strings.
+ */
+void free_macro_vector(vector_t *v)
+{
+    if (!v)
+        return;
+    for (size_t i = 0; i < v->count; i++)
+        macro_free(&((macro_t *)v->data)[i]);
+    vector_free(v);
 }
 


### PR DESCRIPTION
## Summary
- add utility helpers for releasing vectors of strings or macros
- use the new helpers in the preprocessor

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6868102902288324bc4697f0b36014ed