### PR TITLE
Add generic helper for copying members

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -8,6 +8,8 @@
 #ifndef VC_UTIL_H
 #define VC_UTIL_H
 
+#include "ast.h"
+
 /* Duplicate a string using malloc. Returns NULL on allocation failure */
 char *vc_strdup(const char *s);
 
@@ -28,5 +30,8 @@ int vc_strtoul_size(const char *s, size_t *out);
 
 /* Convert string to unsigned, returning 1 on success */
 int vc_strtoul_unsigned(const char *s, unsigned *out);
+
+/* Allocate and duplicate an array of members */
+int copy_members(union_member_t **dst, const union_member_t *src, size_t count);
 
 #endif /* VC_UTIL_H */

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -283,21 +283,9 @@ static int copy_union_metadata(symbol_t *sym, union_member_t *members,
                                size_t count, size_t total)
 {
     sym->total_size = total;
-    if (!count)
-        return 1;
-    sym->members = malloc(count * sizeof(*sym->members));
-    if (!sym->members)
+    if (!copy_members(&sym->members, members, count))
         return 0;
     sym->member_count = count;
-    for (size_t i = 0; i < count; i++) {
-        union_member_t *m = &members[i];
-        sym->members[i].name = vc_strdup(m->name);
-        sym->members[i].type = m->type;
-        sym->members[i].elem_size = m->elem_size;
-        sym->members[i].offset = m->offset;
-        sym->members[i].bit_width = m->bit_width;
-        sym->members[i].bit_offset = m->bit_offset;
-    }
     return 1;
 }
 
@@ -310,21 +298,10 @@ static int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
                                 size_t count, size_t total)
 {
     sym->struct_total_size = total;
-    if (!count)
-        return 1;
-    sym->struct_members = malloc(count * sizeof(*sym->struct_members));
-    if (!sym->struct_members)
+    if (!copy_members((union_member_t **)&sym->struct_members,
+                      (union_member_t *)members, count))
         return 0;
     sym->struct_member_count = count;
-    for (size_t i = 0; i < count; i++) {
-        struct_member_t *m = &members[i];
-        sym->struct_members[i].name = vc_strdup(m->name);
-        sym->struct_members[i].type = m->type;
-        sym->struct_members[i].elem_size = m->elem_size;
-        sym->struct_members[i].offset = m->offset;
-        sym->struct_members[i].bit_width = m->bit_width;
-        sym->struct_members[i].bit_offset = m->bit_offset;
-    }
     return 1;
 }
 

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -335,21 +335,9 @@ static int copy_union_metadata(symbol_t *sym, union_member_t *members,
                                size_t count, size_t total)
 {
     sym->total_size = total;
-    if (!count)
-        return 1;
-    sym->members = malloc(count * sizeof(*sym->members));
-    if (!sym->members)
+    if (!copy_members(&sym->members, members, count))
         return 0;
     sym->member_count = count;
-    for (size_t i = 0; i < count; i++) {
-        union_member_t *m = &members[i];
-        sym->members[i].name = vc_strdup(m->name);
-        sym->members[i].type = m->type;
-        sym->members[i].elem_size = m->elem_size;
-        sym->members[i].offset = m->offset;
-        sym->members[i].bit_width = m->bit_width;
-        sym->members[i].bit_offset = m->bit_offset;
-    }
     return 1;
 }
 
@@ -362,21 +350,10 @@ static int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
                                 size_t count, size_t total)
 {
     sym->struct_total_size = total;
-    if (!count)
-        return 1;
-    sym->struct_members = malloc(count * sizeof(*sym->struct_members));
-    if (!sym->struct_members)
+    if (!copy_members((union_member_t **)&sym->struct_members,
+                      (union_member_t *)members, count))
         return 0;
     sym->struct_member_count = count;
-    for (size_t i = 0; i < count; i++) {
-        struct_member_t *m = &members[i];
-        sym->struct_members[i].name = vc_strdup(m->name);
-        sym->struct_members[i].type = m->type;
-        sym->struct_members[i].elem_size = m->elem_size;
-        sym->struct_members[i].offset = m->offset;
-        sym->struct_members[i].bit_width = m->bit_width;
-        sym->struct_members[i].bit_offset = m->bit_offset;
-    }
     return 1;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <limits.h>
 #include "util.h"
+#include "ast.h"
 
 /*
  * Allocate "size" bytes of memory.  If the allocation fails the process
@@ -140,6 +141,32 @@ int vc_strtoul_unsigned(const char *s, unsigned *out)
     if (errno == ERANGE || val > UINT_MAX || *end != '\0')
         return 0;
     *out = (unsigned)val;
+    return 1;
+}
+
+/*
+ * Allocate and duplicate an array of members.
+ * Each name string is duplicated using vc_strdup.
+ * Returns non-zero on success.
+ */
+int copy_members(union_member_t **dst, const union_member_t *src, size_t count)
+{
+    if (!count) {
+        *dst = NULL;
+        return 1;
+    }
+    union_member_t *out = malloc(count * sizeof(*out));
+    if (!out)
+        return 0;
+    for (size_t i = 0; i < count; i++) {
+        out[i].name = vc_strdup(src[i].name);
+        out[i].type = src[i].type;
+        out[i].elem_size = src[i].elem_size;
+        out[i].offset = src[i].offset;
+        out[i].bit_width = src[i].bit_width;
+        out[i].bit_offset = src[i].bit_offset;
+    }
+    *dst = out;
     return 1;
 }
 


### PR DESCRIPTION
## Summary
- add `copy_members` helper for allocating and duplicating member arrays
- use `copy_members` in `copy_union_metadata` and `copy_struct_metadata`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6868101f94fc8324b01d1773e74807a4