### PR TITLE
Fix lexeme cleanup on scan error

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -603,6 +603,9 @@ token_t *lexer_tokenize(const char *src, size_t *out_count)
     while (1) {
         int res = scan_next_token(src, &i, &line, &col, &vec);
         if (res < 0) {
+            token_t *tokens = (token_t *)vec.data;
+            for (size_t j = 0; j < vec.count; j++)
+                free(tokens[j].lexeme);
             vector_free(&vec);
             return NULL;
         }


### PR DESCRIPTION
## Summary
- avoid leaking lexeme strings in `lexer_tokenize` when scanning fails

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68688a928fc08324b533c2506f224e3e