### PR TITLE
Improve command_to_string overflow handling

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -12,7 +12,10 @@
 #define VC_COMMAND_H
 
 /* Convert an argument vector into a single string for debugging.
- * The returned buffer is heap allocated and must be freed by the caller.
+ * Arguments containing spaces or shell metacharacters are quoted using
+ * single quotes. The returned buffer is heap allocated and must be freed
+ * by the caller. Returns NULL if the result would exceed implementation
+ * limits.
  */
 char *command_to_string(char *const argv[]);
 


### PR DESCRIPTION
## Summary
- gracefully handle overflow in `command_to_string`
- quote command arguments for readability and safety
- fall back to argv[0] if command string can't be produced

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68688b3119e88324a6129708d118bf93