### PR TITLE
Remove unused helper functions

### DIFF
--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -479,41 +479,6 @@ void ir_build_store_idx_vol(ir_builder_t *b, const char *name, ir_value_t idx,
     ins->is_volatile = 1;
 }
 
-/* Load a bit-field from `name` shifted by `shift` and masked by `width`. */
-static ir_value_t ir_build_bfload(ir_builder_t *b, const char *name,
-                                  int shift, int width)
-{
-    ir_instr_t *ins = append_instr(b);
-    if (!ins)
-        return (ir_value_t){0};
-    ins->op = IR_BFLOAD;
-    ins->dest = alloc_value_id(b);
-    ins->name = vc_strdup(name ? name : "");
-    if (!ins->name) {
-        remove_instr(b, ins);
-        return (ir_value_t){0};
-    }
-    ins->imm = ((long long)shift << 32) | (unsigned)width;
-    return (ir_value_t){ins->dest};
-}
-
-/* Store `val` into a bit-field at `name`. */
-static void ir_build_bfstore(ir_builder_t *b, const char *name, int shift,
-                             int width, ir_value_t val)
-{
-    ir_instr_t *ins = append_instr(b);
-    if (!ins)
-        return;
-    ins->op = IR_BFSTORE;
-    ins->src1 = val.id;
-    ins->name = vc_strdup(name ? name : "");
-    if (!ins->name) {
-        remove_instr(b, ins);
-        return;
-    }
-    ins->imm = ((long long)shift << 32) | (unsigned)width;
-}
-
 /* Emit IR_ALLOCA reserving stack space of the given size. */
 ir_value_t ir_build_alloca(ir_builder_t *b, ir_value_t size)
 {

--- a/src/symtable_struct.c
+++ b/src/symtable_struct.c
@@ -74,23 +74,6 @@ int symtable_add_enum_tag_global(symtable_t *table, const char *tag)
     return 1;
 }
 
-/*
- * Search for an enum tag in both the local and global lists.
- * Returns NULL if no matching tag exists.
- */
-static symbol_t *symtable_lookup_enum_tag(symtable_t *table, const char *tag)
-{
-    for (symbol_t *sym = table->head; sym; sym = sym->next) {
-        if (sym->type == TYPE_ENUM && strcmp(sym->name, tag) == 0)
-            return sym;
-    }
-    for (symbol_t *sym = table->globals; sym; sym = sym->next) {
-        if (sym->type == TYPE_ENUM && strcmp(sym->name, tag) == 0)
-            return sym;
-    }
-    return NULL;
-}
-
 /* Insert a union type definition in the current scope */
 int symtable_add_union(symtable_t *table, const char *tag,
                        union_member_t *members, size_t member_count)


### PR DESCRIPTION
## Summary
- drop dead `symtable_lookup_enum_tag()`
- remove unused bit-field builders

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68688e214ca48324abfa2c9e998dbd37