### PR TITLE
Fix CLI vector cleanup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -72,5 +72,9 @@ int main(int argc, char **argv)
 cleanup:
     vector_free(&cli.sources);
     vector_free(&cli.include_dirs);
+    vector_free(&cli.defines);
+    vector_free(&cli.undefines);
+    vector_free(&cli.lib_dirs);
+    vector_free(&cli.libs);
     return ret;
 }

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -35,6 +35,10 @@ static void test_parse_success(void)
     ASSERT(opts.asm_syntax == ASM_ATT);
     vector_free(&opts.sources);
     vector_free(&opts.include_dirs);
+    vector_free(&opts.defines);
+    vector_free(&opts.undefines);
+    vector_free(&opts.lib_dirs);
+    vector_free(&opts.libs);
 }
 
 static void test_intel_syntax_option(void)
@@ -46,6 +50,10 @@ static void test_intel_syntax_option(void)
     ASSERT(opts.asm_syntax == ASM_INTEL);
     vector_free(&opts.sources);
     vector_free(&opts.include_dirs);
+    vector_free(&opts.defines);
+    vector_free(&opts.undefines);
+    vector_free(&opts.lib_dirs);
+    vector_free(&opts.libs);
 }
 
 static void test_parse_failure(void)
@@ -81,6 +89,12 @@ static void test_parse_failure(void)
 
     ASSERT(ret != 0);
     ASSERT(strstr(buf, "Out of memory") != NULL);
+    vector_free(&opts.sources);
+    vector_free(&opts.include_dirs);
+    vector_free(&opts.defines);
+    vector_free(&opts.undefines);
+    vector_free(&opts.lib_dirs);
+    vector_free(&opts.libs);
 }
 
 int main(void)


### PR DESCRIPTION
## Summary
- free all CLI vectors on exit
- update CLI unit tests for new vectors

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68689569cfdc8324aab9e4e4e33de8e5