### PR TITLE
Allow -c with multiple inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ To generate an object file instead, pass `-c`:
 vc -c -o out.o source.c
 ```
 
+When `-c` is given more than once source file may be listed.  An object
+file named after each input (e.g. `foo.o`) will be produced in the
+current directory.
+
 To print the generated assembly to stdout instead of creating a file,
 pass `--dump-asm`:
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -43,6 +43,8 @@ Use `vc -o out.s source.c` to compile a file, `vc -c -o out.o source.c` to
 produce an object, `vc --link -o prog main.c util.c` to build an executable
 from multiple sources, `vc -S source.c` to print the assembly to the
 terminal, or pipe code into `vc -o out.s -` to read from standard input.
+When `-c` is combined with several inputs an object named after each
+source (for example `file.o`) is created in the current directory.
 
 ## Preprocessor Usage
 

--- a/man/vc.1
+++ b/man/vc.1
@@ -105,7 +105,9 @@ Use Intel-style x86 assembly output. When combined with
 assemble the generated code.
 .TP
 .BR -c "," \fB--compile\fR
-Assemble the output into an object file using \fBcc -c\fR.
+Assemble the output into an object file using \fBcc -c\fR. When multiple
+input files are provided an object is created for each source in the
+current directory.
 .TP
 .B --link
 Assemble and link the output to create an executable with \fBcc\fR.
@@ -132,6 +134,10 @@ Compile a source file to \fIout.s\fR:
 Create an object file:
 .PP
 .B vc -c -o out.o source.c
+.PP
+Compile multiple sources to objects:
+.PP
+.B vc -c foo.c bar.c
 .PP
 Build an executable:
 .PP

--- a/src/main.c
+++ b/src/main.c
@@ -31,10 +31,6 @@ int main(int argc, char **argv)
 
     error_use_color = cli.color_diag;
 
-    if (!cli.link && cli.sources.count != 1) {
-        fprintf(stderr, "Error: multiple input files require --link\n");
-        goto cleanup;
-    }
 
     if (cli.preprocess) {
         ret = run_preprocessor(&cli);
@@ -59,6 +55,8 @@ int main(int argc, char **argv)
         else if (cli.dump_asm)
             printf("Compiling %s (assembly dumped to stdout)\n",
                    ((const char **)cli.sources.data)[0]);
+        else if (cli.compile && cli.sources.count > 1)
+            printf("Compiled %zu files to objects\n", cli.sources.count);
         else if (cli.compile)
             printf("Compiling %s -> %s (object)\n",
                    ((const char **)cli.sources.data)[0], cli.output);


### PR DESCRIPTION
## Summary
- support compiling more than one source when using `-c`
- emit an object for each input file
- document multi-source compilation in README, command line docs and manpage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68689b6b77808324af16acf85d3030e5