### PR TITLE
Refactor preprocessor helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ CORE_SRC = src/main.c src/compile.c src/startup.c src/command.c src/cli.c src/le
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_arith.c src/codegen_branch.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/label.c \
-           src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
+           src/preproc_macros.c src/preproc_expr.c src/preproc_file.c \
+           src/preproc_include.c src/preproc_io.c
 
 # Optional optimization sources
 OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_dce.c src/opt_inline.c src/opt_unreachable.c
@@ -23,7 +24,8 @@ OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_global.h include/ir_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
-    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h include/startup.h
+    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h \
+    include/preproc_include.h include/preproc_io.h include/parser_types.h include/parser_core.h include/startup.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man
@@ -187,6 +189,12 @@ src/preproc_expr.o: src/preproc_expr.c $(HDR)
 
 src/preproc_file.o: src/preproc_file.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_file.c -o src/preproc_file.o
+
+src/preproc_include.o: src/preproc_include.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_include.c -o src/preproc_include.o
+
+src/preproc_io.o: src/preproc_io.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_io.c -o src/preproc_io.o
 
 src/opt.o: src/opt.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt.c -o src/opt.o

--- a/include/preproc_include.h
+++ b/include/preproc_include.h
@@ -1,0 +1,16 @@
+#ifndef VC_PREPROC_INCLUDE_H
+#define VC_PREPROC_INCLUDE_H
+
+#include "vector.h"
+
+char *find_include_path(const char *fname, char endc,
+                        const char *dir, const vector_t *incdirs);
+int include_stack_contains(vector_t *stack, const char *path);
+int include_stack_push(vector_t *stack, const char *path);
+void include_stack_pop(vector_t *stack);
+int pragma_once_contains(const char *path);
+int pragma_once_add(const char *path);
+void preproc_include_init(void);
+void preproc_include_cleanup(void);
+
+#endif /* VC_PREPROC_INCLUDE_H */

--- a/include/preproc_io.h
+++ b/include/preproc_io.h
@@ -1,0 +1,10 @@
+#ifndef VC_PREPROC_IO_H
+#define VC_PREPROC_IO_H
+
+#include "vector.h"
+
+int load_source(const char *path, vector_t *stack,
+                char ***out_lines, char **out_dir, char **out_text);
+void cleanup_source(char *text, char **lines, char *dir);
+
+#endif /* VC_PREPROC_IO_H */

--- a/src/preproc_include.c
+++ b/src/preproc_include.c
@@ -1,0 +1,179 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "preproc_include.h"
+#include "util.h"
+
+/* Standard system include directories */
+static const char *std_include_dirs[] = {
+    "/usr/local/include",
+    "/usr/include",
+    NULL
+};
+
+/* Files marked with #pragma once */
+static vector_t pragma_once_files;
+
+void preproc_include_init(void)
+{
+    vector_init(&pragma_once_files, sizeof(char *));
+}
+
+void preproc_include_cleanup(void)
+{
+    for (size_t i = 0; i < pragma_once_files.count; i++)
+        free(((char **)pragma_once_files.data)[i]);
+    vector_free(&pragma_once_files);
+}
+
+int include_stack_contains(vector_t *stack, const char *path)
+{
+    char *canon = realpath(path, NULL);
+    if (!canon) {
+        if (errno != ENOENT)
+            perror(path);
+        return 0;
+    }
+    for (size_t i = 0; i < stack->count; i++) {
+        const char *p = ((const char **)stack->data)[i];
+        if (strcmp(p, canon) == 0) {
+            free(canon);
+            return 1;
+        }
+    }
+    free(canon);
+    return 0;
+}
+
+int include_stack_push(vector_t *stack, const char *path)
+{
+    char *canon = realpath(path, NULL);
+    if (!canon) {
+        canon = vc_strdup(path);
+        if (!canon) {
+            fprintf(stderr, "Out of memory\n");
+            return 0;
+        }
+    }
+    if (!vector_push(stack, &canon)) {
+        free(canon);
+        fprintf(stderr, "Out of memory\n");
+        return 0;
+    }
+    return 1;
+}
+
+void include_stack_pop(vector_t *stack)
+{
+    if (stack->count) {
+        free(((char **)stack->data)[stack->count - 1]);
+        stack->count--;
+    }
+}
+
+int pragma_once_contains(const char *path)
+{
+    char *canon = realpath(path, NULL);
+    if (!canon)
+        canon = vc_strdup(path);
+    if (!canon)
+        return 0;
+    for (size_t i = 0; i < pragma_once_files.count; i++) {
+        const char *p = ((const char **)pragma_once_files.data)[i];
+        if (strcmp(p, canon) == 0) {
+            free(canon);
+            return 1;
+        }
+    }
+    free(canon);
+    return 0;
+}
+
+int pragma_once_add(const char *path)
+{
+    char *canon = realpath(path, NULL);
+    if (!canon)
+        canon = vc_strdup(path);
+    if (!canon)
+        return 0;
+    for (size_t i = 0; i < pragma_once_files.count; i++) {
+        const char *p = ((const char **)pragma_once_files.data)[i];
+        if (strcmp(p, canon) == 0) {
+            free(canon);
+            return 1;
+        }
+    }
+    if (!vector_push(&pragma_once_files, &canon)) {
+        free(canon);
+        fprintf(stderr, "Out of memory\n");
+        return 0;
+    }
+    return 1;
+}
+
+char *find_include_path(const char *fname, char endc,
+                        const char *dir, const vector_t *incdirs)
+{
+    size_t fname_len = strlen(fname);
+    size_t max_len = fname_len;
+    if (endc == '"' && dir) {
+        size_t len = strlen(dir) + fname_len;
+        if (len > max_len)
+            max_len = len;
+    }
+
+    for (size_t i = 0; i < incdirs->count; i++) {
+        const char *base = ((const char **)incdirs->data)[i];
+        size_t len = strlen(base) + 1 + fname_len;
+        if (len > max_len)
+            max_len = len;
+    }
+
+    for (size_t i = 0; std_include_dirs[i]; i++) {
+        size_t len = strlen(std_include_dirs[i]) + 1 + fname_len;
+        if (len > max_len)
+            max_len = len;
+    }
+
+    char *out_path = vc_alloc_or_exit(max_len + 1);
+
+    if (endc == '"' && dir) {
+        snprintf(out_path, max_len + 1, "%s%s", dir, fname);
+        if (access(out_path, R_OK) == 0)
+            return out_path;
+    }
+
+    for (size_t i = 0; i < incdirs->count; i++) {
+        const char *base = ((const char **)incdirs->data)[i];
+        snprintf(out_path, max_len + 1, "%s/%s", base, fname);
+        if (access(out_path, R_OK) == 0)
+            return out_path;
+    }
+
+    if (endc == '<') {
+        for (size_t i = 0; std_include_dirs[i]; i++) {
+            snprintf(out_path, max_len + 1, "%s/%s", std_include_dirs[i], fname);
+            if (access(out_path, R_OK) == 0)
+                return out_path;
+        }
+        free(out_path);
+        return NULL;
+    }
+
+    snprintf(out_path, max_len + 1, "%s", fname);
+    if (access(out_path, R_OK) == 0)
+        return out_path;
+
+    for (size_t i = 0; std_include_dirs[i]; i++) {
+        snprintf(out_path, max_len + 1, "%s/%s", std_include_dirs[i], fname);
+        if (access(out_path, R_OK) == 0)
+            return out_path;
+    }
+
+    free(out_path);
+    return NULL;
+}
+

--- a/src/preproc_io.c
+++ b/src/preproc_io.c
@@ -1,0 +1,81 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "preproc_io.h"
+#include "preproc_include.h"
+#include "util.h"
+
+/* Read a file and split it into NUL terminated lines.  The returned text
+ * buffer backs the line array and must be freed along with the array. */
+static char *read_file_lines(const char *path, char ***out_lines)
+{
+    char *text = vc_read_file(path);
+    if (!text)
+        return NULL;
+
+    size_t len = strlen(text);
+    size_t line_count = 1;
+    for (char *p = text; *p; p++)
+        if (*p == '\n')
+            line_count++;
+    if (len > 0 && text[len - 1] == '\n')
+        line_count--;
+
+    char **lines = vc_alloc_or_exit(sizeof(char *) * (line_count + 1));
+
+    size_t idx = 0;
+    lines[idx++] = text;
+    for (size_t i = 0; i < len; i++) {
+        if (text[i] == '\n') {
+            text[i] = '\0';
+            if (i + 1 < len)
+                lines[idx++] = &text[i + 1];
+        }
+    }
+    lines[idx] = NULL;
+    *out_lines = lines;
+    return text;
+}
+
+/* Load "path" into memory and register it on the include stack. */
+int load_source(const char *path, vector_t *stack,
+                char ***out_lines, char **out_dir, char **out_text)
+{
+    char **lines;
+    char *text = read_file_lines(path, &lines);
+    if (!text)
+        return 0;
+
+    char *dir = NULL;
+    const char *slash = strrchr(path, '/');
+    if (slash) {
+        size_t len = (size_t)(slash - path) + 1;
+        dir = vc_strndup(path, len);
+        if (!dir) {
+            free(lines);
+            free(text);
+            return 0;
+        }
+    }
+
+    if (!include_stack_push(stack, path)) {
+        free(lines);
+        free(text);
+        free(dir);
+        return 0;
+    }
+
+    *out_lines = lines;
+    *out_dir = dir;
+    *out_text = text;
+    return 1;
+}
+
+/* Free resources obtained from load_source. */
+void cleanup_source(char *text, char **lines, char *dir)
+{
+    free(lines);
+    free(text);
+    free(dir);
+}
+


### PR DESCRIPTION
## Summary
- split file loading and include helpers into their own modules
- add `preproc_include.c` and `preproc_io.c`
- adjust `preproc_file.c` to use smaller helpers
- update Makefile for new sources

## Testing
- `make -k`
- `./tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6868a608a6bc8324a5b17dfe2c38c2da