### PR TITLE
Add vc_oom helper and use it

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -17,6 +17,9 @@ char *vc_strdup(const char *s);
 /* Duplicate at most 'n' characters of a string. Returns NULL on allocation failure */
 char *vc_strndup(const char *s, size_t n);
 
+/* Print an out of memory message to stderr */
+void vc_oom(void);
+
 /* Allocate memory or exit on failure */
 void *vc_alloc_or_exit(size_t size);
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "cli.h"
+#include "util.h"
 
 #define VERSION "0.1.0"
 
@@ -111,7 +112,7 @@ void cli_free_opts(cli_options_t *opts)
 static int push_source(cli_options_t *opts, const char *src)
 {
     if (!vector_push(&opts->sources, &src)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return -1;
     }
     return 0;
@@ -124,7 +125,7 @@ static int push_source(cli_options_t *opts, const char *src)
 static int add_include_dir(cli_options_t *opts, const char *dir)
 {
     if (!vector_push(&opts->include_dirs, &dir)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return -1;
     }
     return 0;
@@ -136,7 +137,7 @@ static int add_include_dir(cli_options_t *opts, const char *dir)
 static int add_lib_dir(cli_options_t *opts, const char *dir)
 {
     if (!vector_push(&opts->lib_dirs, &dir)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return -1;
     }
     return 0;
@@ -148,7 +149,7 @@ static int add_lib_dir(cli_options_t *opts, const char *dir)
 static int add_library(cli_options_t *opts, const char *name)
 {
     if (!vector_push(&opts->libs, &name)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return -1;
     }
     return 0;
@@ -330,7 +331,7 @@ static int add_define_opt(const char *arg, const char *prog, cli_options_t *opts
         return 1;
     }
     if (!vector_push(&opts->defines, &arg)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return 1;
     }
     return 0;
@@ -344,7 +345,7 @@ static int add_undef_opt(const char *arg, const char *prog, cli_options_t *opts)
         return 1;
     }
     if (!vector_push(&opts->undefines, &arg)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return 1;
     }
     return 0;

--- a/src/compile.c
+++ b/src/compile.c
@@ -248,7 +248,7 @@ static int read_stdin_source(const cli_options_t *cli,
 
     char *path = vc_strdup(tmpl);
     if (!path) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         unlink(tmpl);
         free(tmpl);
         return 0;
@@ -701,7 +701,7 @@ int compile_unit(const char *source, const cli_options_t *cli,
             size_t len = dot ? (size_t)(dot - base) : strlen(base);
             char *obj = malloc(len + 3);
             if (!obj) {
-                fprintf(stderr, "Out of memory\n");
+                vc_oom();
                 return 0;
             }
             memcpy(obj, base, len);
@@ -862,7 +862,7 @@ static int compile_source_files(const cli_options_t *cli, vector_t *objs)
         }
 
         if (!vector_push(objs, &obj)) {
-            fprintf(stderr, "Out of memory\n");
+            vc_oom();
             ok = 0;
             unlink(obj);
             free(obj);
@@ -966,7 +966,7 @@ static int build_and_link_objects(vector_t *objs, const cli_options_t *cli)
     int ok = create_startup_object(cli, cli->use_x86_64, &stubobj);
     if (ok) {
         if (!vector_push(objs, &stubobj)) {
-            fprintf(stderr, "Out of memory\n");
+            vc_oom();
             unlink(stubobj);
             free(stubobj);
             return 0;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -108,13 +108,13 @@ static void append_token(vector_t *vec, token_type_t type, const char *lexeme,
 {
     char *text = vc_strndup(lexeme, len);
     if (!text) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         exit(1);
     }
     token_t tok = { type, text, line, column };
     if (!vector_push(vec, &tok)) {
         free(text);
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         exit(1);
     }
 }
@@ -410,7 +410,7 @@ static int read_string_lit(const char *src, size_t *i, size_t *col,
             (*i)++; /* consume character */
         }
         if (!vector_push(&buf_v, &c)) {
-            fprintf(stderr, "Out of memory\n");
+            vc_oom();
             vector_free(&buf_v);
             return 0;
         }
@@ -419,7 +419,7 @@ static int read_string_lit(const char *src, size_t *i, size_t *col,
     /* NUL-terminate the buffer for convenience */
     char nul = '\0';
     if (!vector_push(&buf_v, &nul)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         vector_free(&buf_v);
         return 0;
     }

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -102,13 +102,13 @@ static int include_stack_push(vector_t *stack, const char *path)
     if (!canon) {
         canon = vc_strdup(path);
         if (!canon) {
-            fprintf(stderr, "Out of memory\n");
+            vc_oom();
             return 0;
         }
     }
     if (!vector_push(stack, &canon)) {
         free(canon);
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return 0;
     }
     return 1;
@@ -159,7 +159,7 @@ static int pragma_once_add(const char *path)
     }
     if (!vector_push(&pragma_once_files, &canon)) {
         free(canon);
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return 0;
     }
     return 1;
@@ -407,7 +407,7 @@ static int add_macro(const char *name, const char *value, vector_t *params,
                 free(((char **)params->data)[j]);
             vector_free(params);
             macro_free(&m);
-            fprintf(stderr, "Out of memory\n");
+            vc_oom();
             return 0;
         }
     }
@@ -419,7 +419,7 @@ static int add_macro(const char *name, const char *value, vector_t *params,
             free(((char **)m.params.data)[i]);
         m.params.count = 0;
         macro_free(&m);
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return 0;
     }
     return 1;
@@ -479,7 +479,7 @@ static int cond_push_ifdef_common(char *line, vector_t *macros,
         st.taking = 0;
     }
     if (!vector_push(conds, &st)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return 0;
     }
     return 1;
@@ -511,7 +511,7 @@ static int cond_push_ifexpr(char *line, vector_t *macros, vector_t *conds)
         st.taking = 0;
     }
     if (!vector_push(conds, &st)) {
-        fprintf(stderr, "Out of memory\n");
+        vc_oom();
         return 0;
     }
     return 1;

--- a/src/preproc_macros.c
+++ b/src/preproc_macros.c
@@ -415,7 +415,7 @@ static int parse_macro_invocation(const char *line, size_t *pos,
                         strbuf_free(&sb);
                         ap = malloc((fixed + 1) * sizeof(char *));
                         if (!ap) {
-                            fprintf(stderr, "Out of memory\n");
+                            vc_oom();
                             for (size_t t = 0; t < args.count; t++)
                                 free(((char **)args.data)[t]);
                             vector_free(&args);

--- a/src/util.c
+++ b/src/util.c
@@ -16,6 +16,12 @@
 #include "util.h"
 #include "preproc_macros.h"
 
+/* Print a generic out of memory message */
+void vc_oom(void)
+{
+    fprintf(stderr, "Out of memory\n");
+}
+
 /*
  * Allocate "size" bytes of memory.  If the allocation fails the process
  * prints an error message and terminates.  The returned block is


### PR DESCRIPTION
## Summary
- add `vc_oom` helper to centralise out-of-memory message
- declare the helper in `util.h`
- use `vc_oom()` wherever the code previously printed "Out of memory"

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6869fd8f8970832481f448e291642000