### PR TITLE
Introduce preprocessor context

### DIFF
--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -16,11 +16,19 @@
 
 #include "vector.h"
 
+/* Context used by the preprocessor.  Currently only tracks files
+ * processed after encountering '#pragma once'.
+ */
+typedef struct {
+    vector_t pragma_once_files; /* vector of malloc'd char* paths */
+} preproc_context_t;
+
 /* Preprocess the file at the given path.
  * The returned string must be freed by the caller.
  * Returns NULL on failure.
  */
-char *preproc_run(const char *path, const vector_t *include_dirs,
-                  const vector_t *defines, const vector_t *undefines);
+char *preproc_run(preproc_context_t *ctx, const char *path,
+                  const vector_t *include_dirs, const vector_t *defines,
+                  const vector_t *undefines);
 
 #endif /* VC_PREPROC_FILE_H */

--- a/src/compile.c
+++ b/src/compile.c
@@ -255,7 +255,8 @@ static int read_stdin_source(const cli_options_t *cli,
     }
     free(tmpl);
 
-    char *text = preproc_run(path, incdirs, defines, undefines);
+    preproc_context_t ctx;
+    char *text = preproc_run(&ctx, path, incdirs, defines, undefines);
     if (!text) {
         perror("preproc_run");
         unlink(path);
@@ -293,7 +294,8 @@ static int compile_tokenize_impl(const char *source, const cli_options_t *cli,
             stdin_path = NULL;
         }
     } else {
-        text = preproc_run(source, incdirs, defines, undefines);
+        preproc_context_t ctx;
+        text = preproc_run(&ctx, source, incdirs, defines, undefines);
         if (!text) {
             perror("preproc_run");
             return 0;
@@ -982,7 +984,8 @@ int run_preprocessor(const cli_options_t *cli)
 {
     for (size_t i = 0; i < cli->sources.count; i++) {
         const char *src = ((const char **)cli->sources.data)[i];
-        char *text = preproc_run(src, &cli->include_dirs, &cli->defines,
+        preproc_context_t ctx;
+        char *text = preproc_run(&ctx, src, &cli->include_dirs, &cli->defines,
                                 &cli->undefines);
         if (!text) {
             perror("preproc_run");


### PR DESCRIPTION
## Summary
- add `preproc_context_t` to hold `pragma_once` bookkeeping
- thread context through preprocessing functions
- update compiler to pass the new context

## Testing
- `make`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869ff163a5483248a957cf3e05b3147