### PR TITLE
Handle fputs failure when writing NASM macros

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -584,8 +584,16 @@ static int emit_output_file(ir_builder_t *ir, const char *output,
             free(tmpname);
             return 0;
         }
-        if (cli->asm_syntax == ASM_INTEL)
-            fputs(nasm_macros, tmpf);
+        if (cli->asm_syntax == ASM_INTEL) {
+            int rc = fputs(nasm_macros, tmpf);
+            if (rc == EOF) {
+                perror("fputs");
+                fclose(tmpf);
+                unlink(tmpname);
+                free(tmpname);
+                return 0;
+            }
+        }
         codegen_emit_x86(tmpf, ir, use_x86_64,
                         cli->asm_syntax);
         if (fflush(tmpf) == EOF) {

--- a/tests/unit/fail_fputs.c
+++ b/tests/unit/fail_fputs.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <errno.h>
+
+int fputs(const char *s, FILE *stream)
+{
+    (void)s; (void)stream;
+    errno = ENOSPC;
+    return EOF;
+}


### PR DESCRIPTION
## Summary
- check the return value of `fputs(nasm_macros, tmpf)`
- simulate disk-full failures in a new test
- add `fail_fputs.c` helper for the new unit test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a072d66b88324a505a046ce1e8dc0