### PR TITLE
Document memory helpers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,4 @@ provides an overview of the available documentation.
 8. [Development roadmap](roadmap.md) – planned milestones and compatibility
    goals.
 9. [Contributing](../CONTRIBUTING.md) – how to submit patches and bug reports.
+10. [Memory helpers](memory_helpers.md) – cleaning up vectors of strings or macros.

--- a/docs/memory_helpers.md
+++ b/docs/memory_helpers.md
@@ -1,0 +1,23 @@
+# Memory Helpers
+
+Some parts of the compiler store heap allocated strings or `macro_t` objects
+inside `vector_t` containers. The functions `free_string_vector` and
+`free_macro_vector` release these structures safely.
+
+`free_string_vector` walks a vector of `char *`, frees each string and then
+calls `vector_free` on the container. Use it whenever a vector holds
+strings duplicated with `malloc` or `vc_strdup`.
+
+`free_macro_vector` performs the same task for vectors of `macro_t`. It calls
+`macro_free` on each element before freeing the vector itself.
+
+```c
+vector_t paths;
+vector_init(&paths, sizeof(char *));
+vector_push(&paths, vc_strdup("include"));
+...
+free_string_vector(&paths); /* releases strings and vector */
+```
+
+The helpers are declared in [util.h](../include/util.h) and implemented in
+[util.c](../src/util.c).

--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -7,7 +7,7 @@ are produced.  `preproc_run` in `src/preproc_file.c` drives this process.
 ## File processing
 
 `preproc_run` builds a list of include search paths then calls `process_file` to
-read the initial source.  Each line is inspected in order and any recognised
+read the initial source.  The list is released with [`free_string_vector`](memory_helpers.md) once preprocessing finishes.  Each line is inspected in order and any recognised
 preprocessor directive is handled immediately:
 
 - `#include` resolves the requested path and recursively invokes `process_file`
@@ -40,6 +40,7 @@ lookup, handle the `#` stringize operator and manage `##` token pasting.  A
 macro may be declared variadic by using `...` as the final parameter.  When such
 a macro is invoked `__VA_ARGS__` within its body is replaced by the remaining
 arguments.
+The macro table is cleaned up with [`free_macro_vector`](memory_helpers.md) once preprocessing is complete.
 Macro expansion is recursive so macro bodies may reference other macros. To
 avoid infinite loops a hard limit of 100 nested expansions is enforced.  When
 this limit is hit `expand_line` returns zero and the compiler aborts


### PR DESCRIPTION
## Summary
- document `free_string_vector` and `free_macro_vector`
- reference new helpers in the preprocessor docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a07399c0c8324ba8e0a172a02e4d6