### PR TITLE
Add TMPDIR test and stub

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -16,6 +16,24 @@
 #include "util.h"
 #include "preproc_macros.h"
 
+#ifndef __has_attribute
+# define __has_attribute(x) 0
+#endif
+
+/*
+ * Provide a weak stub for macro_free so unit tests linking only a subset
+ * of the source files do not fail due to an unresolved symbol.  When the
+ * real implementation from preproc_macros.c is linked in, it overrides this
+ * weak definition.
+ */
+#if __has_attribute(weak)
+__attribute__((weak)) void macro_free(macro_t *m) { (void)m; }
+__attribute__((weak)) void vector_free(vector_t *v) { (void)v; }
+#else
+void __attribute__((weak)) macro_free(macro_t *m) { (void)m; }
+void __attribute__((weak)) vector_free(vector_t *v) { (void)v; }
+#endif
+
 /* Print a generic out of memory message */
 void vc_oom(void)
 {

--- a/tests/unit/test_temp_file.c
+++ b/tests/unit/test_temp_file.c
@@ -120,12 +120,34 @@ static void test_tmpdir(void)
     rmdir(tmpdir);
 }
 
+static void test_tmpdir_mkdtemp(void)
+{
+    char template[] = "/tmp/vcXXXXXX";
+    char *dir = mkdtemp(template);
+    ASSERT(dir != NULL);
+    setenv("TMPDIR", dir, 1);
+
+    cli_options_t cli;
+    memset(&cli, 0, sizeof(cli));
+    const char *prefix = "vc";
+    char *path = NULL;
+    int fd = create_temp_file(&cli, prefix, &path);
+    ASSERT(fd >= 0);
+    ASSERT(strncmp(path, dir, strlen(dir)) == 0 && path[strlen(dir)] == '/');
+    close(fd);
+    unlink(path);
+    free(path);
+    unsetenv("TMPDIR");
+    rmdir(dir);
+}
+
 int main(void)
 {
     test_reject_long_path();
     test_reject_pathmax_dir();
     test_snprintf_overflow();
     test_tmpdir();
+    test_tmpdir_mkdtemp();
     if (failures == 0)
         printf("All create_temp_file tests passed\n");
     else


### PR DESCRIPTION
## Summary
- add weak stubs for `macro_free` and `vector_free` so unit tests link cleanly
- add a new `TMPDIR` test using `mkdtemp`

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a0b6e2fec83249683492ec1d5ed17