### PR TITLE
Clarify tmp directory selection

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -39,10 +39,10 @@ The compiler supports the following options:
 - `-Uname` – undefine a macro before compilation.
 - `-O<N>` – set optimization level (0 disables all passes).
 
-Temporary object and assembly files are written to the directory specified
-by the `TMPDIR` environment variable when set.  If `TMPDIR` is not set,
-the system default (from `P_tmpdir`, usually `/tmp`) is used.  Use the
-`--obj-dir` option to select a different directory if desired.
+Temporary object and assembly files are written to the directory given with
+the `--obj-dir` option when provided.  Without this flag the compiler
+consults the `TMPDIR` environment variable and then `P_tmpdir` when set.
+Only if neither variable is available does it fall back to `/tmp`.
 
 Use `vc -o out.s source.c` to compile a file, `vc -c -o out.o source.c` to
 produce an object, `vc --link -o prog main.c util.c` to build an executable

--- a/man/vc.1
+++ b/man/vc.1
@@ -133,8 +133,10 @@ current directory.
 Assemble and link the output to create an executable with \fBcc\fR.
 .TP
 .BR --obj-dir " " \fIdir\fR
-Place temporary object files in \fIdir\fR instead of the directory selected
-via \fBTMPDIR\fR or the system default (usually \fB/tmp\fR).
+Place temporary object files in \fIdir\fR.  When this option is
+omitted the compiler first checks \fBTMPDIR\fR and \fBP_tmpdir\fR for
+a directory.  Only if neither variable is set does it default to
+\fB/tmp\fR.
 .TP
 .BR -S "," \fB--dump-asm\fR
 Print generated assembly to stdout rather than creating a file.
@@ -183,5 +185,11 @@ paths are processed.
 Colon separated list of directories added to the include search path after any
 .B -I
 paths are processed.
+.TP
+.B TMPDIR
+Directory for temporary object files when \fB--obj-dir\fR is not used.
+.TP
+.B P_tmpdir
+Alternative directory for temporary files if \fBTMPDIR\fR is unset.
 .SH SEE ALSO
 README.md, docs/command_line.md, docs/language_features.md (see the "Union declarations" section).


### PR DESCRIPTION
## Summary
- document that `--obj-dir` overrides the directory used for temporary files
- explain that `TMPDIR` or `P_tmpdir` are used when available
- note `/tmp` is only used when neither variable nor the option is provided

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a0d46483c8324b0a82cace5820475