### PR TITLE
Add CLI option argument tests

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -16,6 +16,10 @@
 #include "util.h"
 #include "preproc_macros.h"
 
+#ifdef MACRO_FREE_STUB
+void macro_free(macro_t *m) { (void)m; }
+#endif
+
 /* Print a generic out of memory message */
 void vc_oom(void)
 {
@@ -170,6 +174,7 @@ void free_string_vector(vector_t *v)
  * Each macro must have been created by add_macro() so that macro_free()
  * can correctly release the heap allocated strings.
  */
+#ifndef MACRO_FREE_STUB
 void free_macro_vector(vector_t *v)
 {
     if (!v)
@@ -178,4 +183,5 @@ void free_macro_vector(vector_t *v)
         macro_free(&((macro_t *)v->data)[i]);
     vector_free(v);
 }
+#endif
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,7 +7,7 @@ fail=0
 # build the compiler
 make
 # build unit test binary
-cc -Iinclude -Wall -Wextra -std=c99 \
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB \
     -o "$DIR/unit_tests" "$DIR/unit/test_lexer_parser.c" \
     src/parser_core.c src/parser_init.c src/parser_decl.c \
     src/parser_flow.c src/parser_toplevel.c src/parser_expr.c \
@@ -19,7 +19,7 @@ cc -Iinclude -Wall -Wextra -std=c99 \
 cc -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push -c src/cli.c -o cli_test.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_cli.c" -o "$DIR/test_cli.o"
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_test.o
-cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_test.o
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB -ffunction-sections -fdata-sections -c src/util.c -o util_test.o
 cc -o "$DIR/cli_tests" cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
 rm -f cli_test.o "$DIR/test_cli.o" vector_test.o util_test.o
 # build parser alloc failure unit test with vector_push wrapper
@@ -39,21 +39,22 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/ast_expr.c -o ast_expr_fail.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/ast_stmt.c -o ast_stmt_fail.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/lexer.c -o lexer_alloc.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_alloc.o
-cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_alloc.o
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB -ffunction-sections -fdata-sections -c src/util.c -o util_alloc.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_alloc.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_parser_alloc_fail.c" -o "$DIR/test_parser_alloc_fail.o"
 cc -o "$DIR/parser_alloc_tests" parser_core_fail.o parser_init_fail.o parser_decl_fail.o parser_flow_fail.o parser_toplevel_fail.o parser_expr_fail.o parser_stmt_fail.o parser_types_fail.o symtable_core_fail.o symtable_globals_fail.o symtable_struct_fail.o ast_clone_fail.o ast_expr_fail.o ast_stmt_fail.o lexer_alloc.o vector_alloc.o util_alloc.o error_alloc.o "$DIR/test_parser_alloc_fail.o"
 rm -f parser_core_fail.o parser_init_fail.o parser_decl_fail.o parser_flow_fail.o parser_toplevel_fail.o parser_expr_fail.o parser_stmt_fail.o parser_types_fail.o symtable_core_fail.o symtable_globals_fail.o symtable_struct_fail.o ast_clone_fail.o ast_expr_fail.o ast_stmt_fail.o lexer_alloc.o vector_alloc.o util_alloc.o error_alloc.o "$DIR/test_parser_alloc_fail.o"
 # build ir_core unit test binary with malloc wrapper
 cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -c src/ir_core.c -o ir_core_test.o
-cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -c src/util.c -o util_ircore.o
+cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -DMACRO_FREE_STUB -ffunction-sections -fdata-sections -c src/util.c -o util_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/label.c -o label_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_ircore.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_ir_core.c" -o "$DIR/test_ir_core.o"
-cc -o "$DIR/ir_core_tests" ir_core_test.o util_ircore.o error_ircore.o label_ircore.o "$DIR/test_ir_core.o"
-rm -f ir_core_test.o util_ircore.o error_ircore.o label_ircore.o "$DIR/test_ir_core.o"
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_ircore.o
+cc -o "$DIR/ir_core_tests" ir_core_test.o util_ircore.o vector_ircore.o error_ircore.o label_ircore.o "$DIR/test_ir_core.o"
+rm -f ir_core_test.o util_ircore.o vector_ircore.o error_ircore.o label_ircore.o "$DIR/test_ir_core.o"
 # build conditional expression regression test
-cc -Iinclude -Wall -Wextra -std=c99 \
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB \
     -o "$DIR/cond_expr_tests" "$DIR/unit/test_cond_expr.c" \
     src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c \
     src/semantic_call.c src/consteval.c src/symtable_core.c \
@@ -61,35 +62,37 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/error.c src/label.c
 # build sizeof pointer evaluation test
 # eval sizeof with small helper modules
-cc -Iinclude -Wall -Wextra -std=c99 \
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB \
     -o "$DIR/eval_sizeof_tests" "$DIR/unit/test_eval_sizeof.c" \
-    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c src/error.c
+    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c src/vector.c src/error.c
 # build numeric constant overflow regression test
-cc -Iinclude -Wall -Wextra -std=c99 \
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB \
     -o "$DIR/number_overflow" "$DIR/unit/test_number_overflow.c" \
-    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c src/error.c
+    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c src/vector.c src/error.c
 # build constant arithmetic overflow regression test
-cc -Iinclude -Wall -Wextra -std=c99 \
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB \
     -o "$DIR/consteval_overflow" "$DIR/unit/test_consteval_overflow.c" \
-    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c src/error.c
+    src/ast_expr.c src/consteval.c src/symtable_core.c src/util.c src/vector.c src/error.c
 # build strbuf overflow regression test
 cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_overflow_impl.o
-cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strbuf.o
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB -ffunction-sections -fdata-sections -c src/util.c -o util_strbuf.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_strbuf_overflow.c" -o "$DIR/test_strbuf_overflow.o"
-cc -o "$DIR/strbuf_overflow" strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
-rm -f strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_strbuf.o
+cc -o "$DIR/strbuf_overflow" strbuf_overflow_impl.o util_strbuf.o vector_strbuf.o "$DIR/test_strbuf_overflow.o"
+rm -f vector_strbuf.o strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
 # build collect_funcs overflow regression test
 cc -Iinclude -Wall -Wextra -std=c99 "$DIR/unit/test_collect_funcs_overflow.c" -o "$DIR/collect_funcs_overflow"
 # build waitpid EINTR regression test
 cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_eintr_impl.o
-cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_eintr.o
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB -ffunction-sections -fdata-sections -c src/util.c -o util_eintr.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_waitpid_retry.c" -o "$DIR/test_waitpid_retry.o"
-cc -o "$DIR/waitpid_retry" strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
-rm -f strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_eintr.o
+cc -o "$DIR/waitpid_retry" strbuf_eintr_impl.o util_eintr.o vector_eintr.o "$DIR/test_waitpid_retry.o"
+rm -f vector_eintr.o strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
 # build invalid macro parse test
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_invalid_macro.c" -o "$DIR/test_invalid_macro.o"
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_invalid.o
-cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_invalid.o
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB -ffunction-sections -fdata-sections -c src/util.c -o util_invalid.o
 cc -o "$DIR/invalid_macro_tests" "$DIR/test_invalid_macro.o" vector_invalid.o util_invalid.o
 rm -f "$DIR/test_invalid_macro.o" vector_invalid.o util_invalid.o
 # build preprocessor alloc failure tests
@@ -123,7 +126,7 @@ cc -Wl,--gc-sections -o "$DIR/compile_obj_fail" compile_obj_fail.o "$DIR/test_co
 rm -f compile_obj_fail.o "$DIR/test_compile_obj_fail.o"
 # build unreachable block elimination test
 cc -Iinclude -Wall -Wextra -std=c99 -c src/ir_core.c -o ir_unreach.o
-cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -DMACRO_FREE_STUB -ffunction-sections -fdata-sections -c src/util.c -o util_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/label.c -o label_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/opt.c -o opt_main.o
@@ -134,10 +137,11 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_dce.c -o opt_dce_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_inline.c -o opt_inline_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_unreachable.c -o opt_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_opt_unreachable.c" -o "$DIR/test_opt_unreachable.o"
-cc -o "$DIR/opt_unreachable_tests" ir_unreach.o util_unreach.o label_unreach.o error_unreach.o \
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_unreach.o
+cc -o "$DIR/opt_unreachable_tests" ir_unreach.o util_unreach.o vector_unreach.o label_unreach.o error_unreach.o \
     opt_main.o opt_constprop_unreach.o opt_cse_unreach.o opt_fold_unreach.o \
     opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o "$DIR/test_opt_unreachable.o"
-rm -f ir_unreach.o util_unreach.o label_unreach.o error_unreach.o opt_main.o \
+rm -f ir_unreach.o util_unreach.o vector_unreach.o label_unreach.o error_unreach.o opt_main.o \
       opt_constprop_unreach.o opt_cse_unreach.o opt_fold_unreach.o \
       opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o "$DIR/test_opt_unreachable.o"
 # run unit tests

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -81,11 +81,144 @@ static void test_parse_failure(void)
     ASSERT(strstr(buf, "Out of memory") != NULL);
 }
 
+static void test_missing_define_arg(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "-D", "", "-o", "out.s", "file.c", NULL};
+    /* reset getopt state before reusing cli_parse_args */
+    optind = 1;
+#ifdef __BSD_VISIBLE
+    optreset = 1;
+#endif
+    FILE *tmp = tmpfile();
+    if (!tmp) {
+        perror("tmpfile");
+        exit(1);
+    }
+    int saved = dup(fileno(stderr));
+    dup2(fileno(tmp), fileno(stderr));
+
+    int ret = cli_parse_args(6, argv, &opts);
+
+    fflush(stderr);
+    fseek(tmp, 0, SEEK_SET);
+    char buf[256];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    buf[n] = '\0';
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+    fclose(tmp);
+
+    ASSERT(ret != 0);
+    ASSERT(strstr(buf, "Missing argument for -D option") != NULL);
+}
+
+static void test_missing_undef_arg(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "-U", "", "-o", "out.s", "file.c", NULL};
+    optind = 1;
+#ifdef __BSD_VISIBLE
+    optreset = 1;
+#endif
+    FILE *tmp = tmpfile();
+    if (!tmp) {
+        perror("tmpfile");
+        exit(1);
+    }
+    int saved = dup(fileno(stderr));
+    dup2(fileno(tmp), fileno(stderr));
+
+    int ret = cli_parse_args(6, argv, &opts);
+
+    fflush(stderr);
+    fseek(tmp, 0, SEEK_SET);
+    char buf[256];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    buf[n] = '\0';
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+    fclose(tmp);
+
+    ASSERT(ret != 0);
+    ASSERT(strstr(buf, "Missing argument for -U option") != NULL);
+}
+
+static void test_missing_lib_dir_arg(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "-L", "", "-o", "out.s", "file.c", NULL};
+    optind = 1;
+#ifdef __BSD_VISIBLE
+    optreset = 1;
+#endif
+    FILE *tmp = tmpfile();
+    if (!tmp) {
+        perror("tmpfile");
+        exit(1);
+    }
+    int saved = dup(fileno(stderr));
+    dup2(fileno(tmp), fileno(stderr));
+
+    int ret = cli_parse_args(6, argv, &opts);
+
+    fflush(stderr);
+    fseek(tmp, 0, SEEK_SET);
+    char buf[256];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    buf[n] = '\0';
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+    fclose(tmp);
+
+    ASSERT(ret != 0);
+    ASSERT(strstr(buf, "Missing argument for -L option") != NULL);
+}
+
+static void test_missing_lib_arg(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "-l", "", "-o", "out.s", "file.c", NULL};
+    optind = 1;
+#ifdef __BSD_VISIBLE
+    optreset = 1;
+#endif
+    FILE *tmp = tmpfile();
+    if (!tmp) {
+        perror("tmpfile");
+        exit(1);
+    }
+    int saved = dup(fileno(stderr));
+    dup2(fileno(tmp), fileno(stderr));
+
+    int ret = cli_parse_args(6, argv, &opts);
+
+    fflush(stderr);
+    fseek(tmp, 0, SEEK_SET);
+    char buf[256];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    buf[n] = '\0';
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+    fclose(tmp);
+
+    ASSERT(ret != 0);
+    ASSERT(strstr(buf, "Missing argument for -l option") != NULL);
+}
+
 int main(void)
 {
     test_parse_success();
     test_intel_syntax_option();
     test_parse_failure();
+    test_missing_define_arg();
+    test_missing_undef_arg();
+    test_missing_lib_dir_arg();
+    test_missing_lib_arg();
     if (failures == 0)
         printf("All cli tests passed\n");
     else


### PR DESCRIPTION
## Summary
- add missing-argument cases to CLI unit tests
- stub out `macro_free` when building tests
- compile util with stubbed macro helpers in test harness

## Testing
- `bash ./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a0b576ba08324bc181bb0ddb5f197