### PR TITLE
Handle strbuf failures in branch codegen

### DIFF
--- a/include/codegen_branch.h
+++ b/include/codegen_branch.h
@@ -22,8 +22,8 @@
  * Uses `ra` for stack frame information and chooses between 32- and
  * 64-bit encodings according to `x64`.
  */
-void emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
-                       regalloc_t *ra, int x64,
-                       asm_syntax_t syntax);
+int emit_branch_instr(strbuf_t *sb, ir_instr_t *ins,
+                      regalloc_t *ra, int x64,
+                      asm_syntax_t syntax);
 
 #endif /* VC_CODEGEN_BRANCH_H */


### PR DESCRIPTION
## Summary
- update branch code generation to check `strbuf_append` return values
- propagate failures up to the caller
- adjust callers in `codegen.c` for new return type

## Testing
- `make` *(passes)*
- `make test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686a0d7246808324a760ced30f76d74a