### PR TITLE
Document preprocessor context

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ provides an overview of the available documentation.
 3. [Preprocessor workflow](preprocessor.md) – how macros and directives are
    handled before lexing. The standard macros `__FILE__`, `__LINE__`,
    `__DATE__`, `__TIME__`, `__STDC__`, `__STDC_VERSION__` and `__func__` are
-   documented there.
+   documented there. The [preprocessor context](preprocessor.md#preprocessor-context)
+   explains how reentrant preprocessing is achieved.
 4. [Compiler architecture](architecture.md) – overview of the compiler modules
    and their interaction.
 5. [Compilation pipeline](pipeline.md) – detailed description of each stage of

--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -74,3 +74,18 @@ timestamps.
 Additional macros may be defined on the command line using `-Dname=value` or in
 source files with `#define`. After preprocessing the expanded text is handed to
 the lexer for tokenization.
+## Preprocessor context
+
+`preproc_context_t` is defined in `include/preproc_file.h` and is passed to `preproc_run`. It currently contains one field:
+
+```c
+vector_t pragma_once_files; /* vector of malloc'd char* paths */
+```
+
+The vector tracks files that issued `#pragma once` so that they are not
+processed again within the same invocation. Because the entire context is
+provided by the caller rather than stored globally, multiple preprocessing
+operations can run independently. Each call initializes and cleans up the
+vector, allowing the preprocessor to be used reentrantly by simply
+supplying a separate `preproc_context_t` instance.
+


### PR DESCRIPTION
## Summary
- document `preproc_context_t` and its role in reentrant preprocessing
- link to the new section from the docs index

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a0f143afc832482dd6509df3c3b75