### PR TITLE
Add AST dumping capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_tokenize.c src/compile_parse.c s
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_arith.c src/codegen_branch.c \
-           src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/label.c \
+           src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ast_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
 
 # Optional optimization sources
@@ -21,7 +21,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_init.h include/semantic_global.h \
-    include/ir_core.h include/ir_global.h include/ir_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
+    include/ir_core.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h include/startup.h
 PREFIX ?= /usr/local
@@ -181,6 +181,9 @@ src/vector.o: src/vector.c $(HDR)
 
 src/ir_dump.o: src/ir_dump.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/ir_dump.c -o src/ir_dump.o
+
+src/ast_dump.o: src/ast_dump.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/ast_dump.c -o src/ast_dump.o
 
 src/label.o: src/label.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/label.c -o src/label.o

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -29,6 +29,7 @@ The compiler supports the following options:
 - `--link` – build an executable by assembling and linking with `cc`.
 - `--obj-dir <path>` – directory for temporary object files.
 - `-S`, `--dump-asm` – print the generated assembly to stdout instead of creating a file.
+- `--dump-ast` – print the AST to stdout after parsing.
 - `--dump-ir` – print the IR to stdout before code generation.
 - `--std=<c99|gnu99>` – select the language standard (default is `c99`).
 - `-E`, `--preprocess` – print the preprocessed source to stdout and exit.

--- a/include/ast_dump.h
+++ b/include/ast_dump.h
@@ -1,0 +1,20 @@
+/*
+ * Helpers to dump the AST as a human readable string.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_AST_DUMP_H
+#define VC_AST_DUMP_H
+
+#include "ast.h"
+
+/*
+ * Convert the parsed AST into a textual representation.
+ * The returned buffer must be freed by the caller.
+ */
+char *ast_to_string(func_t **funcs, size_t fcount,
+                    stmt_t **globs, size_t gcount);
+
+#endif /* VC_AST_DUMP_H */

--- a/include/cli.h
+++ b/include/cli.h
@@ -32,13 +32,14 @@ typedef enum {
     CLI_OPT_X86_64,
     CLI_OPT_DUMP_ASM_LONG,
     CLI_OPT_NO_CPROP,
+    CLI_OPT_DUMP_AST,
     CLI_OPT_DUMP_IR,
-    CLI_OPT_LINK = 7,
+    CLI_OPT_LINK = 8,
     CLI_OPT_STD,
     CLI_OPT_OBJ_DIR,
-    CLI_OPT_DEBUG = 10,
+    CLI_OPT_DEBUG = 11,
     CLI_OPT_NO_INLINE,
-    CLI_OPT_INTEL_SYNTAX = 12,
+    CLI_OPT_INTEL_SYNTAX = 13,
     CLI_OPT_DEFINE,
     CLI_OPT_UNDEFINE,
     CLI_OPT_NO_COLOR
@@ -52,6 +53,7 @@ typedef struct {
     bool compile;       /* assemble to object */
     bool link;          /* build executable */
     bool dump_asm;      /* dump assembly to stdout (-S/--dump-asm) */
+    bool dump_ast;      /* dump AST to stdout */
     bool dump_ir;       /* dump IR to stdout */
     bool preprocess;    /* run preprocessor only and print to stdout */
     bool debug;         /* emit debug directives */

--- a/man/vc.1
+++ b/man/vc.1
@@ -146,6 +146,9 @@ a directory.  Only if neither variable is set does it default to
 .BR -S "," \fB--dump-asm\fR
 Print generated assembly to stdout rather than creating a file.
 .TP
+.B --dump-ast
+Print the AST to stdout after parsing.
+.TP
 .B --dump-ir
 Print IR to stdout before generating assembly.
 .TP

--- a/src/ast_dump.c
+++ b/src/ast_dump.c
@@ -1,0 +1,217 @@
+#include <stdlib.h>
+#include "ast_dump.h"
+#include "strbuf.h"
+
+static void indent(strbuf_t *sb, int level)
+{
+    for (int i = 0; i < level; i++)
+        strbuf_append(sb, "  ");
+}
+
+static const char *expr_name(expr_kind_t k)
+{
+    switch (k) {
+    case EXPR_NUMBER: return "EXPR_NUMBER";
+    case EXPR_IDENT: return "EXPR_IDENT";
+    case EXPR_STRING: return "EXPR_STRING";
+    case EXPR_CHAR: return "EXPR_CHAR";
+    case EXPR_UNARY: return "EXPR_UNARY";
+    case EXPR_BINARY: return "EXPR_BINARY";
+    case EXPR_COND: return "EXPR_COND";
+    case EXPR_ASSIGN: return "EXPR_ASSIGN";
+    case EXPR_CALL: return "EXPR_CALL";
+    case EXPR_INDEX: return "EXPR_INDEX";
+    case EXPR_ASSIGN_INDEX: return "EXPR_ASSIGN_INDEX";
+    case EXPR_ASSIGN_MEMBER: return "EXPR_ASSIGN_MEMBER";
+    case EXPR_MEMBER: return "EXPR_MEMBER";
+    case EXPR_SIZEOF: return "EXPR_SIZEOF";
+    case EXPR_COMPLIT: return "EXPR_COMPLIT";
+    }
+    return "EXPR_UNKNOWN";
+}
+
+static const char *stmt_name(stmt_kind_t k)
+{
+    switch (k) {
+    case STMT_EXPR: return "STMT_EXPR";
+    case STMT_RETURN: return "STMT_RETURN";
+    case STMT_VAR_DECL: return "STMT_VAR_DECL";
+    case STMT_IF: return "STMT_IF";
+    case STMT_WHILE: return "STMT_WHILE";
+    case STMT_DO_WHILE: return "STMT_DO_WHILE";
+    case STMT_FOR: return "STMT_FOR";
+    case STMT_SWITCH: return "STMT_SWITCH";
+    case STMT_BREAK: return "STMT_BREAK";
+    case STMT_CONTINUE: return "STMT_CONTINUE";
+    case STMT_LABEL: return "STMT_LABEL";
+    case STMT_GOTO: return "STMT_GOTO";
+    case STMT_STATIC_ASSERT: return "STMT_STATIC_ASSERT";
+    case STMT_TYPEDEF: return "STMT_TYPEDEF";
+    case STMT_ENUM_DECL: return "STMT_ENUM_DECL";
+    case STMT_STRUCT_DECL: return "STMT_STRUCT_DECL";
+    case STMT_UNION_DECL: return "STMT_UNION_DECL";
+    case STMT_BLOCK: return "STMT_BLOCK";
+    }
+    return "STMT_UNKNOWN";
+}
+
+static void dump_expr(strbuf_t *sb, const expr_t *e, int lvl);
+static void dump_stmt(strbuf_t *sb, const stmt_t *s, int lvl);
+
+static void dump_expr(strbuf_t *sb, const expr_t *e, int lvl)
+{
+    if (!e)
+        return;
+    indent(sb, lvl);
+    strbuf_appendf(sb, "%s", expr_name(e->kind));
+    if (e->kind == EXPR_NUMBER)
+        strbuf_appendf(sb, " %s", e->number.value);
+    else if (e->kind == EXPR_IDENT)
+        strbuf_appendf(sb, " %s", e->ident.name);
+    else if (e->kind == EXPR_STRING)
+        strbuf_appendf(sb, " \"%s\"", e->string.value);
+    else if (e->kind == EXPR_CHAR)
+        strbuf_appendf(sb, " '%c'", e->ch.value);
+    strbuf_append(sb, "\n");
+
+    switch (e->kind) {
+    case EXPR_UNARY:
+        dump_expr(sb, e->unary.operand, lvl + 1);
+        break;
+    case EXPR_BINARY:
+        dump_expr(sb, e->binary.left, lvl + 1);
+        dump_expr(sb, e->binary.right, lvl + 1);
+        break;
+    case EXPR_COND:
+        dump_expr(sb, e->cond.cond, lvl + 1);
+        dump_expr(sb, e->cond.then_expr, lvl + 1);
+        dump_expr(sb, e->cond.else_expr, lvl + 1);
+        break;
+    case EXPR_ASSIGN:
+        dump_expr(sb, e->assign.value, lvl + 1);
+        break;
+    case EXPR_CALL:
+        for (size_t i = 0; i < e->call.arg_count; i++)
+            dump_expr(sb, e->call.args[i], lvl + 1);
+        break;
+    case EXPR_INDEX:
+        dump_expr(sb, e->index.array, lvl + 1);
+        dump_expr(sb, e->index.index, lvl + 1);
+        break;
+    case EXPR_ASSIGN_INDEX:
+        dump_expr(sb, e->assign_index.array, lvl + 1);
+        dump_expr(sb, e->assign_index.index, lvl + 1);
+        dump_expr(sb, e->assign_index.value, lvl + 1);
+        break;
+    case EXPR_ASSIGN_MEMBER:
+        dump_expr(sb, e->assign_member.object, lvl + 1);
+        dump_expr(sb, e->assign_member.value, lvl + 1);
+        break;
+    case EXPR_MEMBER:
+        dump_expr(sb, e->member.object, lvl + 1);
+        break;
+    case EXPR_SIZEOF:
+        if (!e->sizeof_expr.is_type)
+            dump_expr(sb, e->sizeof_expr.expr, lvl + 1);
+        break;
+    case EXPR_COMPLIT:
+        if (e->compound.init)
+            dump_expr(sb, e->compound.init, lvl + 1);
+        for (size_t i = 0; i < e->compound.init_count; i++)
+            dump_expr(sb, e->compound.init_list[i].value, lvl + 1);
+        break;
+    default:
+        break;
+    }
+}
+
+static void dump_block(strbuf_t *sb, stmt_t **stmts, size_t count, int lvl)
+{
+    for (size_t i = 0; i < count; i++)
+        dump_stmt(sb, stmts[i], lvl);
+}
+
+static void dump_stmt(strbuf_t *sb, const stmt_t *s, int lvl)
+{
+    if (!s)
+        return;
+    indent(sb, lvl);
+    strbuf_appendf(sb, "%s\n", stmt_name(s->kind));
+    switch (s->kind) {
+    case STMT_EXPR:
+        dump_expr(sb, s->expr.expr, lvl + 1);
+        break;
+    case STMT_RETURN:
+        dump_expr(sb, s->ret.expr, lvl + 1);
+        break;
+    case STMT_VAR_DECL:
+        if (s->var_decl.init)
+            dump_expr(sb, s->var_decl.init, lvl + 1);
+        break;
+    case STMT_IF:
+        dump_expr(sb, s->if_stmt.cond, lvl + 1);
+        dump_stmt(sb, s->if_stmt.then_branch, lvl + 1);
+        dump_stmt(sb, s->if_stmt.else_branch, lvl + 1);
+        break;
+    case STMT_WHILE:
+        dump_expr(sb, s->while_stmt.cond, lvl + 1);
+        dump_stmt(sb, s->while_stmt.body, lvl + 1);
+        break;
+    case STMT_DO_WHILE:
+        dump_stmt(sb, s->do_while_stmt.body, lvl + 1);
+        dump_expr(sb, s->do_while_stmt.cond, lvl + 1);
+        break;
+    case STMT_FOR:
+        if (s->for_stmt.init_decl)
+            dump_stmt(sb, s->for_stmt.init_decl, lvl + 1);
+        else
+            dump_expr(sb, s->for_stmt.init, lvl + 1);
+        dump_expr(sb, s->for_stmt.cond, lvl + 1);
+        dump_expr(sb, s->for_stmt.incr, lvl + 1);
+        dump_stmt(sb, s->for_stmt.body, lvl + 1);
+        break;
+    case STMT_SWITCH:
+        dump_expr(sb, s->switch_stmt.expr, lvl + 1);
+        for (size_t i = 0; i < s->switch_stmt.case_count; i++) {
+            dump_expr(sb, s->switch_stmt.cases[i].expr, lvl + 1);
+            dump_stmt(sb, s->switch_stmt.cases[i].body, lvl + 2);
+        }
+        dump_stmt(sb, s->switch_stmt.default_body, lvl + 1);
+        break;
+    case STMT_LABEL:
+        indent(sb, lvl + 1);
+        if (s->label.name)
+            strbuf_appendf(sb, "label: %s\n", s->label.name);
+        break;
+    case STMT_GOTO:
+    case STMT_BREAK:
+    case STMT_CONTINUE:
+    case STMT_STATIC_ASSERT:
+    case STMT_TYPEDEF:
+    case STMT_ENUM_DECL:
+    case STMT_STRUCT_DECL:
+    case STMT_UNION_DECL:
+        break;
+    case STMT_BLOCK:
+        dump_block(sb, s->block.stmts, s->block.count, lvl + 1);
+        break;
+    }
+}
+
+static void dump_func(strbuf_t *sb, const func_t *f)
+{
+    strbuf_appendf(sb, "FUNC %s\n", f->name);
+    dump_block(sb, f->body, f->body_count, 1);
+}
+
+char *ast_to_string(func_t **funcs, size_t fcount,
+                    stmt_t **globs, size_t gcount)
+{
+    strbuf_t sb;
+    strbuf_init(&sb);
+    for (size_t i = 0; i < gcount; i++)
+        dump_stmt(&sb, globs[i], 0);
+    for (size_t i = 0; i < fcount; i++)
+        dump_func(&sb, funcs[i]);
+    return sb.data; /* caller frees */
+}

--- a/src/cli.c
+++ b/src/cli.c
@@ -348,6 +348,7 @@ static int handle_option(int opt, const char *arg, const char *prog,
         {CLI_OPT_DUMP_ASM_LONG, offsetof(cli_options_t, dump_asm), 1, true},
         {CLI_OPT_NO_CPROP,  offsetof(cli_options_t, opt_cfg.const_prop), 0, false},
         {CLI_OPT_DUMP_IR,   offsetof(cli_options_t, dump_ir), 1, true},
+        {CLI_OPT_DUMP_AST, offsetof(cli_options_t, dump_ast), 1, true},
         {CLI_OPT_DEBUG,     offsetof(cli_options_t, debug), 1, true},
         {CLI_OPT_NO_INLINE, offsetof(cli_options_t, opt_cfg.inline_funcs), 0, false},
         {CLI_OPT_NO_COLOR,  offsetof(cli_options_t, color_diag), 0, true},
@@ -414,6 +415,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"x86-64",  no_argument,       0, CLI_OPT_X86_64},
         {"intel-syntax", no_argument, 0, CLI_OPT_INTEL_SYNTAX},
         {"dump-asm", no_argument,     0, CLI_OPT_DUMP_ASM_LONG},
+        {"dump-ast", no_argument,     0, CLI_OPT_DUMP_AST},
         {"no-cprop", no_argument,     0, CLI_OPT_NO_CPROP},
         {"no-inline", no_argument,   0, CLI_OPT_NO_INLINE},
         {"dump-ir", no_argument,      0, CLI_OPT_DUMP_IR},
@@ -452,7 +454,8 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         }
     }
 
-    if (!opts->output && !opts->dump_asm && !opts->dump_ir && !opts->preprocess) {
+    if (!opts->output && !opts->dump_asm && !opts->dump_ir &&
+        !opts->dump_ast && !opts->preprocess) {
         fprintf(stderr, "Error: no output path specified.\n");
         print_usage(argv[0]);
         cli_free_opts(opts);

--- a/src/compile.c
+++ b/src/compile.c
@@ -38,6 +38,7 @@
 #include "error.h"
 #include "ir_core.h"
 #include "ir_dump.h"
+#include "ast_dump.h"
 #include "opt.h"
 #include "codegen.h"
 #include "label.h"
@@ -389,9 +390,19 @@ static int compile_single_unit(const char *source, const cli_options_t *cli,
                                 &cli->defines, &cli->undefines);
     if (ok)
         ok = compile_parse_stage(&ctx);
-    if (ok)
+    if (ok && cli->dump_ast) {
+        char *text = ast_to_string((func_t **)ctx.func_list_v.data,
+                                   ctx.func_list_v.count,
+                                   (stmt_t **)ctx.glob_list_v.data,
+                                   ctx.glob_list_v.count);
+        if (text) {
+            printf("%s", text);
+            free(text);
+        }
+    }
+    if (ok && !cli->dump_ast)
         ok = compile_semantic_stage(&ctx);
-    if (ok) {
+    if (ok && !cli->dump_ast) {
         ok = compile_optimize_stage(&ctx, &cli->opt_cfg);
         if (ok)
             ok = compile_output_stage(&ctx, output, cli->dump_ir,

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,9 @@ int main(int argc, char **argv)
         else if (cli.dump_ir)
             printf("Compiling %s (IR dumped to stdout)\n",
                    ((const char **)cli.sources.data)[0]);
+        else if (cli.dump_ast)
+            printf("Compiling %s (AST dumped to stdout)\n",
+                   ((const char **)cli.sources.data)[0]);
         else if (cli.dump_asm)
             printf("Compiling %s (assembly dumped to stdout)\n",
                    ((const char **)cli.sources.data)[0]);

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -46,6 +46,16 @@ static void test_intel_syntax_option(void)
     cli_free_opts(&opts);
 }
 
+static void test_dump_ast_option(void)
+{
+    cli_options_t opts;
+    char *argv[] = {"vc", "--dump-ast", "file.c", NULL};
+    int ret = cli_parse_args(3, argv, &opts);
+    ASSERT(ret == 0);
+    ASSERT(opts.dump_ast);
+    cli_free_opts(&opts);
+}
+
 static void test_parse_failure(void)
 {
     cli_options_t opts;
@@ -85,6 +95,7 @@ int main(void)
 {
     test_parse_success();
     test_intel_syntax_option();
+    test_dump_ast_option();
     test_parse_failure();
     if (failures == 0)
         printf("All cli tests passed\n");


### PR DESCRIPTION
## Summary
- add `--dump-ast` option in CLI
- implement AST pretty printer
- print AST after parsing when the flag is used
- document new option
- test command-line parsing of the flag

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686bfdf380548324834ad7719d5a45a9