### PR TITLE
Add flexible array member support

### DIFF
--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -28,6 +28,7 @@ shows a short example and how to compile it.
 - [Switch statements](#switch-statements)
 - [Logical operators](#logical-operators)
 - [Enum declarations](#enum-declarations)
+- [Flexible array members](#flexible-array-members)
 
 - Basic arithmetic expressions
 - Function definitions and calls
@@ -52,7 +53,8 @@ shows a short example and how to compile it.
 - `struct` and `union` objects with member assignments
 - `typedef` declarations creating type aliases
 - Bit-field members using `type name : width`
-- Object-like and multi-parameter `#define` macros with recursive expansion
+- Flexible array members as the final struct field
+ - Object-like and multi-parameter `#define` macros with recursive expansion
 - `#undef` to remove a previously defined macro
 - Conditional preprocessing directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else`, `#endif`)
 - 64-bit integer literals and arithmetic when using `long long`
@@ -657,6 +659,23 @@ int main() {
 Compile with:
 ```sh
 vc -o union_char.s union_char.c
+```
+
+### Flexible array members
+Structures may end with a member declared using empty brackets. The flexible
+member occupies no space in `sizeof` calculations and allows extra storage to be
+appended at runtime.
+
+```c
+/* flex_size.c */
+struct Flex { int len; int data[]; };
+int main() {
+    return sizeof(struct Flex);
+}
+```
+Compile with:
+```sh
+vc -o flex_size.s flex_size.c
 ```
 
 ### Typedef declarations

--- a/man/vc.1
+++ b/man/vc.1
@@ -46,7 +46,8 @@ Inline function definitions.
 .PP
 Variable length arrays are supported only for block scope variables.
 They may be sized using any runtime expression and are fully compatible
-with \fBsizeof\fR, but cannot appear at file scope or as struct members.
+with \fBsizeof\fR, but cannot appear at file scope.  Structures may end
+with a flexible array member declared using an empty bracket pair.
 .PP
 The built-in preprocessor expands \fB#include\fR and \fB#include_next\fR
 directives, object-like

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -65,7 +65,9 @@ size_t layout_struct_members(struct_member_t *members, size_t count)
             members[i].bit_offset = 0;
             if (bit_off)
                 byte_off++, bit_off = 0;
-            byte_off += members[i].elem_size;
+            if (!(i == count - 1 && members[i].type == TYPE_ARRAY &&
+                  members[i].elem_size == 0))
+                byte_off += members[i].elem_size;
         }
     }
     if (bit_off)

--- a/tests/fixtures/flex_size.c
+++ b/tests/fixtures/flex_size.c
@@ -1,0 +1,2 @@
+struct Flex { int len; int data[]; };
+int main() { return sizeof(struct Flex); }

--- a/tests/fixtures/flex_size.s
+++ b/tests/fixtures/flex_size.s
@@ -1,0 +1,9 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $4, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- allow empty brackets for the final struct member
- ignore flexible array size when laying out struct members
- document flexible array members
- add integration fixture

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c135f38cc8324aa36930f90e807ff