### PR TITLE
Implement dependency generation

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -32,6 +32,8 @@ The compiler supports the following options:
 - `--dump-ast` – print the AST to stdout after parsing.
 - `--dump-ir` – print the IR to stdout before code generation.
 - `--dump-tokens` – print the token list to stdout after preprocessing.
+- `-M` – generate a `.d` file listing the source and headers.
+- `-MD` – like `-M` but also compile the source.
 - `--std=<c99|gnu99>` – select the language standard (default is `c99`).
 - `-E`, `--preprocess` – print the preprocessed source to stdout and exit.
 - `-I`, `--include <dir>` – add directory to the `#include` search path.

--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -79,16 +79,18 @@ source files with `#define`. After preprocessing the expanded text is handed to
 the lexer for tokenization.
 ## Preprocessor context
 
-`preproc_context_t` is defined in `include/preproc_file.h` and is passed to `preproc_run`. It currently contains one field:
+`preproc_context_t` is defined in `include/preproc_file.h` and is passed to `preproc_run`. It contains two vectors:
 
 ```c
-vector_t pragma_once_files; /* vector of malloc'd char* paths */
+vector_t pragma_once_files; /* headers marked with #pragma once */
+vector_t deps;              /* all processed files */
 ```
 
-The vector tracks files that issued `#pragma once` so that they are not
-processed again within the same invocation. Because the entire context is
-provided by the caller rather than stored globally, multiple preprocessing
-operations can run independently. Each call initializes and cleans up the
-vector, allowing the preprocessor to be used reentrantly by simply
-supplying a separate `preproc_context_t` instance.
+`pragma_once_files` tracks headers that issued `#pragma once` so they are not
+processed again. `deps` records every file read during preprocessing, enabling
+dependency generation. Because the entire context is provided by the caller
+rather than stored globally, multiple preprocessing operations can run
+independently. Each call initializes and cleans up the vectors, allowing the
+preprocessor to be used reentrantly by supplying a separate
+`preproc_context_t` instance.
 

--- a/include/cli.h
+++ b/include/cli.h
@@ -43,7 +43,9 @@ typedef enum {
     CLI_OPT_DEFINE,
     CLI_OPT_UNDEFINE,
     CLI_OPT_NO_COLOR,
-    CLI_OPT_DUMP_TOKENS
+    CLI_OPT_DUMP_TOKENS,
+    CLI_OPT_DEP_ONLY,
+    CLI_OPT_DEP
 } cli_opt_id;
 
 /* Command line options parsed from argv */
@@ -60,6 +62,8 @@ typedef struct {
     bool preprocess;    /* run preprocessor only and print to stdout */
     bool debug;         /* emit debug directives */
     bool color_diag;    /* use ANSI colors in diagnostics */
+    bool dep_only;      /* generate dependencies only */
+    bool deps;          /* generate dependency file */
     asm_syntax_t asm_syntax; /* assembly syntax flavor */
     c_std_t std;        /* language standard */
     char *obj_dir;      /* directory for temporary object files */

--- a/include/compile.h
+++ b/include/compile.h
@@ -24,6 +24,9 @@ char *tokens_to_string(const token_t *toks, size_t count);
 /* Run only the preprocessor stage and print the result. */
 int run_preprocessor(const cli_options_t *cli);
 
+/* Generate dependency files without compiling */
+int generate_dependencies(const cli_options_t *cli);
+
 /* Compile multiple sources and link them into an executable. */
 int link_sources(const cli_options_t *cli);
 

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -16,12 +16,20 @@
 
 #include "vector.h"
 
-/* Context used by the preprocessor.  Currently only tracks files
- * processed after encountering '#pragma once'.
+/* Context used by the preprocessor.
+ *
+ * `pragma_once_files` stores headers that emitted `#pragma once` so
+ * subsequent includes are ignored. `deps` records every file processed
+ * including the initial source and all headers. The caller is
+ * responsible for freeing both vectors via `preproc_context_free()`.
  */
 typedef struct {
     vector_t pragma_once_files; /* vector of malloc'd char* paths */
+    vector_t deps;              /* vector of malloc'd char* paths */
 } preproc_context_t;
+
+/* Free the dependency lists stored in the context */
+void preproc_context_free(preproc_context_t *ctx);
 
 /* Preprocess the file at the given path.
  * The returned string must be freed by the caller.

--- a/man/vc.1
+++ b/man/vc.1
@@ -157,6 +157,12 @@ Print IR to stdout before generating assembly.
 .B --dump-tokens
 Print the token list to stdout after preprocessing.
 .TP
+.B -M
+Generate a .d file listing the source and all headers and exit.
+.TP
+.B -MD
+Generate a .d file while compiling normally.
+.TP
 .BR --std=\fIstd\fR
 Select the language standard. Valid values are \fIc99\fR (default) or \fIgnu99\fR.
 .TP

--- a/src/main.c
+++ b/src/main.c
@@ -37,6 +37,11 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
+    if (cli.dep_only) {
+        ret = generate_dependencies(&cli);
+        goto cleanup;
+    }
+
     int ok = 1;
     if (cli.link) {
         ok = link_sources(&cli);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -543,6 +543,26 @@ if ! od -An -t x1 "${libm_exe}" | head -n 1 | grep -q "7f 45 4c 46"; then
 fi
 rm -f "${libm_exe}"
 
+# dependency generation with -MD
+dep_obj=depobj$$.o
+"$BINARY" -MD -c -I "$DIR/includes" -o "$dep_obj" "$DIR/fixtures/include_search.c"
+dep_file="${dep_obj%.o}.d"
+if [ ! -f "$dep_file" ] || ! grep -q "val.h" "$dep_file"; then
+    echo "Test dep_md failed"
+    fail=1
+fi
+rm -f "$dep_obj" "$dep_file"
+
+# dependency generation with -M
+dep_src="include_search.d"
+rm -f "$dep_src"
+"$BINARY" -M -I "$DIR/includes" "$DIR/fixtures/include_search.c"
+if [ ! -f "$dep_src" ] || ! grep -q "val.h" "$dep_src"; then
+    echo "Test dep_M failed"
+    fail=1
+fi
+rm -f "$dep_src"
+
 # test --std option
 std_out=$(mktemp)
 "$BINARY" --std=gnu99 -o "${std_out}" "$DIR/fixtures/simple_add.c"


### PR DESCRIPTION
## Summary
- add dependency tracking to the preprocessor
- support `-M` and `-MD` options in the CLI
- emit `.d` files during compilation or when requested
- document new options and context fields
- test dependency generation

## Testing
- `make -j4`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c2793e0d083248c26a984f8a4ba03