### PR TITLE
Implement cast expression checking

### DIFF
--- a/src/ast_clone.c
+++ b/src/ast_clone.c
@@ -173,6 +173,17 @@ static expr_t *clone_sizeof(const expr_t *expr)
     return ast_make_sizeof_expr(e, expr->line, expr->column);
 }
 
+/* Clone a cast expression. */
+static expr_t *clone_cast(const expr_t *expr)
+{
+    expr_t *inner = clone_expr(expr->cast.expr);
+    if (!inner)
+        return NULL;
+    return ast_make_cast(expr->cast.type, expr->cast.array_size,
+                         expr->cast.elem_size, inner,
+                         expr->line, expr->column);
+}
+
 /* Clone a function call expression and its arguments. */
 static expr_t *clone_call(const expr_t *expr)
 {
@@ -269,6 +280,8 @@ expr_t *clone_expr(const expr_t *expr)
         return clone_member(expr);
     case EXPR_SIZEOF:
         return clone_sizeof(expr);
+    case EXPR_CAST:
+        return clone_cast(expr);
     case EXPR_COMPLIT:
         return clone_complit(expr);
     }

--- a/src/ast_dump.c
+++ b/src/ast_dump.c
@@ -25,6 +25,7 @@ static const char *expr_name(expr_kind_t k)
     case EXPR_ASSIGN_MEMBER: return "EXPR_ASSIGN_MEMBER";
     case EXPR_MEMBER: return "EXPR_MEMBER";
     case EXPR_SIZEOF: return "EXPR_SIZEOF";
+    case EXPR_CAST: return "EXPR_CAST";
     case EXPR_COMPLIT: return "EXPR_COMPLIT";
     }
     return "EXPR_UNKNOWN";
@@ -113,6 +114,9 @@ static void dump_expr(strbuf_t *sb, const expr_t *e, int lvl)
     case EXPR_SIZEOF:
         if (!e->sizeof_expr.is_type)
             dump_expr(sb, e->sizeof_expr.expr, lvl + 1);
+        break;
+    case EXPR_CAST:
+        dump_expr(sb, e->cast.expr, lvl + 1);
         break;
     case EXPR_COMPLIT:
         if (e->compound.init)

--- a/src/consteval.c
+++ b/src/consteval.c
@@ -221,6 +221,23 @@ static int eval_sizeof(expr_t *expr, int use_x86_64, long long *out)
     return 1;
 }
 
+/*
+ * Evaluate a cast expression when the operand is constant.
+ * The value is returned unchanged as primitive types share a
+ * unified representation in the evaluator.
+ */
+static int eval_cast(expr_t *expr, symtable_t *vars,
+                     int use_x86_64, long long *out)
+{
+    (void)use_x86_64;
+    long long val;
+    if (!eval_const_expr(expr->cast.expr, vars, use_x86_64, &val))
+        return 0;
+    if (out)
+        *out = val;
+    return 1;
+}
+
 int eval_const_expr(expr_t *expr, symtable_t *vars,
                     int use_x86_64, long long *out)
 {
@@ -239,6 +256,8 @@ int eval_const_expr(expr_t *expr, symtable_t *vars,
         return eval_conditional(expr, vars, use_x86_64, out);
     case EXPR_IDENT:
         return eval_ident(expr, vars, out);
+    case EXPR_CAST:
+        return eval_cast(expr, vars, use_x86_64, out);
     case EXPR_SIZEOF:
         return eval_sizeof(expr, use_x86_64, out);
     default:


### PR DESCRIPTION
## Summary
- add semantic analysis for cast expressions
- allow constant evaluator to handle casts
- support cloning and dumping of cast expressions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c5cad441c83249e4d1cbebd71550e