### PR TITLE
Add #warning preprocessor directive

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -20,6 +20,8 @@ preprocessor directive is handled immediately:
 - `#undef` removes existing definitions.
 - `#error` prints the given message to stderr and aborts preprocessing when
   encountered in an active block.
+- `#warning` prints the given message to stderr but continues preprocessing
+  when encountered in an active block.
 - Conditional directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else` and
   `#endif`) manipulate a stack of state objects so nested conditions may be
   evaluated correctly.
@@ -27,6 +29,12 @@ preprocessor directive is handled immediately:
 - `#pragma once` marks the current file so subsequent includes of the same
   path are ignored.
 - Any other line has macros expanded and is appended to the output buffer.
+
+A simple usage example is:
+
+```c
+#warning "incomplete feature"
+```
 
 At the end of processing the combined text is returned to the compiler and fed
 into the lexer.

--- a/man/vc.1
+++ b/man/vc.1
@@ -63,7 +63,8 @@ expanded recursively. The \fB#\fR operator stringizes a parameter and
 Variadic macros are declared by ending the parameter list with \fB...\fR and
 use \fB__VA_ARGS__\fR within the body to access the extra arguments.
 The \fB#error\fR directive prints its message to stderr and aborts
-preprocessing when encountered.  The special pragma
+preprocessing when encountered.  The \fB#warning\fR directive prints its
+message but preprocessing continues.  The special pragma
 \fB#pragma once\fR marks a header so subsequent includes of the same
 file are ignored.
 Several standard identifiers are always defined and expand to context

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -972,6 +972,22 @@ static int handle_error_directive(char *line, const char *dir,
     return 1;
 }
 
+/* Emit a warning message but continue preprocessing when active. */
+static int handle_warning_directive(char *line, const char *dir,
+                                    vector_t *macros, vector_t *conds,
+                                    strbuf_t *out,
+                                    const vector_t *incdirs,
+                                    vector_t *stack,
+                                    preproc_context_t *ctx)
+{
+    (void)dir; (void)macros; (void)out; (void)incdirs; (void)stack; (void)ctx;
+    char *msg = line + 8; /* skip '#warning' */
+    msg = skip_ws(msg);
+    if (is_active(conds))
+        fprintf(stderr, "%s\n", *msg ? msg : "preprocessor warning");
+    return 1;
+}
+
 /* Copy a #pragma line into the output when active. */
 static int handle_pragma_directive(char *line, const char *dir,
                                    vector_t *macros, vector_t *conds,
@@ -1071,6 +1087,7 @@ static const directive_entry_t directive_table[] = {
     {"#line",         SPACE_ANY,   handle_line_directive},
     {"#pragma",  SPACE_ANY,   handle_pragma_directive},
     {"#undef",   SPACE_ANY,   handle_undef_directive},
+    {"#warning", SPACE_ANY,   handle_warning_directive},
 };
 
 static const directive_bucket_t directive_buckets[26] = {
@@ -1080,6 +1097,7 @@ static const directive_bucket_t directive_buckets[26] = {
     ['l' - 'a'] = {10, 1}, /* #line */
     ['p' - 'a'] = {11, 1}, /* #pragma */
     ['u' - 'a'] = {12, 1}, /* #undef */
+    ['w' - 'a'] = {13, 1}, /* #warning */
 };
 
 static const directive_entry_t *lookup_directive(const char *line)


### PR DESCRIPTION
## Summary
- support the `#warning` directive in the preprocessor
- document `#warning` usage and add an example
- mention `#warning` in the manual

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c80e52ab88324a9bf0f2210fe092a