### PR TITLE
Add unreachable statement warnings

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -22,6 +22,7 @@ The compiler supports the following options:
 - `--no-inline` – disable inline expansion of small functions.
 - `--debug` – emit `.file` and `.loc` directives in the assembly output.
 - `--no-color` – disable ANSI colors in diagnostics.
+- `--no-warn-unreachable` – disable warnings for unreachable statements.
 - `--x86-64` – generate 64‑bit x86 assembly.
 - `--intel-syntax` – enable Intel-style x86 assembly output. When used
   together with `--compile` or `--link`, the assembler must be `nasm`.
@@ -42,6 +43,10 @@ The compiler supports the following options:
 - `-Dname[=val]` – define a preprocessor macro before compilation.
 - `-Uname` – undefine a macro before compilation.
 - `-O<N>` – set optimization level (0 disables all passes).
+
+The compiler warns about statements that cannot be reached because a
+`return` or `goto` to the function's end label appears earlier. Use
+`--no-warn-unreachable` to silence this warning.
 
 Temporary object and assembly files are written to the directory given with
 the `--obj-dir` option when provided.  Without this flag the compiler

--- a/include/cli.h
+++ b/include/cli.h
@@ -45,7 +45,8 @@ typedef enum {
     CLI_OPT_NO_COLOR,
     CLI_OPT_DUMP_TOKENS,
     CLI_OPT_DEP_ONLY,
-    CLI_OPT_DEP
+    CLI_OPT_DEP,
+    CLI_OPT_NO_WARN_UNREACHABLE
 } cli_opt_id;
 
 /* Command line options parsed from argv */
@@ -64,6 +65,7 @@ typedef struct {
     bool color_diag;    /* use ANSI colors in diagnostics */
     bool dep_only;      /* generate dependencies only */
     bool deps;          /* generate dependency file */
+    bool warn_unreachable; /* warn on unreachable statements */
     asm_syntax_t asm_syntax; /* assembly syntax flavor */
     c_std_t std;        /* language standard */
     char *obj_dir;      /* directory for temporary object files */

--- a/include/semantic_stmt.h
+++ b/include/semantic_stmt.h
@@ -13,9 +13,14 @@
 #include "ast.h"
 #include "ir_core.h"
 #include "symtable.h"
+#include <stdbool.h>
 
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                void *labels, ir_builder_t *ir, type_kind_t func_ret_type,
                const char *break_label, const char *continue_label);
+
+/* Emit warnings for unreachable statements in a function body */
+extern bool semantic_warn_unreachable;
+void warn_unreachable_function(func_t *func);
 
 #endif /* VC_SEMANTIC_STMT_H */

--- a/man/vc.1
+++ b/man/vc.1
@@ -129,6 +129,11 @@ Emit .file and .loc directives for debugging.
 .B --no-color
 Disable ANSI colors in diagnostic output.
 .TP
+.B --no-warn-unreachable
+Suppress warnings for unreachable statements after a
+.B return
+or a goto to the function end label.
+.TP
 .B --x86-64
 Generate x86-64 assembly instead of 32-bit.
 .TP

--- a/src/cli.c
+++ b/src/cli.c
@@ -48,6 +48,7 @@ static void print_usage(const char *prog)
     printf("      --no-inline      Disable inline expansion\n");
     printf("      --debug          Emit .file/.loc directives\n");
     printf("      --no-color       Disable colored diagnostics\n");
+    printf("      --no-warn-unreachable  Disable unreachable code warnings\n");
     printf("      --x86-64         Generate 64-bit x86 assembly\n");
     printf("      --intel-syntax    Use Intel assembly syntax\n");
     printf("  -S, --dump-asm       Print assembly to stdout and exit\n");
@@ -85,6 +86,7 @@ static void init_default_opts(cli_options_t *opts)
     opts->color_diag = true;
     opts->dep_only = false;
     opts->deps = false;
+    opts->warn_unreachable = true;
     opts->asm_syntax = ASM_ATT;
     opts->std = STD_C99;
     opts->obj_dir = NULL;
@@ -359,6 +361,7 @@ static int handle_option(int opt, const char *arg, const char *prog,
         {CLI_OPT_DEBUG,     offsetof(cli_options_t, debug), 1, true},
         {CLI_OPT_NO_INLINE, offsetof(cli_options_t, opt_cfg.inline_funcs), 0, false},
         {CLI_OPT_NO_COLOR,  offsetof(cli_options_t, color_diag), 0, true},
+        {CLI_OPT_NO_WARN_UNREACHABLE, offsetof(cli_options_t, warn_unreachable), 0, true},
         {CLI_OPT_DEP_ONLY, offsetof(cli_options_t, dep_only), 1, true},
         {CLI_OPT_DEP,      offsetof(cli_options_t, deps), 1, true},
         {'E', offsetof(cli_options_t, preprocess), 1, true},
@@ -452,6 +455,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"std", required_argument,   0, CLI_OPT_STD},
         {"obj-dir", required_argument, 0, CLI_OPT_OBJ_DIR},
         {"no-color", no_argument, 0, CLI_OPT_NO_COLOR},
+        {"no-warn-unreachable", no_argument, 0, CLI_OPT_NO_WARN_UNREACHABLE},
         {0, 0, 0, 0}
     };
 

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@
 #include "cli.h"
 #include "compile.h"
 #include "error.h"
+#include "semantic_stmt.h"
 
 /*
  * Program entry point. Parses command line options and coordinates
@@ -30,6 +31,7 @@ int main(int argc, char **argv)
         goto cleanup;
 
     error_use_color = cli.color_diag;
+    semantic_warn_unreachable = cli.warn_unreachable;
 
 
     if (cli.preprocess) {

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -117,6 +117,8 @@ int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
         error_current_function = NULL;
         return 1;
     }
+
+    warn_unreachable_function(func);
     int mismatch = decl->type != func->return_type ||
                    decl->param_count != func->param_count ||
                    decl->is_variadic != func->is_variadic;

--- a/tests/invalid/unreachable_goto.c
+++ b/tests/invalid/unreachable_goto.c
@@ -1,0 +1,6 @@
+int main() {
+    goto end;
+    int x = 1;
+end:
+    return x;
+}

--- a/tests/invalid/unreachable_return.c
+++ b/tests/invalid/unreachable_return.c
@@ -1,0 +1,4 @@
+int main() {
+    return 0;
+    1;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -667,6 +667,26 @@ if [ $ret -eq 0 ] || grep -qi "double free" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# unreachable warning for return
+err=$(mktemp)
+out=$(mktemp)
+"$BINARY" -o "${out}" "$DIR/invalid/unreachable_return.c" 2> "${err}"
+if ! grep -q "warning: unreachable statement" "${err}"; then
+    echo "Test warn_unreachable_return failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
+# unreachable warning for goto
+err=$(mktemp)
+out=$(mktemp)
+"$BINARY" -o "${out}" "$DIR/invalid/unreachable_goto.c" 2> "${err}"
+if ! grep -q "warning: unreachable statement" "${err}"; then
+    echo "Test warn_unreachable_goto failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 if [ $fail -eq 0 ]; then
     echo "All tests passed"
 else


### PR DESCRIPTION
## Summary
- warn when statements appear after a return or goto to the function end
- allow disabling these warnings with `--no-warn-unreachable`
- document the option and the warning
- add regression tests for the new warning

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c8832fa0083248452ffe4c8793a2b