### PR TITLE
Track XMM registers for SSE ops

### DIFF
--- a/include/regalloc_x86.h
+++ b/include/regalloc_x86.h
@@ -34,6 +34,14 @@
  */
 const char *regalloc_reg_name(int idx);
 
+/* Allocate and release temporary XMM registers. */
+int regalloc_xmm_acquire(void);
+void regalloc_xmm_release(int reg);
+void regalloc_xmm_reset(void);
+
+/* Return textual name for an XMM register index. */
+const char *regalloc_xmm_name(int idx);
+
 /* Enable or disable 64-bit register naming. */
 void regalloc_set_x86_64(int enable);
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -119,6 +119,7 @@ char *codegen_ir_to_string(ir_builder_t *ir, int x64,
     regalloc_set_x86_64(x64);
     regalloc_set_asm_syntax(syntax);
     regalloc_run(ir, &ra);
+    regalloc_xmm_reset();
 
     strbuf_t sb;
     strbuf_init(&sb);

--- a/src/codegen_arith.c
+++ b/src/codegen_arith.c
@@ -71,7 +71,8 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     type_kind_t src = (type_kind_t)((unsigned long long)ins->imm >> 32);
     type_kind_t dst = (type_kind_t)(ins->imm & 0xffffffffu);
 
-    const char *reg0 = fmt_reg("%xmm0", syntax);
+    int r0 = regalloc_xmm_acquire();
+    const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
     const char *sfx = x64 ? "q" : "l";
 
     if (is_intlike(src) && dst == TYPE_FLOAT) {
@@ -87,6 +88,7 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
         return;
     }
 
@@ -103,6 +105,7 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
         return;
     }
 
@@ -119,6 +122,7 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    cvttss2si %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
         return;
     }
 
@@ -135,6 +139,7 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    cvttsd2si %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
         return;
     }
 
@@ -152,6 +157,7 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
         return;
     }
 
@@ -169,6 +175,7 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
         return;
     }
 
@@ -181,6 +188,7 @@ static void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
                        loc_str(b1, ra, ins->src1, x64, syntax),
                        loc_str(b2, ra, ins->dest, x64, syntax));
+    regalloc_xmm_release(r0);
 }
 /* Add a scaled index to a pointer operand. */
 static void emit_ptr_add(strbuf_t *sb, ir_instr_t *ins,
@@ -254,8 +262,10 @@ static void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
 {
     char b1[32];
     char b2[32];
-    const char *reg0 = fmt_reg("%xmm0", syntax);
-    const char *reg1 = fmt_reg("%xmm1", syntax);
+    int r0 = regalloc_xmm_acquire();
+    int r1 = regalloc_xmm_acquire();
+    const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
+    const char *reg1 = fmt_reg(regalloc_xmm_name(r1), syntax);
     if (syntax == ASM_INTEL) {
         strbuf_appendf(sb, "    movd %s, %s\n", reg0,
                        loc_str(b1, ra, ins->src1, x64, syntax));
@@ -281,6 +291,8 @@ static void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
     }
+    regalloc_xmm_release(r1);
+    regalloc_xmm_release(r0);
 }
 
 /* Generate a long double binary operation using the x87 FPU. */

--- a/tests/fixtures/float_chain.c
+++ b/tests/fixtures/float_chain.c
@@ -1,0 +1,3 @@
+float foo(float a, float b, float c) {
+    return a + b + c;
+}

--- a/tests/fixtures/float_chain.s
+++ b/tests/fixtures/float_chain.s
@@ -1,0 +1,19 @@
+foo:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %eax
+    movl 12(%ebp), %ebx
+    movd %eax, %xmm0
+    movd %ebx, %xmm1
+    addss %xmm1, %xmm0
+    movd %xmm0, %ecx
+    movl 16(%ebp), %ebx
+    movd %ecx, %xmm0
+    movd %ebx, %xmm1
+    addss %xmm1, %xmm0
+    movd %xmm0, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- add simple XMM register pool to `regalloc_x86.c`
- expose helper APIs in `regalloc_x86.h`
- reset XMM pool before emitting code
- use temporary XMM registers in floating‑point operations
- add regression fixture for chained float addition

## Testing
- `make -j4`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c8b4e3bc88324b6f31c0c31871039