### PR TITLE
Add alias analysis pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_tokenize.c src/compile_parse.c s
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
 
 # Optional optimization sources
-OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_dce.c src/opt_inline.c src/opt_unreachable.c
+OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_dce.c src/opt_inline.c src/opt_unreachable.c src/opt_alias.c
 # Additional sources can be specified by the user
 EXTRA_SRC ?=
 # Final source list
@@ -218,3 +218,6 @@ src/opt_inline.o: src/opt_inline.c $(HDR)
 
 src/opt_unreachable.o: src/opt_unreachable.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt_unreachable.c -o src/opt_unreachable.o
+
+src/opt_alias.o: src/opt_alias.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt_alias.c -o src/opt_alias.o

--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -88,6 +88,7 @@ typedef struct ir_instr {
     char *data;
     int is_volatile;
     int is_restrict;
+    int alias_set;
     struct ir_instr *next;
     const char *file;
     size_t line;

--- a/include/opt.h
+++ b/include/opt.h
@@ -21,6 +21,9 @@ typedef struct {
 /* Print an optimization error message */
 void opt_error(const char *msg);
 
+/* Assign alias sets to memory operations */
+void compute_alias_sets(ir_builder_t *ir);
+
 /*
  * Run optimization passes on the given IR builder.
  *

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -70,7 +70,7 @@ static ir_instr_t *append_instr(ir_builder_t *b)
     ins->data = NULL;
     ins->is_volatile = 0;
     ins->is_restrict = 0;
-    ins->is_restrict = 0;
+    ins->alias_set = 0;
     ins->file = b->cur_file;
     ins->line = b->cur_line;
     ins->column = b->cur_column;
@@ -129,6 +129,8 @@ ir_instr_t *ir_insert_after(ir_builder_t *b, ir_instr_t *pos)
     ins->name = NULL;
     ins->data = NULL;
     ins->is_volatile = 0;
+    ins->is_restrict = 0;
+    ins->alias_set = 0;
     ins->file = b->cur_file;
     ins->line = b->cur_line;
     ins->column = b->cur_column;

--- a/src/ir_dump.c
+++ b/src/ir_dump.c
@@ -123,6 +123,8 @@ char *ir_to_string(ir_builder_t *ir)
         strbuf_appendf(&sb, " imm=%lld name=%s data=%s", ins->imm,
                        ins->name ? ins->name : "",
                        ins->data ? ins->data : "");
+        if (ins->alias_set)
+            strbuf_appendf(&sb, " alias=%d", ins->alias_set);
         if (ins->is_restrict)
             strbuf_append(&sb, " restrict");
         if (ins->is_volatile)

--- a/src/opt.c
+++ b/src/opt.c
@@ -15,6 +15,7 @@ void inline_small_funcs(ir_builder_t *ir);
 void fold_constants(ir_builder_t *ir);
 void remove_unreachable_blocks(ir_builder_t *ir);
 void dead_code_elim(ir_builder_t *ir);
+void compute_alias_sets(ir_builder_t *ir);
 
 /* Print an optimization error message */
 void opt_error(const char *msg)
@@ -27,6 +28,7 @@ void opt_run(ir_builder_t *ir, const opt_config_t *cfg)
 {
     opt_config_t def = {1, 1, 1, 1, 1};
     const opt_config_t *c = cfg ? cfg : &def;
+    compute_alias_sets(ir);
     if (c->const_prop)
         propagate_load_consts(ir);
     common_subexpr_elim(ir);

--- a/src/opt_alias.c
+++ b/src/opt_alias.c
@@ -1,0 +1,72 @@
+/*
+ * Alias analysis pass assigning alias sets to memory operations.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "opt.h"
+
+typedef struct alias_ent {
+    const char *name;
+    int set;
+    struct alias_ent *next;
+} alias_ent_t;
+
+static int lookup_alias(alias_ent_t **list, const char *name, int *next_id)
+{
+    alias_ent_t *e = *list;
+    while (e && strcmp(e->name, name) != 0)
+        e = e->next;
+    if (e)
+        return e->set;
+    e = malloc(sizeof(*e));
+    if (!e) {
+        opt_error("out of memory");
+        return 0;
+    }
+    e->name = name;
+    e->set = (*next_id)++;
+    e->next = *list;
+    *list = e;
+    return e->set;
+}
+
+/* Compute alias sets for memory instructions */
+void compute_alias_sets(ir_builder_t *ir)
+{
+    if (!ir)
+        return;
+
+    alias_ent_t *vars = NULL;
+    int next_id = 1;
+
+    for (ir_instr_t *ins = ir->head; ins; ins = ins->next) {
+        switch (ins->op) {
+        case IR_LOAD:
+        case IR_STORE:
+        case IR_LOAD_IDX:
+        case IR_STORE_IDX:
+        case IR_BFLOAD:
+        case IR_BFSTORE:
+            if (ins->name)
+                ins->alias_set = lookup_alias(&vars, ins->name, &next_id);
+            break;
+        case IR_LOAD_PTR:
+        case IR_STORE_PTR:
+            if (ins->is_restrict)
+                ins->alias_set = next_id++;
+            break;
+        default:
+            break;
+        }
+    }
+
+    while (vars) {
+        alias_ent_t *n = vars->next;
+        free(vars);
+        vars = n;
+    }
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -147,13 +147,14 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_fold.c -o opt_fold_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_dce.c -o opt_dce_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_inline.c -o opt_inline_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_unreachable.c -o opt_unreach.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/opt_alias.c -o opt_alias_unreach.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_opt_unreachable.c" -o "$DIR/test_opt_unreachable.o"
 cc -o "$DIR/opt_unreachable_tests" ir_unreach.o util_unreach.o label_unreach.o error_unreach.o \
     opt_main.o opt_constprop_unreach.o opt_cse_unreach.o opt_fold_unreach.o \
-    opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o "$DIR/test_opt_unreachable.o"
+    opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o opt_alias_unreach.o "$DIR/test_opt_unreachable.o"
 rm -f ir_unreach.o util_unreach.o label_unreach.o error_unreach.o opt_main.o \
       opt_constprop_unreach.o opt_cse_unreach.o opt_fold_unreach.o \
-      opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o "$DIR/test_opt_unreachable.o"
+      opt_dce_unreach.o opt_inline_unreach.o opt_unreach.o opt_alias_unreach.o "$DIR/test_opt_unreachable.o"
 # run unit tests
 "$DIR/unit_tests"
 "$DIR/cli_tests"


### PR DESCRIPTION
## Summary
- support alias sets on IR instructions
- compute alias sets for restrict-qualified pointers
- hook alias pass into optimizer
- build new pass in Makefile and tests

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686c994576c88324ba19ea3826b46a1f