### PR TITLE
Integrate alias analysis documentation

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -3,18 +3,19 @@
 See the [documentation index](README.md) for a list of all available pages.
 
 The optimizer in **vc** operates on the intermediate representation (IR).
-Six passes are currently available and are executed in order:
-1. **Constant propagation** – replaces loads of variables whose values are
+Seven passes are currently available and are executed in order:
+1. **Alias analysis** – assigns alias sets to memory operations.
+2. **Constant propagation** – replaces loads of variables whose values are
    known constants with immediate constants.
-2. **Common subexpression elimination** – reuses results of identical
+3. **Common subexpression elimination** – reuses results of identical
    computations.
-3. **Inline expansion** – inlines functions containing up to four arithmetic
+4. **Inline expansion** – inlines functions containing up to four arithmetic
    instructions or just a `return` when they are marked `inline`.
-4. **Constant folding** – evaluates arithmetic instructions whose operands are
+5. **Constant folding** – evaluates arithmetic instructions whose operands are
    constants and replaces them with a single constant.
-5. **Unreachable block elimination** – removes instructions that cannot be
+6. **Unreachable block elimination** – removes instructions that cannot be
    executed from the start of the function.
-6. **Dead code elimination** – removes instructions that produce values which
+7. **Dead code elimination** – removes instructions that produce values which
    are never used and have no side effects.
 
 Constant propagation tracks variables written with constants. When a later

--- a/include/opt.h
+++ b/include/opt.h
@@ -28,12 +28,13 @@ void compute_alias_sets(ir_builder_t *ir);
  * Run optimization passes on the given IR builder.
  *
  * Passes execute in the following order:
- * 1. Constant propagation
- * 2. Common subexpression elimination
- * 3. Inline expansion
- * 4. Constant folding
- * 5. Unreachable block elimination
- * 6. Dead code elimination
+ * 1. Alias analysis
+ * 2. Constant propagation
+ * 3. Common subexpression elimination
+ * 4. Inline expansion
+ * 5. Constant folding
+ * 6. Unreachable block elimination
+ * 7. Dead code elimination
  */
 void opt_run(ir_builder_t *ir, const opt_config_t *cfg);
 


### PR DESCRIPTION
## Summary
- document the alias analysis pass in the optimization docs
- note alias analysis in the pipeline description
- update optimization header comment with the new pass order

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686d22d185c483249cf31f852dee1ae2