### PR TITLE
Add complex literal AST node

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -34,6 +34,9 @@ typedef enum {
     TYPE_FLOAT,
     TYPE_DOUBLE,
     TYPE_LDOUBLE,
+    TYPE_FLOAT_COMPLEX,
+    TYPE_DOUBLE_COMPLEX,
+    TYPE_LDOUBLE_COMPLEX,
     TYPE_PTR,
     TYPE_ARRAY,
     TYPE_VOID,
@@ -49,6 +52,7 @@ typedef enum {
     EXPR_IDENT,
     EXPR_STRING,
     EXPR_CHAR,
+    EXPR_COMPLEX_LITERAL,
     EXPR_UNARY,
     EXPR_BINARY,
     EXPR_COND,
@@ -142,6 +146,10 @@ struct expr {
             char value;
             int is_wide;
         } ch;
+        struct {
+            double real;
+            double imag;
+        } complex_lit;
         struct {
             unop_t op;
             expr_t *operand;

--- a/include/ast_expr.h
+++ b/include/ast_expr.h
@@ -27,6 +27,9 @@ expr_t *ast_make_wstring(const char *value, size_t line, size_t column);
 expr_t *ast_make_char(char value, size_t line, size_t column);
 /* Create a wide character literal expression. */
 expr_t *ast_make_wchar(char value, size_t line, size_t column);
+/* Create a complex number literal expression. */
+expr_t *ast_make_complex_literal(double real, double imag,
+                                 size_t line, size_t column);
 /* Create a binary operation expression. */
 expr_t *ast_make_binary(binop_t op, expr_t *left, expr_t *right,
                         size_t line, size_t column);

--- a/src/ast_clone.c
+++ b/src/ast_clone.c
@@ -60,6 +60,14 @@ static expr_t *clone_char(const expr_t *expr)
     return ast_make_char(expr->ch.value, expr->line, expr->column);
 }
 
+/* Duplicate a complex literal expression node. */
+static expr_t *clone_complex_literal(const expr_t *expr)
+{
+    return ast_make_complex_literal(expr->complex_lit.real,
+                                    expr->complex_lit.imag,
+                                    expr->line, expr->column);
+}
+
 /* Clone a unary operation and its operand. */
 static expr_t *clone_unary(const expr_t *expr)
 {
@@ -290,6 +298,8 @@ expr_t *clone_expr(const expr_t *expr)
         return clone_string(expr);
     case EXPR_CHAR:
         return clone_char(expr);
+    case EXPR_COMPLEX_LITERAL:
+        return clone_complex_literal(expr);
     case EXPR_UNARY:
         return clone_unary(expr);
     case EXPR_BINARY:

--- a/src/ast_dump.c
+++ b/src/ast_dump.c
@@ -15,6 +15,7 @@ static const char *expr_name(expr_kind_t k)
     case EXPR_IDENT: return "EXPR_IDENT";
     case EXPR_STRING: return "EXPR_STRING";
     case EXPR_CHAR: return "EXPR_CHAR";
+    case EXPR_COMPLEX_LITERAL: return "EXPR_COMPLEX_LITERAL";
     case EXPR_UNARY: return "EXPR_UNARY";
     case EXPR_BINARY: return "EXPR_BINARY";
     case EXPR_COND: return "EXPR_COND";
@@ -74,6 +75,8 @@ static void dump_expr(strbuf_t *sb, const expr_t *e, int lvl)
         strbuf_appendf(sb, " \"%s\"", e->string.value);
     else if (e->kind == EXPR_CHAR)
         strbuf_appendf(sb, " '%c'", e->ch.value);
+    else if (e->kind == EXPR_COMPLEX_LITERAL)
+        strbuf_appendf(sb, " %f%+fi", e->complex_lit.real, e->complex_lit.imag);
     strbuf_append(sb, "\n");
 
     switch (e->kind) {

--- a/src/ast_expr.c
+++ b/src/ast_expr.c
@@ -131,6 +131,21 @@ expr_t *ast_make_wchar(char value, size_t line, size_t column)
     return make_char(value, line, column, 1);
 }
 
+/* Create a complex number literal expression node. */
+expr_t *ast_make_complex_literal(double real, double imag,
+                                 size_t line, size_t column)
+{
+    expr_t *expr = malloc(sizeof(*expr));
+    if (!expr)
+        return NULL;
+    expr->kind = EXPR_COMPLEX_LITERAL;
+    expr->line = line;
+    expr->column = column;
+    expr->complex_lit.real = real;
+    expr->complex_lit.imag = imag;
+    return expr;
+}
+
 /* Create a binary operation expression node. */
 expr_t *ast_make_binary(binop_t op, expr_t *left, expr_t *right,
                         size_t line, size_t column)
@@ -401,6 +416,8 @@ void ast_free_expr(expr_t *expr)
         free(expr->string.value);
         break;
     case EXPR_CHAR:
+        break;
+    case EXPR_COMPLEX_LITERAL:
         break;
     case EXPR_UNARY:
         ast_free_expr(expr->unary.operand);


### PR DESCRIPTION
## Summary
- support complex number types
- add AST node for complex literals
- handle complex literals in cloning, dumping, and freeing routines

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686d3695e3848324b42f1419dc01e159