### PR TITLE
Add complex number parsing

### DIFF
--- a/src/parser_types.c
+++ b/src/parser_types.c
@@ -19,8 +19,12 @@ int parse_basic_type(parser_t *p, type_kind_t *out)
     if (match(p, TOK_KW_SHORT))
         t = is_unsigned ? TYPE_USHORT : TYPE_SHORT;
     else if (match(p, TOK_KW_LONG)) {
-        if (match(p, TOK_KW_DOUBLE))
-            t = TYPE_LDOUBLE;
+        if (match(p, TOK_KW_DOUBLE)) {
+            if (match(p, TOK_KW_COMPLEX))
+                t = TYPE_LDOUBLE_COMPLEX;
+            else
+                t = TYPE_LDOUBLE;
+        }
         else if (match(p, TOK_KW_LONG))
             t = is_unsigned ? TYPE_ULLONG : TYPE_LLONG;
         else
@@ -32,9 +36,17 @@ int parse_basic_type(parser_t *p, type_kind_t *out)
     } else if (match(p, TOK_KW_CHAR)) {
         t = TYPE_CHAR;
     } else if (match(p, TOK_KW_FLOAT)) {
-        t = TYPE_FLOAT;
+        if (match(p, TOK_KW_COMPLEX))
+            t = TYPE_FLOAT_COMPLEX;
+        else
+            t = TYPE_FLOAT;
     } else if (match(p, TOK_KW_DOUBLE)) {
-        t = TYPE_DOUBLE;
+        if (match(p, TOK_KW_COMPLEX))
+            t = TYPE_DOUBLE_COMPLEX;
+        else
+            t = TYPE_DOUBLE;
+    } else if (match(p, TOK_KW_COMPLEX)) {
+        t = TYPE_DOUBLE_COMPLEX;
     } else if (match(p, TOK_KW_VOID)) {
         t = TYPE_VOID;
     } else if (match(p, TOK_KW_ENUM)) {
@@ -82,10 +94,16 @@ size_t basic_type_size(type_kind_t t)
         return 4;
     case TYPE_DOUBLE:
         return 8;
+    case TYPE_FLOAT_COMPLEX:
+        return 8;
+    case TYPE_DOUBLE_COMPLEX:
+        return 16;
     case TYPE_LLONG: case TYPE_ULLONG:
         return 8;
     case TYPE_LDOUBLE:
         return 10;
+    case TYPE_LDOUBLE_COMPLEX:
+        return 20;
     default:
         return 4;
     }

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -124,6 +124,36 @@ static void test_lexer_imag_number(void)
     lexer_free_tokens(toks, count);
 }
 
+/* Parsing of an imaginary constant as a complex literal. */
+static void test_parser_imag_literal(void)
+{
+    const char *src = "2i";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    expr_t *expr = parser_parse_expr(&p);
+    ASSERT(expr && expr->kind == EXPR_COMPLEX_LITERAL);
+    ASSERT(expr->complex_lit.real == 0.0);
+    ASSERT(expr->complex_lit.imag == 2.0);
+    ast_free_expr(expr);
+    lexer_free_tokens(toks, count);
+}
+
+/* Parsing of a real plus imaginary constant as a complex literal. */
+static void test_parser_complex_literal(void)
+{
+    const char *src = "1.0 + 2.0i";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    expr_t *expr = parser_parse_expr(&p);
+    ASSERT(expr && expr->kind == EXPR_COMPLEX_LITERAL);
+    ASSERT(expr->complex_lit.real == 1.0);
+    ASSERT(expr->complex_lit.imag == 2.0);
+    ast_free_expr(expr);
+    lexer_free_tokens(toks, count);
+}
+
 /* Parse a simple arithmetic expression and verify operator precedence. */
 static void test_parser_expr(void)
 {
@@ -232,6 +262,48 @@ static void test_parser__Bool_decl(void)
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
     ASSERT(stmt->var_decl.type == TYPE_BOOL);
+    ast_free_stmt(stmt);
+    lexer_free_tokens(toks, count);
+}
+
+/* Declaration of a float _Complex variable. */
+static void test_parser_float_complex_decl(void)
+{
+    const char *src = "float _Complex z;";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    stmt_t *stmt = parser_parse_stmt(&p);
+    ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
+    ASSERT(stmt->var_decl.type == TYPE_FLOAT_COMPLEX);
+    ast_free_stmt(stmt);
+    lexer_free_tokens(toks, count);
+}
+
+/* Declaration of a double _Complex variable. */
+static void test_parser_double_complex_decl(void)
+{
+    const char *src = "double _Complex z;";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    stmt_t *stmt = parser_parse_stmt(&p);
+    ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
+    ASSERT(stmt->var_decl.type == TYPE_DOUBLE_COMPLEX);
+    ast_free_stmt(stmt);
+    lexer_free_tokens(toks, count);
+}
+
+/* Declaration of a long double _Complex variable. */
+static void test_parser_long_double_complex_decl(void)
+{
+    const char *src = "long double _Complex z;";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    parser_t p; parser_init(&p, toks, count);
+    stmt_t *stmt = parser_parse_stmt(&p);
+    ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
+    ASSERT(stmt->var_decl.type == TYPE_LDOUBLE_COMPLEX);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -686,6 +758,8 @@ int main(void)
     test_lexer_new_types();
     test_lexer_complex_kw();
     test_lexer_imag_number();
+    test_parser_imag_literal();
+    test_parser_complex_literal();
     test_parser_expr();
     test_parser_stmt_return();
     test_parser_stmt_return_void();
@@ -693,6 +767,9 @@ int main(void)
     test_parser_short_decl();
     test_parser_bool_decl();
     test_parser__Bool_decl();
+    test_parser_float_complex_decl();
+    test_parser_double_complex_decl();
+    test_parser_long_double_complex_decl();
     test_lexer_static_kw();
     test_parser_static_local();
     test_parser_array_decl();


### PR DESCRIPTION
## Summary
- support `_Complex` fundamental types
- parse complex literals including imaginary numbers
- add parser tests for complex types and literals

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686d37ff8cf483248b1278d344411a44