### PR TITLE
Implement complex arithmetic SSE handlers

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -85,6 +85,8 @@ static void emit_instr(strbuf_t *sb, ir_instr_t *ins,
     case IR_PTR_ADD: case IR_PTR_DIFF:
     case IR_FADD: case IR_FSUB: case IR_FMUL: case IR_FDIV:
     case IR_LFADD: case IR_LFSUB: case IR_LFMUL: case IR_LFDIV:
+    case IR_CPLX_ADD: case IR_CPLX_SUB:
+    case IR_CPLX_MUL: case IR_CPLX_DIV:
     case IR_ADD: case IR_SUB: case IR_MUL:
     case IR_DIV: case IR_MOD: case IR_SHL:
     case IR_SHR: case IR_AND: case IR_OR:

--- a/src/codegen_arith.c
+++ b/src/codegen_arith.c
@@ -295,6 +295,240 @@ static void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
     regalloc_xmm_release(r0);
 }
 
+/* Compute the location of the imaginary or real part of a complex value. */
+static const char *loc_str_off(char buf[32], regalloc_t *ra, int id,
+                               int off, int x64, asm_syntax_t syntax)
+{
+    if (!ra || id <= 0)
+        return "";
+    int loc = ra->loc[id];
+    if (loc >= 0)
+        return reg_str(loc, syntax);
+    int size = x64 ? 8 : 4;
+    int disp = -loc * size + off;
+    if (syntax == ASM_INTEL)
+        snprintf(buf, 32, x64 ? "[rbp-%d]" : "[ebp-%d]", disp);
+    else
+        snprintf(buf, 32, "-%d(%s)", disp, x64 ? "%rbp" : "%ebp");
+    return buf;
+}
+
+/* Complex add/sub helper using SSE2. */
+static void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                             int x64, const char *op, asm_syntax_t syntax)
+{
+    char b1[32];
+    char b2[32];
+    char b3[32];
+    int r0 = regalloc_xmm_acquire();
+    int r1 = regalloc_xmm_acquire();
+    const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
+    const char *reg1 = fmt_reg(regalloc_xmm_name(r1), syntax);
+
+    /* real part */
+    if (syntax == ASM_INTEL) {
+        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                       loc_str_off(b1, ra, ins->src1, 0, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", reg1,
+                       loc_str_off(b2, ra, ins->src2, 0, x64, syntax));
+        strbuf_appendf(sb, "    %s %s, %s\n", op, reg0, reg1);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(b3, ra, ins->dest, 0, x64, syntax), reg0);
+        /* imag part */
+        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                       loc_str_off(b1, ra, ins->src1, 8, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", reg1,
+                       loc_str_off(b2, ra, ins->src2, 8, x64, syntax));
+        strbuf_appendf(sb, "    %s %s, %s\n", op, reg0, reg1);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(b3, ra, ins->dest, 8, x64, syntax), reg0);
+    } else {
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(b1, ra, ins->src1, 0, x64, syntax), reg0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(b2, ra, ins->src2, 0, x64, syntax), reg1);
+        strbuf_appendf(sb, "    %s %s, %s\n", op, reg1, reg0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                       loc_str_off(b3, ra, ins->dest, 0, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(b1, ra, ins->src1, 8, x64, syntax), reg0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(b2, ra, ins->src2, 8, x64, syntax), reg1);
+        strbuf_appendf(sb, "    %s %s, %s\n", op, reg1, reg0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                       loc_str_off(b3, ra, ins->dest, 8, x64, syntax));
+    }
+    regalloc_xmm_release(r1);
+    regalloc_xmm_release(r0);
+}
+
+/* Complex multiplication using SSE2. */
+static void emit_cplx_mul(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                          int x64, asm_syntax_t syntax)
+{
+    char a[32], b[32], c[32], d[32], out[32];
+    int r0 = regalloc_xmm_acquire();
+    int r1 = regalloc_xmm_acquire();
+    int r2 = regalloc_xmm_acquire();
+    int r3 = regalloc_xmm_acquire();
+    const char *x0 = fmt_reg(regalloc_xmm_name(r0), syntax);
+    const char *x1 = fmt_reg(regalloc_xmm_name(r1), syntax);
+    const char *x2 = fmt_reg(regalloc_xmm_name(r2), syntax);
+    const char *x3 = fmt_reg(regalloc_xmm_name(r3), syntax);
+
+    if (syntax == ASM_INTEL) {
+        /* real part: (a*c - b*d) */
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", x1,
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", x2,
+                       loc_str_off(c, ra, ins->src2, 0, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", x3,
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax));
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x2, x0);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x1);
+        strbuf_appendf(sb, "    subsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(out, ra, ins->dest, 0, x64, syntax), x0);
+        /* imag part: (a*d + b*c) */
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax));
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x1,
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax));
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x2, x1);
+        strbuf_appendf(sb, "    addsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(out, ra, ins->dest, 8, x64, syntax), x0);
+    } else {
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax), x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax), x1);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(c, ra, ins->src2, 0, x64, syntax), x2);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax), x3);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x2, x0);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x1);
+        strbuf_appendf(sb, "    subsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(out, ra, ins->dest, 0, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax), x0);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax), x1);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x2, x1);
+        strbuf_appendf(sb, "    addsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(out, ra, ins->dest, 8, x64, syntax));
+    }
+    regalloc_xmm_release(r3);
+    regalloc_xmm_release(r2);
+    regalloc_xmm_release(r1);
+    regalloc_xmm_release(r0);
+}
+
+/* Complex division using SSE2. */
+static void emit_cplx_div(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                          int x64, asm_syntax_t syntax)
+{
+    char a[32], b[32], c[32], d[32], out[32];
+    int r0 = regalloc_xmm_acquire();
+    int r1 = regalloc_xmm_acquire();
+    int r2 = regalloc_xmm_acquire();
+    int r3 = regalloc_xmm_acquire();
+    int r4 = regalloc_xmm_acquire();
+    const char *x0 = fmt_reg(regalloc_xmm_name(r0), syntax);
+    const char *x1 = fmt_reg(regalloc_xmm_name(r1), syntax);
+    const char *x2 = fmt_reg(regalloc_xmm_name(r2), syntax);
+    const char *x3 = fmt_reg(regalloc_xmm_name(r3), syntax);
+    const char *x4 = fmt_reg(regalloc_xmm_name(r4), syntax);
+
+    if (syntax == ASM_INTEL) {
+        /* denominator c*c + d*d */
+        strbuf_appendf(sb, "    movsd %s, %s\n", x2,
+                       loc_str_off(c, ra, ins->src2, 0, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", x3,
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", x4, x2);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x2, x2);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x3);
+        strbuf_appendf(sb, "    addsd %s, %s\n", x3, x2);
+
+        /* real part */
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax));
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x4, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x1,
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", x3,
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax));
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x1);
+        strbuf_appendf(sb, "    addsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    divsd %s, %s\n", x2, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(out, ra, ins->dest, 0, x64, syntax), x0);
+
+        /* imag part */
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax));
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x4, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x1,
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax));
+        strbuf_appendf(sb, "    movsd %s, %s\n", x3,
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax));
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x1);
+        strbuf_appendf(sb, "    subsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    divsd %s, %s\n", x2, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(out, ra, ins->dest, 8, x64, syntax), x0);
+    } else {
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(c, ra, ins->src2, 0, x64, syntax), x2);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax), x3);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x2, x4);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x2, x2);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x3);
+        strbuf_appendf(sb, "    addsd %s, %s\n", x3, x2);
+
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax), x0);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x4, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax), x1);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax), x3);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x1);
+        strbuf_appendf(sb, "    addsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    divsd %s, %s\n", x2, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(out, ra, ins->dest, 0, x64, syntax));
+
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 8, x64, syntax), x0);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x4, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(a, ra, ins->src1, 0, x64, syntax), x1);
+        strbuf_appendf(sb, "    movsd %s, %s\n",
+                       loc_str_off(d, ra, ins->src2, 8, x64, syntax), x3);
+        strbuf_appendf(sb, "    mulsd %s, %s\n", x3, x1);
+        strbuf_appendf(sb, "    subsd %s, %s\n", x1, x0);
+        strbuf_appendf(sb, "    divsd %s, %s\n", x2, x0);
+        strbuf_appendf(sb, "    movsd %s, %s\n", x0,
+                       loc_str_off(out, ra, ins->dest, 8, x64, syntax));
+    }
+
+    regalloc_xmm_release(r4);
+    regalloc_xmm_release(r3);
+    regalloc_xmm_release(r2);
+    regalloc_xmm_release(r1);
+    regalloc_xmm_release(r0);
+}
+
 /* Generate a long double binary operation using the x87 FPU. */
 static void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins,
                                   regalloc_t *ra, int x64, const char *op,
@@ -646,6 +880,18 @@ void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
         break;
     case IR_LFDIV:
         emit_long_float_binop(sb, ins, ra, x64, "fdivp", syntax);
+        break;
+    case IR_CPLX_ADD:
+        emit_cplx_addsub(sb, ins, ra, x64, "addsd", syntax);
+        break;
+    case IR_CPLX_SUB:
+        emit_cplx_addsub(sb, ins, ra, x64, "subsd", syntax);
+        break;
+    case IR_CPLX_MUL:
+        emit_cplx_mul(sb, ins, ra, x64, syntax);
+        break;
+    case IR_CPLX_DIV:
+        emit_cplx_div(sb, ins, ra, x64, syntax);
         break;
     case IR_ADD:
         emit_int_arith(sb, ins, ra, x64, "add", syntax);


### PR DESCRIPTION
## Summary
- add SSE2 handlers for complex add/sub/mul/div in `emit_arith_instr`
- route complex opcodes through arithmetic code generation

## Testing
- `make -j4`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d3ca4a92083248185980e1781e8dd