### PR TITLE
Document complex numbers

### DIFF
--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -11,6 +11,7 @@ shows a short example and how to compile it.
 - [Compound assignment](#compound-assignment)
 - [Increment and decrement](#increment-and-decrement)
 - [Floating-point arithmetic](#floating-point-arithmetic)
+- [Complex numbers](#complex-numbers)
 - [Bitwise operations](#bitwise-operations)
 - [64-bit integers](#64-bit-integers)
 - [Numeric constants](#numeric-constants)
@@ -46,6 +47,7 @@ shows a short example and how to compile it.
 - `switch` statements with `case` and `default`
 - Bitwise operators (`&`, `|`, `^`, `<<`, `>>` and compound forms)
 - Floating-point types (`float`, `double`, `long double`)
+- Complex numbers using the `_Complex` keyword
 - `sizeof` operator
 - Global variables
 - Variadic functions using `...`
@@ -123,6 +125,24 @@ float main() {
 Compile with:
 ```sh
 vc -o float_add.s float_add.c
+```
+
+### Complex numbers
+The `_Complex` keyword introduces complex floating-point types. Complex
+literals use `a+bi` syntax with `i` denoting the imaginary part.
+Addition, subtraction, multiplication and division are supported.
+
+```c
+/* complex_add.c */
+double _Complex main() {
+    double _Complex a = 1.0 + 2.0i;
+    double _Complex b = 3.0 - 1.0i;
+    return a + b;
+}
+```
+Compile with:
+```sh
+vc -o complex_add.s complex_add.c
 ```
 
 ### Bitwise operations

--- a/man/vc.1
+++ b/man/vc.1
@@ -28,6 +28,8 @@ Global and external variable declarations.
 .IP \[bu] 2
 Floating\-point types (including \fBlong double\fR) and the boolean type via \fB_Bool\fR.
 .IP \[bu] 2
+Complex number types using \fB_Complex\fR with support for +, \-, \*, and / operators.
+.IP \[bu] 2
 64\-bit integer constants (hexadecimal and octal) and character or string literals with standard escape sequences.
 .IP \[bu] 2
 Integer literals may use the suffixes \fBu\fR/\fBU\fR and \fBl\fR/\fBLL\fR in any order.

--- a/tests/fixtures/complex_add.c
+++ b/tests/fixtures/complex_add.c
@@ -1,0 +1,5 @@
+double _Complex main() {
+    double _Complex a = 1.0 + 2.0i;
+    double _Complex b = 3.0 - 1.0i;
+    return a + b;
+}

--- a/tests/fixtures/complex_add.s
+++ b/tests/fixtures/complex_add.s
@@ -1,0 +1,20 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl %eax, a
+    movl %eax, b
+    movl a, %eax
+    movl b, %ebx
+    movsd %eax, %xmm0
+    movsd %ebx, %xmm1
+    addsd %xmm1, %xmm0
+    movsd %xmm0, %ecx
+    movsd %eax, %xmm0
+    movsd %ebx, %xmm1
+    addsd %xmm1, %xmm0
+    movsd %xmm0, %ecx
+    movl %ecx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/complex_div.c
+++ b/tests/fixtures/complex_div.c
@@ -1,0 +1,5 @@
+double _Complex main() {
+    double _Complex a = 3.0 + 2.0i;
+    double _Complex b = 1.0 - 4.0i;
+    return a / b;
+}

--- a/tests/fixtures/complex_div.s
+++ b/tests/fixtures/complex_div.s
@@ -1,0 +1,34 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl %eax, a
+    movl %eax, b
+    movl a, %eax
+    movl b, %ebx
+    movsd %ebx, %xmm2
+    movsd %ebx, %xmm3
+    movsd %xmm2, %xmm4
+    mulsd %xmm2, %xmm2
+    mulsd %xmm3, %xmm3
+    addsd %xmm3, %xmm2
+    movsd %eax, %xmm0
+    mulsd %xmm4, %xmm0
+    movsd %eax, %xmm1
+    movsd %ebx, %xmm3
+    mulsd %xmm3, %xmm1
+    addsd %xmm1, %xmm0
+    divsd %xmm2, %xmm0
+    movsd %xmm0, %ecx
+    movsd %eax, %xmm0
+    mulsd %xmm4, %xmm0
+    movsd %eax, %xmm1
+    movsd %ebx, %xmm3
+    mulsd %xmm3, %xmm1
+    subsd %xmm1, %xmm0
+    divsd %xmm2, %xmm0
+    movsd %xmm0, %ecx
+    movl %ecx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/complex_mul.c
+++ b/tests/fixtures/complex_mul.c
@@ -1,0 +1,5 @@
+double _Complex main() {
+    double _Complex a = 1.0 + 2.0i;
+    double _Complex b = 3.0 + 4.0i;
+    return a * b;
+}

--- a/tests/fixtures/complex_mul.s
+++ b/tests/fixtures/complex_mul.s
@@ -1,0 +1,26 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl %eax, a
+    movl %eax, b
+    movl a, %eax
+    movl b, %ebx
+    movsd %eax, %xmm0
+    movsd %eax, %xmm1
+    movsd %ebx, %xmm2
+    movsd %ebx, %xmm3
+    mulsd %xmm2, %xmm0
+    mulsd %xmm3, %xmm1
+    subsd %xmm1, %xmm0
+    movsd %xmm0, %ecx
+    movsd %eax, %xmm0
+    mulsd %xmm3, %xmm0
+    movsd %eax, %xmm1
+    mulsd %xmm2, %xmm1
+    addsd %xmm1, %xmm0
+    movsd %xmm0, %ecx
+    movl %ecx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/complex_sub.c
+++ b/tests/fixtures/complex_sub.c
@@ -1,0 +1,5 @@
+double _Complex main() {
+    double _Complex a = 5.0 + 1.0i;
+    double _Complex b = 2.0 + 3.0i;
+    return a - b;
+}

--- a/tests/fixtures/complex_sub.s
+++ b/tests/fixtures/complex_sub.s
@@ -1,0 +1,20 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl %eax, a
+    movl %eax, b
+    movl a, %eax
+    movl b, %ebx
+    movsd %eax, %xmm0
+    movsd %ebx, %xmm1
+    subsd %xmm1, %xmm0
+    movsd %xmm0, %ecx
+    movsd %eax, %xmm0
+    movsd %ebx, %xmm1
+    subsd %xmm1, %xmm0
+    movsd %xmm0, %ecx
+    movl %ecx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- document `_Complex` literals and operators
- mention complex number support in the man page
- add complex arithmetic fixtures

## Testing
- `tests/run.sh` *(fails: undefined reference to `symtable_lookup_struct`)*

------
https://chatgpt.com/codex/tasks/task_e_686d3fdb99388324b3929f69b42422f3