### PR TITLE
Add CC and AS environment variable support

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -53,6 +53,9 @@ Temporary object and assembly files are written to the directory given with
 the `--obj-dir` option when provided.  Without this flag the compiler
 consults the `TMPDIR` environment variable and then `P_tmpdir` when set.
 Only if neither variable is available does it fall back to `/tmp`.
+The assembler can be overridden with the `AS` environment variable while
+`CC` specifies the linker command and the default assembler for AT&T
+syntax.  When unset they default to `nasm` (Intel mode) and `cc`.
 
 Use `vc -o out.s source.c` to compile a file, `vc -c -o out.o source.c` to
 produce an object, `vc --link -o prog main.c util.c` to build an executable

--- a/man/vc.1
+++ b/man/vc.1
@@ -11,8 +11,8 @@ It processes input through lexical analysis, parsing, semantic analysis,
 optional optimizations, register allocation and code generation.
 The resulting assembly can be written to a file or printed to stdout.
 Intel-style assembly output may be selected with \fB--intel-syntax\fR.
-When this mode is combined with \fB--compile\fR or \fB--link\fR the
-\fInasm\fR assembler must be available.
+When this mode is combined with \fB--compile\fR or \fB--link\fR an
+assembler capable of NASM syntax (see \fBAS\fR) must be available.
 Functions may return \fBstruct\fR or \fBunion\fR values via a hidden pointer.
 Supported constructs include:
 .IP \[bu] 2
@@ -149,8 +149,8 @@ Generate x86-64 assembly instead of 32-bit.
 .TP
 .B --intel-syntax
 Use Intel-style x86 assembly output. When combined with
-\fB--compile\fR or \fB--link\fR this option requires \fInasm\fR to
-assemble the generated code.
+\fB--compile\fR or \fB--link\fR this option requires an assembler that
+understands NASM syntax (see \fBAS\fR).
 .TP
 .BR -c "," \fB--compile\fR
 Assemble the output into an object file using \fBcc -c\fR. When multiple
@@ -225,6 +225,12 @@ paths are processed.
 Colon separated list of directories added to the include search path after any
 .B -I
 paths are processed.
+.TP
+.B AS
+Assembler program to invoke instead of the default.
+.TP
+.B CC
+Command used for linking and as the default assembler when using AT&T syntax.
 .TP
 .B TMPDIR
 Directory for temporary object files when \fB--obj-dir\fR is not used.

--- a/src/compile.c
+++ b/src/compile.c
@@ -93,6 +93,8 @@ static int compile_optimize_impl(ir_builder_t *ir, const opt_config_t *cfg);
 int compile_output_impl(ir_builder_t *ir, const char *output,
                         int dump_ir, int dump_asm, int use_x86_64,
                         int compile, const cli_options_t *cli);
+const char *get_cc(void);
+const char *get_as(int intel);
 
 /* Stage helpers */
 static void compile_ctx_init(compile_context_t *ctx);
@@ -714,7 +716,7 @@ build_linker_args(const vector_t *objs, const vector_t *lib_dirs,
     char **argv = vc_alloc_or_exit(n * sizeof(char *));
 
     size_t idx = 0;
-    argv[idx++] = "cc";
+    argv[idx++] = (char *)get_cc();
     argv[idx++] = (char *)arch_flag;
     for (size_t i = 0; i < objs->count; i++)
         argv[idx++] = ((char **)objs->data)[i];
@@ -757,9 +759,9 @@ static int run_link_command(const vector_t *objs, const vector_t *lib_dirs,
     free_linker_args(argv);
     if (rc != 1) {
         if (rc == 0)
-            fprintf(stderr, "cc failed\n");
+            fprintf(stderr, "linker failed\n");
         else if (rc == -1)
-            fprintf(stderr, "cc terminated by signal\n");
+            fprintf(stderr, "linker terminated by signal\n");
         return 0;
     }
     return 1;


### PR DESCRIPTION
## Summary
- let users override tools via `CC` and `AS`
- document these new variables

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686d5868b6f48324a4eeeb1a3f544895