### PR TITLE
Add perror on include failure and regression test

### DIFF
--- a/tests/include_next/miss1/foo.h
+++ b/tests/include_next/miss1/foo.h
@@ -1,0 +1,2 @@
+#define VALUE 1
+#include_next <foo.h>

--- a/tests/include_next/miss2/foo.h
+++ b/tests/include_next/miss2/foo.h
@@ -1,0 +1,3 @@
+#undef VALUE
+#define VALUE 2
+#include_next <foo.h>

--- a/tests/invalid/include_next_missing.c
+++ b/tests/invalid/include_next_missing.c
@@ -1,0 +1,2 @@
+#include <foo.h>
+int main() { return VALUE; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -297,6 +297,19 @@ if [ $ret -eq 0 ] || ! grep -q "nonexistent.h: No such file or directory" "${err
 fi
 rm -f "${out}" "${err}"
 
+# negative test for include_next missing file
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -I "$DIR/include_next/miss1" -I "$DIR/include_next/miss2" -o "${out}" "$DIR/invalid/include_next_missing.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "foo.h: No such file or directory" "${err}"; then
+    echo "Test include_next_missing failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 # negative test for macro recursion limit
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- report include errors via `perror` to show system message
- keep errno from the failing include
- add a regression test for missing `#include_next`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686d62d6cc68832494a3d3789d2531cd