### PR TITLE
Add VCFLAGS option support

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -56,6 +56,10 @@ Only if neither variable is available does it fall back to `/tmp`.
 The assembler can be overridden with the `AS` environment variable while
 `CC` specifies the linker command and the default assembler for AT&T
 syntax.  When unset they default to `nasm` (Intel mode) and `cc`.
+Additional options may be supplied in the `VCFLAGS` environment variable.
+Its contents are split on spaces and prepended to the argument vector so
+flags provided directly on the command line override those from
+`VCFLAGS`.
 
 Use `vc -o out.s source.c` to compile a file, `vc -c -o out.o source.c` to
 produce an object, `vc --link -o prog main.c util.c` to build an executable

--- a/man/vc.1
+++ b/man/vc.1
@@ -228,6 +228,10 @@ Colon separated list of directories added to the include search path after any
 .B -I
 paths are processed.
 .TP
+.B VCFLAGS
+Space separated list of additional command line options prepended before
+parsing. Flags given directly on the command line override these.
+.TP
 .B AS
 Assembler program to invoke instead of the default.
 .TP

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -127,6 +127,23 @@ if ! diff -u "$DIR/fixtures/include_search.s" "${inc_env_out}"; then
 fi
 rm -f "${inc_env_out}"
 
+# verify VCFLAGS options are parsed
+vcflags_out=$(mktemp)
+VCFLAGS="--x86-64" "$BINARY" -o "${vcflags_out}" "$DIR/fixtures/simple_add.c"
+if ! diff -u "$DIR/fixtures/simple_add_x86-64.s" "${vcflags_out}"; then
+    echo "Test vcflags_x86_64 failed"
+    fail=1
+fi
+rm -f "${vcflags_out}"
+
+vcflags_out=$(mktemp)
+VCFLAGS="--intel-syntax" "$BINARY" -o "${vcflags_out}" "$DIR/fixtures/pointer_add.c"
+if ! diff -u "$DIR/fixtures/pointer_add_intel.s" "${vcflags_out}"; then
+    echo "Test vcflags_intel failed"
+    fail=1
+fi
+rm -f "${vcflags_out}"
+
 # verify #include_next directive
 next_out=$(mktemp)
 "$BINARY" -I "$DIR/include_next/dir1" -I "$DIR/include_next/dir2" -I "$DIR/include_next/dir3" -o "${next_out}" "$DIR/fixtures/include_next.c"


### PR DESCRIPTION
## Summary
- prepend tokens from `$VCFLAGS` to argv in `cli_parse_args`
- document new `VCFLAGS` environment variable in docs and man page
- test VCFLAGS handling with new regression tests

## Testing
- `make -j$(nproc)`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d6eb388548324bd8e3fcf92e5769d