### PR TITLE
Refactor load/store emitters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_tokenize.c src/compile_parse.c s
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
-           src/codegen.c src/codegen_mem.c src/codegen_arith.c src/codegen_branch.c \
+           src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith.c src/codegen_branch.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ast_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
 
@@ -21,7 +21,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_init.h include/semantic_global.h \
-    include/ir_core.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
+    include/ir_core.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h include/startup.h
 PREFIX ?= /usr/local
@@ -157,6 +157,9 @@ src/codegen.o: src/codegen.c $(HDR)
 
 src/codegen_mem.o: src/codegen_mem.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_mem.c -o src/codegen_mem.o
+
+src/codegen_loadstore.o: src/codegen_loadstore.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_loadstore.c -o src/codegen_loadstore.o
 
 src/codegen_arith.o: src/codegen_arith.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_arith.c -o src/codegen_arith.o

--- a/include/codegen_loadstore.h
+++ b/include/codegen_loadstore.h
@@ -1,0 +1,43 @@
+/*
+ * Load and store instruction emission helpers.
+ *
+ * These helpers translate IR load and store operations using register
+ * allocation results.  The `x64` flag selects 32- or 64-bit forms.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_CODEGEN_LOADSTORE_H
+#define VC_CODEGEN_LOADSTORE_H
+
+#include "strbuf.h"
+#include "ir_core.h"
+#include "regalloc.h"
+#include "cli.h"
+
+void emit_load(strbuf_t *sb, ir_instr_t *ins,
+               regalloc_t *ra, int x64,
+               asm_syntax_t syntax);
+
+void emit_store(strbuf_t *sb, ir_instr_t *ins,
+                regalloc_t *ra, int x64,
+                asm_syntax_t syntax);
+
+void emit_load_idx(strbuf_t *sb, ir_instr_t *ins,
+                   regalloc_t *ra, int x64,
+                   asm_syntax_t syntax);
+
+void emit_store_idx(strbuf_t *sb, ir_instr_t *ins,
+                    regalloc_t *ra, int x64,
+                    asm_syntax_t syntax);
+
+void emit_load_ptr(strbuf_t *sb, ir_instr_t *ins,
+                   regalloc_t *ra, int x64,
+                   asm_syntax_t syntax);
+
+void emit_store_ptr(strbuf_t *sb, ir_instr_t *ins,
+                    regalloc_t *ra, int x64,
+                    asm_syntax_t syntax);
+
+#endif /* VC_CODEGEN_LOADSTORE_H */

--- a/src/codegen_loadstore.c
+++ b/src/codegen_loadstore.c
@@ -1,0 +1,176 @@
+/*
+ * Emitters for load and store IR instructions.
+ *
+ * These helpers move values between memory and registers after register
+ * allocation.  The `x64` flag toggles between 32- and 64-bit encodings.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdio.h>
+#include "codegen_loadstore.h"
+#include "regalloc_x86.h"
+
+#define SCRATCH_REG 0
+
+/* Move from `src` to `dest` and optionally spill to `slot`. */
+static void emit_move_with_spill(strbuf_t *sb, const char *sfx,
+                                 const char *src, const char *dest,
+                                 const char *slot, int spill,
+                                 asm_syntax_t syntax)
+{
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest, src);
+    else
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, src, dest);
+    if (spill) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, slot, dest);
+        else
+            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest, slot);
+    }
+}
+
+/* Helper to format a register name. */
+static const char *reg_str(int reg, asm_syntax_t syntax)
+{
+    const char *name = regalloc_reg_name(reg);
+    if (syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
+}
+
+static const char *fmt_reg(const char *name, asm_syntax_t syntax)
+{
+    if (syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
+}
+
+/* Format the location for operand `id`. */
+static const char *loc_str(char buf[32], regalloc_t *ra, int id, int x64,
+                           asm_syntax_t syntax)
+{
+    if (!ra || id <= 0)
+        return "";
+    int loc = ra->loc[id];
+    if (loc >= 0)
+        return reg_str(loc, syntax);
+    if (x64) {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[rbp-%d]", -loc * 8);
+        else
+            snprintf(buf, 32, "-%d(%%rbp)", -loc * 8);
+    } else {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[ebp-%d]", -loc * 4);
+        else
+            snprintf(buf, 32, "-%d(%%ebp)", -loc * 4);
+    }
+    return buf;
+}
+
+void emit_load(strbuf_t *sb, ir_instr_t *ins,
+               regalloc_t *ra, int x64,
+               asm_syntax_t syntax)
+{
+    char destb[32];
+    char mem[32];
+    const char *sfx = x64 ? "q" : "l";
+    int spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
+    const char *dest = spill ? reg_str(SCRATCH_REG, syntax)
+                             : loc_str(destb, ra, ins->dest, x64, syntax);
+    const char *slot = loc_str(mem, ra, ins->dest, x64, syntax);
+    emit_move_with_spill(sb, sfx, ins->name, dest, slot, spill, syntax);
+}
+
+void emit_store(strbuf_t *sb, ir_instr_t *ins,
+                regalloc_t *ra, int x64,
+                asm_syntax_t syntax)
+{
+    char b1[32];
+    const char *sfx = x64 ? "q" : "l";
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, ins->name,
+                       loc_str(b1, ra, ins->src1, x64, syntax));
+    else
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
+                       loc_str(b1, ra, ins->src1, x64, syntax), ins->name);
+}
+
+void emit_load_ptr(strbuf_t *sb, ir_instr_t *ins,
+                   regalloc_t *ra, int x64,
+                   asm_syntax_t syntax)
+{
+    char b1[32];
+    char destb[32];
+    char mem[32];
+    const char *sfx = x64 ? "q" : "l";
+    int spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
+    const char *dest = spill ? reg_str(SCRATCH_REG, syntax)
+                             : loc_str(destb, ra, ins->dest, x64, syntax);
+    const char *slot = loc_str(mem, ra, ins->dest, x64, syntax);
+    char srcbuf[32];
+    if (syntax == ASM_INTEL)
+        snprintf(srcbuf, sizeof(srcbuf), "[%s]",
+                 loc_str(b1, ra, ins->src1, x64, syntax));
+    else
+        snprintf(srcbuf, sizeof(srcbuf), "(%s)",
+                 loc_str(b1, ra, ins->src1, x64, syntax));
+    emit_move_with_spill(sb, sfx, srcbuf, dest, slot, spill, syntax);
+}
+
+void emit_store_ptr(strbuf_t *sb, ir_instr_t *ins,
+                    regalloc_t *ra, int x64,
+                    asm_syntax_t syntax)
+{
+    char b1[32];
+    char b2[32];
+    const char *sfx = x64 ? "q" : "l";
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    mov%s [%s], %s\n", sfx,
+                       loc_str(b2, ra, ins->src1, x64, syntax),
+                       loc_str(b1, ra, ins->src2, x64, syntax));
+    else
+        strbuf_appendf(sb, "    mov%s %s, (%s)\n", sfx,
+                       loc_str(b1, ra, ins->src2, x64, syntax),
+                       loc_str(b2, ra, ins->src1, x64, syntax));
+}
+
+void emit_load_idx(strbuf_t *sb, ir_instr_t *ins,
+                   regalloc_t *ra, int x64,
+                   asm_syntax_t syntax)
+{
+    char b1[32];
+    char destb[32];
+    char mem[32];
+    const char *sfx = x64 ? "q" : "l";
+    int spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
+    const char *dest = spill ? reg_str(SCRATCH_REG, syntax)
+                             : loc_str(destb, ra, ins->dest, x64, syntax);
+    const char *slot = loc_str(mem, ra, ins->dest, x64, syntax);
+    char srcbuf[64];
+    snprintf(srcbuf, sizeof(srcbuf), "%s(,%s,4)",
+             ins->name, loc_str(b1, ra, ins->src1, x64, syntax));
+    emit_move_with_spill(sb, sfx, srcbuf, dest, slot, spill, syntax);
+}
+
+void emit_store_idx(strbuf_t *sb, ir_instr_t *ins,
+                    regalloc_t *ra, int x64,
+                    asm_syntax_t syntax)
+{
+    char b1[32];
+    char b2[32];
+    const char *sfx = x64 ? "q" : "l";
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    mov%s %s(,%s,4), %s\n", sfx, ins->name,
+                       loc_str(b2, ra, ins->src1, x64, syntax),
+                       loc_str(b1, ra, ins->src2, x64, syntax));
+    else
+        strbuf_appendf(sb, "    mov%s %s, %s(,%s,4)\n", sfx,
+                       loc_str(b1, ra, ins->src2, x64, syntax),
+                       ins->name,
+                       loc_str(b2, ra, ins->src1, x64, syntax));
+}
+


### PR DESCRIPTION
## Summary
- split load and store helpers into codegen_loadstore.c
- add public header codegen_loadstore.h
- include new header where needed
- compile new source in Makefile

## Testing
- `make -j2`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686d7651ac908324b29337de7496ca41