### PR TITLE
Split arithmetic code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_tokenize.c src/compile_parse.c s
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
-           src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith.c src/codegen_branch.c \
+           src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ast_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_file.c
@@ -22,7 +22,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_var.h include/semantic_init.h include/semantic_global.h \
-    include/ir_core.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_branch.h include/strbuf.h \
+    include/ir_core.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/parser_types.h include/parser_core.h include/startup.h
 PREFIX ?= /usr/local
@@ -169,6 +169,10 @@ src/codegen_arith.o: src/codegen_arith.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_arith.c -o src/codegen_arith.o
 src/codegen_float.o: src/codegen_float.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_float.c -o src/codegen_float.o
+src/codegen_arith_int.o: src/codegen_arith_int.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_arith_int.c -o src/codegen_arith_int.o
+src/codegen_arith_float.o: src/codegen_arith_float.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_arith_float.c -o src/codegen_arith_float.o
 
 src/codegen_complex.o: src/codegen_complex.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_complex.c -o src/codegen_complex.o

--- a/include/codegen_arith_float.h
+++ b/include/codegen_arith_float.h
@@ -1,0 +1,16 @@
+#ifndef VC_CODEGEN_ARITH_FLOAT_H
+#define VC_CODEGEN_ARITH_FLOAT_H
+
+#include "strbuf.h"
+#include "ir_core.h"
+#include "regalloc.h"
+#include "cli.h"
+
+void emit_cast(strbuf_t *sb, ir_instr_t *ins,
+               regalloc_t *ra, int x64,
+               asm_syntax_t syntax);
+void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins,
+                           regalloc_t *ra, int x64, const char *op,
+                           asm_syntax_t syntax);
+
+#endif /* VC_CODEGEN_ARITH_FLOAT_H */

--- a/include/codegen_arith_int.h
+++ b/include/codegen_arith_int.h
@@ -1,0 +1,40 @@
+#ifndef VC_CODEGEN_ARITH_INT_H
+#define VC_CODEGEN_ARITH_INT_H
+
+#include "strbuf.h"
+#include "ir_core.h"
+#include "regalloc.h"
+#include "cli.h"
+
+void emit_ptr_add(strbuf_t *sb, ir_instr_t *ins,
+                  regalloc_t *ra, int x64,
+                  asm_syntax_t syntax);
+void emit_ptr_diff(strbuf_t *sb, ir_instr_t *ins,
+                   regalloc_t *ra, int x64,
+                   asm_syntax_t syntax);
+void emit_int_arith(strbuf_t *sb, ir_instr_t *ins,
+                    regalloc_t *ra, int x64, const char *op,
+                    asm_syntax_t syntax);
+void emit_div(strbuf_t *sb, ir_instr_t *ins,
+              regalloc_t *ra, int x64,
+              asm_syntax_t syntax);
+void emit_mod(strbuf_t *sb, ir_instr_t *ins,
+              regalloc_t *ra, int x64,
+              asm_syntax_t syntax);
+void emit_shift(strbuf_t *sb, ir_instr_t *ins,
+                regalloc_t *ra, int x64, const char *op,
+                asm_syntax_t syntax);
+void emit_bitwise(strbuf_t *sb, ir_instr_t *ins,
+                  regalloc_t *ra, int x64, const char *op,
+                  asm_syntax_t syntax);
+void emit_cmp(strbuf_t *sb, ir_instr_t *ins,
+              regalloc_t *ra, int x64,
+              asm_syntax_t syntax);
+void emit_logand(strbuf_t *sb, ir_instr_t *ins,
+                 regalloc_t *ra, int x64,
+                 asm_syntax_t syntax);
+void emit_logor(strbuf_t *sb, ir_instr_t *ins,
+                regalloc_t *ra, int x64,
+                asm_syntax_t syntax);
+
+#endif /* VC_CODEGEN_ARITH_INT_H */

--- a/src/codegen_arith_float.c
+++ b/src/codegen_arith_float.c
@@ -1,0 +1,188 @@
+/*
+ * Floating point helpers extracted from codegen_arith.c
+ */
+
+#include <stdio.h>
+#include "codegen_arith_float.h"
+#include "regalloc_x86.h"
+#include "consteval.h"
+
+static const char *reg_str(int reg, asm_syntax_t syntax)
+{
+    const char *name = regalloc_reg_name(reg);
+    if (syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
+}
+
+static const char *fmt_reg(const char *name, asm_syntax_t syntax)
+{
+    if (syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
+}
+
+static const char *loc_str(char buf[32], regalloc_t *ra, int id, int x64,
+                           asm_syntax_t syntax)
+{
+    if (!ra || id <= 0)
+        return "";
+    int loc = ra->loc[id];
+    if (loc >= 0)
+        return reg_str(loc, syntax);
+    if (x64) {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[rbp-%d]", -loc * 8);
+        else
+            snprintf(buf, 32, "-%d(%%rbp)", -loc * 8);
+    } else {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[ebp-%d]", -loc * 4);
+        else
+            snprintf(buf, 32, "-%d(%%ebp)", -loc * 4);
+    }
+    return buf;
+}
+
+/* Convert between integer and floating-point types. */
+void emit_cast(strbuf_t *sb, ir_instr_t *ins,
+               regalloc_t *ra, int x64,
+               asm_syntax_t syntax)
+{
+    char b1[32];
+    char b2[32];
+    type_kind_t src = (type_kind_t)((unsigned long long)ins->imm >> 32);
+    type_kind_t dst = (type_kind_t)(ins->imm & 0xffffffffu);
+
+    int r0 = regalloc_xmm_acquire();
+    const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
+    const char *sfx = x64 ? "q" : "l";
+
+    if (is_intlike(src) && dst == TYPE_FLOAT) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    cvtsi2ss %s, %s\n", reg0,
+                           loc_str(b1, ra, ins->src1, x64, syntax));
+        else
+            strbuf_appendf(sb, "    cvtsi2ss %s, %s\n",
+                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        if (ra && ra->loc[ins->dest] >= 0)
+            strbuf_appendf(sb, "    movd %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movss %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
+        return;
+    }
+
+    if (is_intlike(src) && dst == TYPE_DOUBLE) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    cvtsi2sd %s, %s\n", reg0,
+                           loc_str(b1, ra, ins->src1, x64, syntax));
+        else
+            strbuf_appendf(sb, "    cvtsi2sd %s, %s\n",
+                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        if (ra && ra->loc[ins->dest] >= 0)
+            strbuf_appendf(sb, "    movq %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
+        return;
+    }
+
+    if (src == TYPE_FLOAT && is_intlike(dst)) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movss %s, %s\n", reg0,
+                           loc_str(b1, ra, ins->src1, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movss %s, %s\n",
+                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    cvttss2si %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        else
+            strbuf_appendf(sb, "    cvttss2si %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
+        return;
+    }
+
+    if (src == TYPE_DOUBLE && is_intlike(dst)) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                           loc_str(b1, ra, ins->src1, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movsd %s, %s\n",
+                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    cvttsd2si %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        else
+            strbuf_appendf(sb, "    cvttsd2si %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
+        return;
+    }
+
+    if (src == TYPE_FLOAT && dst == TYPE_DOUBLE) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movss %s, %s\n", reg0,
+                           loc_str(b1, ra, ins->src1, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movss %s, %s\n",
+                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        strbuf_appendf(sb, "    cvtss2sd %s, %s\n", reg0, reg0);
+        if (ra && ra->loc[ins->dest] >= 0)
+            strbuf_appendf(sb, "    movq %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
+        return;
+    }
+
+    if (src == TYPE_DOUBLE && dst == TYPE_FLOAT) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
+                           loc_str(b1, ra, ins->src1, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movsd %s, %s\n",
+                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        strbuf_appendf(sb, "    cvtsd2ss %s, %s\n", reg0, reg0);
+        if (ra && ra->loc[ins->dest] >= 0)
+            strbuf_appendf(sb, "    movd %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        else
+            strbuf_appendf(sb, "    movss %s, %s\n", reg0,
+                           loc_str(b2, ra, ins->dest, x64, syntax));
+        regalloc_xmm_release(r0);
+        return;
+    }
+
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
+                       loc_str(b2, ra, ins->dest, x64, syntax),
+                       loc_str(b1, ra, ins->src1, x64, syntax));
+    else
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
+                       loc_str(b1, ra, ins->src1, x64, syntax),
+                       loc_str(b2, ra, ins->dest, x64, syntax));
+    regalloc_xmm_release(r0);
+}
+
+/* Generate a long double binary operation using the x87 FPU. */
+void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins,
+                           regalloc_t *ra, int x64, const char *op,
+                           asm_syntax_t syntax)
+{
+    char b1[32];
+    char b2[32];
+    strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src1, x64, syntax));
+    strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src2, x64, syntax));
+    strbuf_appendf(sb, "    %s\n", op);
+    strbuf_appendf(sb, "    fstpt %s\n", loc_str(b2, ra, ins->dest, x64, syntax));
+}
+


### PR DESCRIPTION
## Summary
- divide codegen_arith.c into int/float implementations
- expose new helpers via `codegen_arith_int.h` and `codegen_arith_float.h`
- compile new files in Makefile

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686dcf3936508324987185ca130df1be