### PR TITLE
Refactor loop helpers into dedicated module

### DIFF
--- a/include/semantic_loops.h
+++ b/include/semantic_loops.h
@@ -30,4 +30,11 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                    label_table_t *labels, ir_builder_t *ir,
                    type_kind_t func_ret_type);
 
+/* Validate a break statement */
+int check_break_stmt(stmt_t *stmt, const char *break_label, ir_builder_t *ir);
+
+/* Validate a continue statement */
+int check_continue_stmt(stmt_t *stmt, const char *continue_label,
+                        ir_builder_t *ir);
+
 #endif /* VC_SEMANTIC_LOOPS_H */

--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -10,6 +10,7 @@
 #include "semantic_loops.h"
 #include "semantic_expr.h"
 #include "label.h"
+#include "error.h"
 
 /* Forward declaration from semantic_stmt.c */
 extern int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
@@ -135,5 +136,31 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     ir_build_label(ir, end_label);
     symtable_pop_scope(vars, old_head);
     return 1;
+}
+
+/* Internal helper used by break/continue handlers */
+static int handle_loop_stmt(stmt_t *stmt, const char *target,
+                            ir_builder_t *ir)
+{
+    if (!target) {
+        error_set(stmt->line, stmt->column, error_current_file,
+                  error_current_function);
+        return 0;
+    }
+    ir_build_br(ir, target);
+    return 1;
+}
+
+/* Validate a break statement */
+int check_break_stmt(stmt_t *stmt, const char *break_label, ir_builder_t *ir)
+{
+    return handle_loop_stmt(stmt, break_label, ir);
+}
+
+/* Validate a continue statement */
+int check_continue_stmt(stmt_t *stmt, const char *continue_label,
+                        ir_builder_t *ir)
+{
+    return handle_loop_stmt(stmt, continue_label, ir);
 }
 

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -329,21 +329,6 @@ static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
     return 1;
 }
 
-/*
- * Handle break and continue statements. The target label must be
- * provided by the caller. If no valid label is available an error
- * is reported.
- */
-static int handle_loop_stmt(stmt_t *stmt, const char *target,
-                            ir_builder_t *ir)
-{
-    if (!target) {
-        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        return 0;
-    }
-    ir_build_br(ir, target);
-    return 1;
-}
 
 /*
  * Handle a label statement. The label name is recorded in the table
@@ -448,23 +433,6 @@ static int check_goto_stmt(stmt_t *stmt, label_table_t *labels,
     return 1;
 }
 
-/*
- * Wrapper used to validate a break statement.
- */
-static int check_break_stmt(stmt_t *stmt, const char *break_label,
-                            ir_builder_t *ir)
-{
-    return handle_loop_stmt(stmt, break_label, ir);
-}
-
-/*
- * Wrapper used to validate a continue statement.
- */
-static int check_continue_stmt(stmt_t *stmt, const char *continue_label,
-                               ir_builder_t *ir)
-{
-    return handle_loop_stmt(stmt, continue_label, ir);
-}
 
 /* Evaluate a _Static_assert expression and emit an error if zero */
 static int check_static_assert_stmt(stmt_t *stmt, symtable_t *vars)


### PR DESCRIPTION
## Summary
- move break/continue handling to `semantic_loops.c`
- expose new loop helpers in `semantic_loops.h`
- trim `semantic_stmt.c` to only orchestrate these calls

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686dd707b14883248990d871795cef70