### PR TITLE
Move linking helpers to new file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc
 # Core compiler sources
 
-CORE_SRC = src/main.c src/compile.c src/compile_tokenize.c src/compile_parse.c src/compile_output.c src/startup.c src/command.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_expr_primary.c src/parser_expr_binary.c src/parser_init.c \
+CORE_SRC = src/main.c src/compile.c src/compile_link.c src/compile_tokenize.c src/compile_parse.c src/compile_output.c src/startup.c src/command.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_expr_primary.c src/parser_expr_binary.c src/parser_init.c \
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
@@ -54,6 +54,8 @@ src/main.o: src/main.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/main.c -o src/main.o
 src/compile.o: src/compile.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile.c -o src/compile.o
+src/compile_link.o: src/compile_link.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile_link.c -o src/compile_link.o
 src/compile_tokenize.o: src/compile_tokenize.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile_tokenize.c -o src/compile_tokenize.o
 src/compile_parse.o: src/compile_parse.c $(HDR)

--- a/src/compile.c
+++ b/src/compile.c
@@ -111,7 +111,7 @@ static int compile_optimize_stage(compile_context_t *ctx,
 static int compile_output_stage(compile_context_t *ctx, const char *output,
                                 int dump_ir, int dump_asm, int use_x86_64,
                                 int compile_obj, const cli_options_t *cli);
-static char *vc_obj_name(const char *source);
+char *vc_obj_name(const char *source);
 static int register_function_prototypes(func_t **func_list, size_t fcount,
                                         symtable_t *funcs);
 static int check_global_decls(stmt_t **glob_list, size_t gcount,
@@ -125,28 +125,7 @@ int compile_unit(const char *source, const cli_options_t *cli,
                  const char *output, int compile_obj);
 
 /* Compile one source file into a temporary object file. */
-#ifdef UNIT_TESTING
-int compile_source_obj(const char *source, const cli_options_t *cli,
-                       char **out_path);
-#else
-static int compile_source_obj(const char *source, const cli_options_t *cli,
-                              char **out_path);
-#endif
-
-/* Build and run the final linker command. */
-static int run_link_command(const vector_t *objs, const vector_t *lib_dirs,
-                            const vector_t *libs, const char *output,
-                            int use_x86_64);
-
-/* Allocate and populate argv array for the linker. */
-static char **build_linker_args(const vector_t *objs,
-                                const vector_t *lib_dirs,
-                                const vector_t *libs,
-                                const char *output,
-                                int use_x86_64);
-
-/* Free argv array returned by build_linker_args. */
-static void free_linker_args(char **argv);
+int write_dep_file(const char *target, const vector_t *deps);
 
 /* Spawn a command and wait for completion */
 
@@ -162,23 +141,10 @@ static char *create_temp_template(const cli_options_t *cli,
 /* Wrapper around mkstemp that sets FD_CLOEXEC on the returned descriptor. */
 static int open_temp_file(char *tmpl);
 
-/* Create an object file containing the entry stub for linking. */
-static int create_startup_object(const cli_options_t *cli, int use_x86_64,
-                                 char **out_path);
-
-/* Compile all input sources into temporary object files. */
-static int compile_source_files(const cli_options_t *cli, vector_t *objs);
-
-/* Build the startup stub and link all objects into the final executable. */
-static int build_and_link_objects(vector_t *objs, const cli_options_t *cli);
-
 /* Run only the preprocessor stage on each input source. */
 int run_preprocessor(const cli_options_t *cli);
 
 int generate_dependencies(const cli_options_t *cli);
-
-/* Link multiple object files into the final executable. */
-int link_sources(const cli_options_t *cli);
 
 /* Read source from stdin into a temporary file and run the preprocessor */
 
@@ -364,67 +330,6 @@ static int compile_output_stage(compile_context_t *ctx, const char *output,
 
 /* Emit assembly or an object file */
 
-/*
- * Return a newly allocated object file name for the given source path.
- * The caller must free the returned string.  NULL is returned on memory
- * allocation failure.
- */
-static char *
-vc_obj_name(const char *source)
-{
-    const char *base = strrchr(source, '/');
-    base = base ? base + 1 : source;
-    const char *dot = strrchr(base, '.');
-    size_t len = dot ? (size_t)(dot - base) : strlen(base);
-
-    char *obj = malloc(len + 3);
-    if (!obj)
-        return NULL;
-
-    memcpy(obj, base, len);
-    strcpy(obj + len, ".o");
-    return obj;
-}
-
-/* Return a dependency file name derived from TARGET */
-static char *vc_dep_name(const char *target)
-{
-    const char *base = strrchr(target, '/');
-    base = base ? base + 1 : target;
-    const char *dot = strrchr(base, '.');
-    size_t len = dot ? (size_t)(dot - base) : strlen(base);
-    char *dep = malloc(len + 3);
-    if (!dep)
-        return NULL;
-    memcpy(dep, base, len);
-    strcpy(dep + len, ".d");
-    return dep;
-}
-
-static int write_dep_file(const char *target, const vector_t *deps)
-{
-    char *dep = vc_dep_name(target);
-    if (!dep) {
-        vc_oom();
-        return 0;
-    }
-    FILE *f = fopen(dep, "w");
-    if (!f) {
-        perror(dep);
-        free(dep);
-        return 0;
-    }
-    fprintf(f, "%s:", target);
-    for (size_t i = 0; i < deps->count; i++)
-        fprintf(f, " %s", ((const char **)deps->data)[i]);
-    fprintf(f, "\n");
-    int ok = (fclose(f) == 0);
-    if (!ok)
-        perror(dep);
-    free(dep);
-    return ok;
-}
-
 /* Compile a single translation unit */
 #ifndef UNIT_TESTING
 static int compile_single_unit(const char *source, const cli_options_t *cli,
@@ -607,184 +512,6 @@ int create_temp_file(const cli_options_t *cli, const char *prefix,
     return fd;
 }
 
-
-
-/* Create object file with program entry point */
-static int create_startup_object(const cli_options_t *cli, int use_x86_64,
-                                char **out_path)
-{
-    char *asmfile = NULL;
-    int ok = write_startup_asm(use_x86_64, cli->asm_syntax, cli, &asmfile);
-    if (ok)
-        ok = assemble_startup_obj(asmfile, use_x86_64, cli, out_path);
-    if (asmfile) {
-        unlink(asmfile);
-        free(asmfile);
-    }
-    return ok;
-}
-
-/* Compile a single source file to a temporary object. */
-#ifdef UNIT_TESTING
-int compile_source_obj(const char *source, const cli_options_t *cli,
-                       char **out_path)
-#else
-static int compile_source_obj(const char *source, const cli_options_t *cli,
-                              char **out_path)
-#endif
-{
-    char *objname = NULL;
-    int fd = create_temp_file(cli, "vcobj", &objname);
-    if (fd < 0) {
-        perror("mkstemp");
-        return 0;
-    }
-    close(fd);
-
-    int ok = compile_unit(source, cli, objname, 1);
-    if (!ok) {
-        unlink(objname);
-        free(objname);
-        return 0;
-    }
-
-    *out_path = objname;
-    return 1;
-}
-
-/* Compile all sources to temporary object files. */
-static int compile_source_files(const cli_options_t *cli, vector_t *objs)
-{
-    int ok = 1;
-    vector_init(objs, sizeof(char *));
-
-    for (size_t i = 0; i < cli->sources.count; i++) {
-        const char *src = ((const char **)cli->sources.data)[i];
-        char *obj = NULL;
-
-        if (!compile_source_obj(src, cli, &obj)) {
-            ok = 0;
-            break;
-        }
-
-        if (!vector_push(objs, &obj)) {
-            vc_oom();
-            ok = 0;
-            unlink(obj);
-            free(obj);
-            break;
-        }
-    }
-
-    if (!ok) {
-        for (size_t j = 0; j < objs->count; j++) {
-            unlink(((char **)objs->data)[j]);
-            free(((char **)objs->data)[j]);
-        }
-        objs->count = 0;
-    }
-
-    return ok;
-}
-
-/* Allocate and populate the argument vector for the linker command. */
-static char **
-build_linker_args(const vector_t *objs, const vector_t *lib_dirs,
-                  const vector_t *libs, const char *output, int use_x86_64)
-{
-    const char *arch_flag = use_x86_64 ? "-m64" : "-m32";
-
-    /* calculate required argument count and detect overflow */
-    size_t argc = 0;
-    if (objs->count > SIZE_MAX - argc)
-        goto arg_overflow;
-    argc += objs->count;
-    if (lib_dirs->count > (SIZE_MAX - argc) / 2)
-        goto arg_overflow;
-    argc += lib_dirs->count * 2;
-    if (libs->count > (SIZE_MAX - argc) / 2)
-        goto arg_overflow;
-    argc += libs->count * 2;
-    if (5 > SIZE_MAX - argc)
-        goto arg_overflow;
-    argc += 5;
-
-    size_t n = argc + 1; /* plus NULL terminator */
-    if (n > SIZE_MAX / sizeof(char *))
-        goto arg_overflow;
-
-    char **argv = vc_alloc_or_exit(n * sizeof(char *));
-
-    size_t idx = 0;
-    argv[idx++] = (char *)get_cc();
-    argv[idx++] = (char *)arch_flag;
-    for (size_t i = 0; i < objs->count; i++)
-        argv[idx++] = ((char **)objs->data)[i];
-    for (size_t i = 0; i < lib_dirs->count; i++) {
-        argv[idx++] = "-L";
-        argv[idx++] = ((char **)lib_dirs->data)[i];
-    }
-    argv[idx++] = "-nostdlib";
-    for (size_t i = 0; i < libs->count; i++) {
-        argv[idx++] = "-l";
-        argv[idx++] = ((char **)libs->data)[i];
-    }
-    argv[idx++] = "-o";
-    argv[idx++] = (char *)output;
-    argv[idx] = NULL;
-    return argv;
-
-arg_overflow:
-    fprintf(stderr, "vc: argument vector too large\n");
-    return NULL;
-}
-
-/* Free argument vector returned by build_linker_args. */
-static void free_linker_args(char **argv)
-{
-    free(argv);
-}
-
-/* Construct and run the final cc link command. */
-static int run_link_command(const vector_t *objs, const vector_t *lib_dirs,
-                            const vector_t *libs, const char *output,
-                            int use_x86_64)
-{
-    char **argv = build_linker_args(objs, lib_dirs, libs, output,
-                                    use_x86_64);
-    if (!argv)
-        return 0;
-
-    int rc = command_run(argv);
-    free_linker_args(argv);
-    if (rc != 1) {
-        if (rc == 0)
-            fprintf(stderr, "linker failed\n");
-        else if (rc == -1)
-            fprintf(stderr, "linker terminated by signal\n");
-        return 0;
-    }
-    return 1;
-}
-
-/* Create entry stub and link all objects into the final executable. */
-static int build_and_link_objects(vector_t *objs, const cli_options_t *cli)
-{
-    char *stubobj = NULL;
-    int ok = create_startup_object(cli, cli->use_x86_64, &stubobj);
-    if (ok) {
-        if (!vector_push(objs, &stubobj)) {
-            vc_oom();
-            unlink(stubobj);
-            free(stubobj);
-            return 0;
-        }
-        ok = run_link_command(objs, &cli->lib_dirs, &cli->libs,
-                              cli->output, cli->use_x86_64);
-    }
-    return ok;
-}
-
 /* Run the preprocessor and print the result. */
 int run_preprocessor(const cli_options_t *cli)
 {
@@ -842,20 +569,5 @@ int generate_dependencies(const cli_options_t *cli)
     return 0;
 }
 
-/* Compile all sources and link them into the final executable. */
-int link_sources(const cli_options_t *cli)
-{
-    vector_t objs;
-    int ok = compile_source_files(cli, &objs);
 
-    if (ok)
-        ok = build_and_link_objects(&objs, cli);
 
-    for (size_t i = 0; i < objs.count; i++) {
-        unlink(((char **)objs.data)[i]);
-        free(((char **)objs.data)[i]);
-    }
-    vector_free(&objs);
-
-    return ok;
-}

--- a/src/compile_link.c
+++ b/src/compile_link.c
@@ -1,0 +1,277 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "util.h"
+#include "vector.h"
+#include "command.h"
+#include "compile.h"
+#include "startup.h"
+#include "cli.h"
+
+/* external helpers from other compilation units */
+int create_temp_file(const cli_options_t *cli, const char *prefix,
+                     char **out_path);
+const char *get_cc(void);
+
+/*
+ * Return a newly allocated object file name for the given source path.
+ * The caller must free the returned string.  NULL is returned on memory
+ * allocation failure.
+ */
+char *
+vc_obj_name(const char *source)
+{
+    const char *base = strrchr(source, '/');
+    base = base ? base + 1 : source;
+    const char *dot = strrchr(base, '.');
+    size_t len = dot ? (size_t)(dot - base) : strlen(base);
+
+    char *obj = malloc(len + 3);
+    if (!obj)
+        return NULL;
+
+    memcpy(obj, base, len);
+    strcpy(obj + len, ".o");
+    return obj;
+}
+
+/* Return a dependency file name derived from TARGET */
+static char *vc_dep_name(const char *target)
+{
+    const char *base = strrchr(target, '/');
+    base = base ? base + 1 : target;
+    const char *dot = strrchr(base, '.');
+    size_t len = dot ? (size_t)(dot - base) : strlen(base);
+    char *dep = malloc(len + 3);
+    if (!dep)
+        return NULL;
+    memcpy(dep, base, len);
+    strcpy(dep + len, ".d");
+    return dep;
+}
+
+int write_dep_file(const char *target, const vector_t *deps)
+{
+    char *dep = vc_dep_name(target);
+    if (!dep) {
+        vc_oom();
+        return 0;
+    }
+    FILE *f = fopen(dep, "w");
+    if (!f) {
+        perror(dep);
+        free(dep);
+        return 0;
+    }
+    fprintf(f, "%s:", target);
+    for (size_t i = 0; i < deps->count; i++)
+        fprintf(f, " %s", ((const char **)deps->data)[i]);
+    fprintf(f, "\n");
+    int ok = (fclose(f) == 0);
+    if (!ok)
+        perror(dep);
+    free(dep);
+    return ok;
+}
+
+/* Create object file with program entry point */
+static int create_startup_object(const cli_options_t *cli, int use_x86_64,
+                                char **out_path)
+{
+    char *asmfile = NULL;
+    int ok = write_startup_asm(use_x86_64, cli->asm_syntax, cli, &asmfile);
+    if (ok)
+        ok = assemble_startup_obj(asmfile, use_x86_64, cli, out_path);
+    if (asmfile) {
+        unlink(asmfile);
+        free(asmfile);
+    }
+    return ok;
+}
+
+/* Compile a single source file to a temporary object. */
+#ifdef UNIT_TESTING
+int compile_source_obj(const char *source, const cli_options_t *cli,
+                       char **out_path)
+#else
+static int compile_source_obj(const char *source, const cli_options_t *cli,
+                              char **out_path)
+#endif
+{
+    char *objname = NULL;
+    int fd = create_temp_file(cli, "vcobj", &objname);
+    if (fd < 0) {
+        perror("mkstemp");
+        return 0;
+    }
+    close(fd);
+
+    int ok = compile_unit(source, cli, objname, 1);
+    if (!ok) {
+        unlink(objname);
+        free(objname);
+        return 0;
+    }
+
+    *out_path = objname;
+    return 1;
+}
+
+/* Compile all sources to temporary object files. */
+static int compile_source_files(const cli_options_t *cli, vector_t *objs)
+{
+    int ok = 1;
+    vector_init(objs, sizeof(char *));
+
+    for (size_t i = 0; i < cli->sources.count; i++) {
+        const char *src = ((const char **)cli->sources.data)[i];
+        char *obj = NULL;
+
+        if (!compile_source_obj(src, cli, &obj)) {
+            ok = 0;
+            break;
+        }
+
+        if (!vector_push(objs, &obj)) {
+            vc_oom();
+            ok = 0;
+            unlink(obj);
+            free(obj);
+            break;
+        }
+    }
+
+    if (!ok) {
+        for (size_t j = 0; j < objs->count; j++) {
+            unlink(((char **)objs->data)[j]);
+            free(((char **)objs->data)[j]);
+        }
+        objs->count = 0;
+    }
+
+    return ok;
+}
+
+/* Allocate and populate the argument vector for the linker command. */
+static char **
+build_linker_args(const vector_t *objs, const vector_t *lib_dirs,
+                  const vector_t *libs, const char *output, int use_x86_64)
+{
+    const char *arch_flag = use_x86_64 ? "-m64" : "-m32";
+
+    /* calculate required argument count and detect overflow */
+    size_t argc = 0;
+    if (objs->count > SIZE_MAX - argc)
+        goto arg_overflow;
+    argc += objs->count;
+    if (lib_dirs->count > (SIZE_MAX - argc) / 2)
+        goto arg_overflow;
+    argc += lib_dirs->count * 2;
+    if (libs->count > (SIZE_MAX - argc) / 2)
+        goto arg_overflow;
+    argc += libs->count * 2;
+    if (5 > SIZE_MAX - argc)
+        goto arg_overflow;
+    argc += 5;
+
+    size_t n = argc + 1; /* plus NULL terminator */
+    if (n > SIZE_MAX / sizeof(char *))
+        goto arg_overflow;
+
+    char **argv = vc_alloc_or_exit(n * sizeof(char *));
+
+    size_t idx = 0;
+    argv[idx++] = (char *)get_cc();
+    argv[idx++] = (char *)arch_flag;
+    for (size_t i = 0; i < objs->count; i++)
+        argv[idx++] = ((char **)objs->data)[i];
+    for (size_t i = 0; i < lib_dirs->count; i++) {
+        argv[idx++] = "-L";
+        argv[idx++] = ((char **)lib_dirs->data)[i];
+    }
+    argv[idx++] = "-nostdlib";
+    for (size_t i = 0; i < libs->count; i++) {
+        argv[idx++] = "-l";
+        argv[idx++] = ((char **)libs->data)[i];
+    }
+    argv[idx++] = "-o";
+    argv[idx++] = (char *)output;
+    argv[idx] = NULL;
+    return argv;
+
+arg_overflow:
+    fprintf(stderr, "vc: argument vector too large\n");
+    return NULL;
+}
+
+/* Free argument vector returned by build_linker_args. */
+static void free_linker_args(char **argv)
+{
+    free(argv);
+}
+
+/* Construct and run the final cc link command. */
+static int run_link_command(const vector_t *objs, const vector_t *lib_dirs,
+                            const vector_t *libs, const char *output,
+                            int use_x86_64)
+{
+    char **argv = build_linker_args(objs, lib_dirs, libs, output,
+                                    use_x86_64);
+    if (!argv)
+        return 0;
+
+    int rc = command_run(argv);
+    free_linker_args(argv);
+    if (rc != 1) {
+        if (rc == 0)
+            fprintf(stderr, "linker failed\n");
+        else if (rc == -1)
+            fprintf(stderr, "linker terminated by signal\n");
+        return 0;
+    }
+    return 1;
+}
+
+/* Create entry stub and link all objects into the final executable. */
+static int build_and_link_objects(vector_t *objs, const cli_options_t *cli)
+{
+    char *stubobj = NULL;
+    int ok = create_startup_object(cli, cli->use_x86_64, &stubobj);
+    if (ok) {
+        if (!vector_push(objs, &stubobj)) {
+            vc_oom();
+            unlink(stubobj);
+            free(stubobj);
+            return 0;
+        }
+        ok = run_link_command(objs, &cli->lib_dirs, &cli->libs,
+                              cli->output, cli->use_x86_64);
+    }
+    return ok;
+}
+
+/* Compile all sources and link them into the final executable. */
+int link_sources(const cli_options_t *cli)
+{
+    vector_t objs;
+    int ok = compile_source_files(cli, &objs);
+
+    if (ok)
+        ok = build_and_link_objects(&objs, cli);
+
+    for (size_t i = 0; i < objs.count; i++) {
+        unlink(((char **)objs.data)[i]);
+        free(((char **)objs.data)[i]);
+    }
+    vector_free(&objs);
+
+    return ok;
+}
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -145,9 +145,10 @@ cc -Wl,--gc-sections -o "$DIR/temp_file_tests" compile_temp.o "$DIR/test_temp_fi
 rm -f compile_temp.o "$DIR/test_temp_file.o"
 # build compile_source_obj temp file failure test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -Dcompile_unit=test_compile_unit -ffunction-sections -fdata-sections -c src/compile.c -o compile_obj_fail.o
+cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -Dcompile_unit=test_compile_unit -ffunction-sections -fdata-sections -c src/compile_link.c -o compile_link_obj_fail.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_compile_obj_fail.c" -o "$DIR/test_compile_obj_fail.o"
-cc -Wl,--gc-sections -o "$DIR/compile_obj_fail" compile_obj_fail.o "$DIR/test_compile_obj_fail.o"
-rm -f compile_obj_fail.o "$DIR/test_compile_obj_fail.o"
+cc -Wl,--gc-sections -o "$DIR/compile_obj_fail" compile_obj_fail.o compile_link_obj_fail.o "$DIR/test_compile_obj_fail.o"
+rm -f compile_obj_fail.o compile_link_obj_fail.o "$DIR/test_compile_obj_fail.o"
 # build constant folding tests
 cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Dfree=test_free -c src/ir_core.c -o ir_fold.o
 cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Dfree=test_free -c src/util.c -o util_fold.o


### PR DESCRIPTION
## Summary
- extract link-related helpers into `compile_link.c`
- adjust prototypes in `compile.c`
- compile new file in Makefile
- update unit tests to link new object file

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686de71706688324ac7c623c1e4ee807