### PR TITLE
Refactor IR builder helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_link.c src/compile_tokenize.c sr
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c \
-           src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ast_dump.c src/label.c \
+           src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_cond.c src/preproc_file.c \
            src/preproc_file_io.c src/preproc_include.c src/preproc_path.c
 
@@ -23,7 +23,7 @@ EXTRA_SRC ?=
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_var.h include/semantic_init.h include/semantic_global.h \
-    include/ir_core.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
+    include/ir_core.h include/ir_builder.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/preproc_cond.h include/preproc_path.h include/parser_types.h include/parser_core.h include/startup.h
 PREFIX ?= /usr/local
@@ -163,6 +163,9 @@ src/error.o: src/error.c $(HDR)
 
 src/ir_core.o: src/ir_core.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/ir_core.c -o src/ir_core.o
+
+src/ir_builder.o: src/ir_builder.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/ir_builder.c -o src/ir_builder.o
 
 src/ir_global.o: src/ir_global.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/ir_global.c -o src/ir_global.o

--- a/include/ir_builder.h
+++ b/include/ir_builder.h
@@ -1,0 +1,27 @@
+#ifndef VC_IR_BUILDER_H
+#define VC_IR_BUILDER_H
+
+#include "ir_core.h"
+
+typedef struct alias_ent {
+    const char *name;
+    int set;
+    struct alias_ent *next;
+} alias_ent_t;
+
+/* Append a new blank instruction to the builder's list */
+ir_instr_t *append_instr(ir_builder_t *b);
+
+/* Allocate the next unique value id */
+int alloc_value_id(ir_builder_t *b);
+
+/* Remove instruction from the builder list */
+void remove_instr(ir_builder_t *b, ir_instr_t *ins);
+
+/* Get or create an alias set for a variable */
+int get_alias(ir_builder_t *b, const char *name);
+
+/* Insert a blank instruction after the given position */
+ir_instr_t *ir_insert_after(ir_builder_t *b, ir_instr_t *pos);
+
+#endif /* VC_IR_BUILDER_H */

--- a/src/ir_builder.c
+++ b/src/ir_builder.c
@@ -1,0 +1,115 @@
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <stdio.h>
+#include "ir_builder.h"
+
+/* Allocate and append a blank instruction */
+ir_instr_t *append_instr(ir_builder_t *b)
+{
+    ir_instr_t *ins = calloc(1, sizeof(*ins));
+    if (!ins)
+        return NULL;
+    ins->dest = -1;
+    ins->name = NULL;
+    ins->data = NULL;
+    ins->is_volatile = 0;
+    ins->is_restrict = 0;
+    ins->alias_set = 0;
+    ins->file = b->cur_file;
+    ins->line = b->cur_line;
+    ins->column = b->cur_column;
+    if (!b->head)
+        b->head = ins;
+    else
+        b->tail->next = ins;
+    b->tail = ins;
+    return ins;
+}
+
+/* Allocate the next value identifier */
+int alloc_value_id(ir_builder_t *b)
+{
+    if (b->next_value_id >= (size_t)INT_MAX) {
+        fprintf(stderr, "ir_core: too many values\n");
+        exit(1);
+    }
+    return (int)b->next_value_id++;
+}
+
+/* Remove an instruction from the list */
+void remove_instr(ir_builder_t *b, ir_instr_t *ins)
+{
+    if (!b || !ins)
+        return;
+    ir_instr_t *prev = NULL;
+    ir_instr_t *cur = b->head;
+    while (cur && cur != ins) {
+        prev = cur;
+        cur = cur->next;
+    }
+    if (!cur)
+        return;
+    if (prev)
+        prev->next = cur->next;
+    else
+        b->head = cur->next;
+    if (b->tail == cur)
+        b->tail = prev;
+    free(cur->name);
+    free(cur->data);
+    free(cur);
+}
+
+/* Lookup or create an alias set for the given variable name */
+int get_alias(ir_builder_t *b, const char *name)
+{
+    alias_ent_t *e = b->aliases;
+    while (e && strcmp(e->name, name) != 0)
+        e = e->next;
+    if (e)
+        return e->set;
+    e = malloc(sizeof(*e));
+    if (!e)
+        return 0;
+    e->name = name;
+    e->set = b->next_alias_id++;
+    e->next = b->aliases;
+    b->aliases = e;
+    return e->set;
+}
+
+/* Insert a blank instruction after `pos` */
+ir_instr_t *ir_insert_after(ir_builder_t *b, ir_instr_t *pos)
+{
+    if (!b)
+        return NULL;
+
+    ir_instr_t *ins = calloc(1, sizeof(*ins));
+    if (!ins)
+        return NULL;
+    ins->dest = -1;
+    ins->name = NULL;
+    ins->data = NULL;
+    ins->is_volatile = 0;
+    ins->is_restrict = 0;
+    ins->alias_set = 0;
+    ins->file = b->cur_file;
+    ins->line = b->cur_line;
+    ins->column = b->cur_column;
+
+    if (!pos) {
+        ins->next = b->head;
+        b->head = ins;
+        if (!b->tail)
+            b->tail = ins;
+    } else {
+        ins->next = pos->next;
+        pos->next = ins;
+        if (b->tail == pos)
+            b->tail = ins;
+    }
+
+    return ins;
+}
+


### PR DESCRIPTION
## Summary
- add `ir_builder.c` for basic list utilities
- declare list helper functions in new `ir_builder.h`
- use these helpers from `ir_core.c`
- compile `ir_builder.c` in the Makefile

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686e7f99c5308324862f5635c7f13c1f