### PR TITLE
Fix alignof expression cleanup

### DIFF
--- a/src/ast_expr.c
+++ b/src/ast_expr.c
@@ -498,6 +498,10 @@ void ast_free_expr(expr_t *expr)
         free(expr->offsetof_expr.members);
         free(expr->offsetof_expr.tag);
         break;
+    case EXPR_ALIGNOF:
+        if (!expr->alignof_expr.is_type)
+            ast_free_expr(expr->alignof_expr.expr);
+        break;
     case EXPR_CALL:
         for (size_t i = 0; i < expr->call.arg_count; i++)
             ast_free_expr(expr->call.args[i]);


### PR DESCRIPTION
## Summary
- handle EXPR_ALIGNOF in `ast_free_expr`
- free nested expression when alignof operand is an expression

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686e9373fd408324b9f22139b0c4deb5