### PR TITLE
Fix missing preproc macros header

### DIFF
--- a/src/preproc_file_io.c
+++ b/src/preproc_file_io.c
@@ -8,6 +8,7 @@
 
 #include "util.h"
 #include "preproc_file_io.h"
+#include "preproc_macros.h"
 #include "preproc_path.h"
 
 int include_stack_contains(vector_t *stack, const char *path)


### PR DESCRIPTION
## Summary
- include `preproc_macros.h` in `src/preproc_file_io.c`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686e9a53440883249209c62a63daa295