### PR TITLE
Fix process_file forward declaration location

### DIFF
--- a/src/preproc_include.c
+++ b/src/preproc_include.c
@@ -13,6 +13,11 @@
 #include "preproc_file_io.h"
 #include "preproc_path.h"
 
+/* external declaration from preproc_file.c */
+int process_file(const char *path, vector_t *macros, vector_t *conds,
+                 strbuf_t *out, const vector_t *incdirs, vector_t *stack,
+                 preproc_context_t *ctx, size_t idx);
+
 /* Return 1 if all conditional states on the stack are active */
 static int stack_active(vector_t *conds)
 {
@@ -79,10 +84,6 @@ static int process_include_file(const char *fname, const char *chosen,
     return ok;
 }
 
-/* external declaration from preproc_file.c */
-int process_file(const char *path, vector_t *macros, vector_t *conds,
-                 strbuf_t *out, const vector_t *incdirs, vector_t *stack,
-                 preproc_context_t *ctx, size_t idx);
 
 int handle_include(char *line, const char *dir, vector_t *macros,
                    vector_t *conds, strbuf_t *out,


### PR DESCRIPTION
## Summary
- move the `process_file` prototype to the top of `preproc_include.c`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686e9b4c14f883248fb3d7d71ee98635