### PR TITLE
Refactor compile stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc
 # Core compiler sources
 
-CORE_SRC = src/main.c src/compile.c src/compile_link.c src/compile_tokenize.c src/compile_parse.c src/compile_output.c src/startup.c src/command.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_expr_primary.c src/parser_expr_binary.c src/parser_init.c \
+CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/compile_tokenize.c src/compile_parse.c src/compile_output.c src/startup.c src/command.c src/cli.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_expr_primary.c src/parser_expr_binary.c src/parser_init.c \
            src/parser_decl.c src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
@@ -25,7 +25,7 @@ OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_const.h include/ir_memory.h include/ir_control.h include/ir_builder.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
-    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/preproc_cond.h include/preproc_path.h include/parser_types.h include/parser_core.h include/startup.h
+    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/preproc_cond.h include/preproc_path.h include/parser_types.h include/parser_core.h include/startup.h include/compile_stage.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man
@@ -54,6 +54,8 @@ src/main.o: src/main.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/main.c -o src/main.o
 src/compile.o: src/compile.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile.c -o src/compile.o
+src/compile_stage.o: src/compile_stage.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile_stage.c -o src/compile_stage.o
 src/compile_link.o: src/compile_link.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/compile_link.c -o src/compile_link.o
 src/compile_tokenize.o: src/compile_tokenize.c $(HDR)

--- a/include/compile_stage.h
+++ b/include/compile_stage.h
@@ -1,0 +1,20 @@
+/*
+ * Compilation pipeline orchestrator.
+ *
+ * Provides a helper for running all compilation stages for a single
+ * translation unit.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_COMPILE_STAGE_H
+#define VC_COMPILE_STAGE_H
+
+#include "cli.h"
+
+/* Run the full compilation pipeline on SOURCE. */
+int compile_pipeline(const char *source, const cli_options_t *cli,
+                     const char *output, int compile_obj);
+
+#endif /* VC_COMPILE_STAGE_H */

--- a/src/compile.c
+++ b/src/compile.c
@@ -45,6 +45,7 @@
 #include "preproc.h"
 #include "command.h"
 #include "compile.h"
+#include "compile_stage.h"
 #include "startup.h"
 
 /* Use binary mode for temporary files on platforms that require it */
@@ -59,396 +60,8 @@ extern const char *error_current_file;
 extern const char *error_current_function;
 extern char **environ;
 
-typedef struct compile_context {
-    char       *src_text;
-    token_t    *tokens;
-    size_t      tok_count;
-    char       *stdin_tmp;
-    vector_t    func_list_v;
-    vector_t    glob_list_v;
-    symtable_t  funcs;
-    symtable_t  globals;
-    ir_builder_t ir;
-    vector_t    deps;
-    size_t      pack_alignment;
-} compile_context_t;
-
-/* Stage implementations */
-int compile_tokenize_impl(const char *source, const cli_options_t *cli,
-                          const vector_t *incdirs,
-                          const vector_t *defines,
-                          const vector_t *undefines,
-                          char **out_src, token_t **out_toks,
-                          size_t *out_count, char **tmp_path,
-                          vector_t *deps);
-char *tokens_to_string(const token_t *toks, size_t count);
-int compile_parse_impl(token_t *toks, size_t count,
-                       vector_t *funcs_v, vector_t *globs_v,
-                       symtable_t *funcs);
-static int compile_semantic_impl(func_t **func_list, size_t fcount,
-                                 stmt_t **glob_list, size_t gcount,
-                                 symtable_t *funcs, symtable_t *globals,
-                                 ir_builder_t *ir);
-static int compile_optimize_impl(ir_builder_t *ir, const opt_config_t *cfg);
-int compile_output_impl(ir_builder_t *ir, const char *output,
-                        int dump_ir, int dump_asm, int use_x86_64,
-                        int compile, const cli_options_t *cli);
-const char *get_cc(void);
-const char *get_as(int intel);
-
-/* Stage helpers */
-static void compile_ctx_init(compile_context_t *ctx);
-static void compile_ctx_cleanup(compile_context_t *ctx);
-static int compile_tokenize_stage(compile_context_t *ctx, const char *source,
-                                  const cli_options_t *cli,
-                                  const vector_t *incdirs,
-                                  const vector_t *defines,
-                                  const vector_t *undefines);
-static int compile_parse_stage(compile_context_t *ctx);
-static int compile_semantic_stage(compile_context_t *ctx);
-static int compile_optimize_stage(compile_context_t *ctx,
-                                  const opt_config_t *cfg);
-static int compile_output_stage(compile_context_t *ctx, const char *output,
-                                int dump_ir, int dump_asm, int use_x86_64,
-                                int compile_obj, const cli_options_t *cli);
 char *vc_obj_name(const char *source);
-static int register_function_prototypes(func_t **func_list, size_t fcount,
-                                        symtable_t *funcs);
-static int check_global_decls(stmt_t **glob_list, size_t gcount,
-                              symtable_t *globals, ir_builder_t *ir);
-static int check_function_defs(func_t **func_list, size_t fcount,
-                               symtable_t *funcs, symtable_t *globals,
-                               ir_builder_t *ir);
 
-/* Compile one translation unit to the given output path. */
-int compile_unit(const char *source, const cli_options_t *cli,
-                 const char *output, int compile_obj);
-
-/* Compile one source file into a temporary object file. */
-int write_dep_file(const char *target, const vector_t *deps);
-
-/* Spawn a command and wait for completion */
-
-
-/* Create a temporary file and return its descriptor. */
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
-
-/* Assemble the template path for a temporary file. */
-static char *create_temp_template(const cli_options_t *cli,
-                                  const char *prefix);
-
-/* Wrapper around mkstemp that sets FD_CLOEXEC on the returned descriptor. */
-static int open_temp_file(char *tmpl);
-
-/* Run only the preprocessor stage on each input source. */
-int run_preprocessor(const cli_options_t *cli);
-
-int generate_dependencies(const cli_options_t *cli);
-
-/* Read source from stdin into a temporary file and run the preprocessor */
-
-/* Register function prototypes and definitions in the symbol table */
-static int register_function_prototypes(func_t **func_list, size_t fcount,
-                                        symtable_t *funcs)
-{
-    for (size_t i = 0; i < fcount; i++) {
-        symbol_t *existing = symtable_lookup(funcs, func_list[i]->name);
-        if (existing) {
-            int mismatch = existing->type != func_list[i]->return_type ||
-                           existing->param_count != func_list[i]->param_count ||
-                           existing->is_variadic != func_list[i]->is_variadic;
-            for (size_t j = 0; j < existing->param_count && !mismatch; j++)
-                if (existing->param_types[j] != func_list[i]->param_types[j])
-                    mismatch = 1;
-            if (mismatch) {
-                error_set(0, 0, error_current_file, error_current_function);
-                error_print("Semantic error");
-                return 0;
-            }
-            existing->is_prototype = 0;
-            if (func_list[i]->is_inline)
-                existing->is_inline = 1;
-            if (func_list[i]->is_noreturn)
-                existing->is_noreturn = 1;
-        } else {
-            size_t rsz = (func_list[i]->return_type == TYPE_STRUCT ||
-                          func_list[i]->return_type == TYPE_UNION) ? 4 : 0;
-            symtable_add_func(funcs, func_list[i]->name,
-                              func_list[i]->return_type,
-                              rsz,
-                              func_list[i]->param_elem_sizes,
-                              func_list[i]->param_types,
-                              func_list[i]->param_count,
-                              func_list[i]->is_variadic,
-                              0,
-                              func_list[i]->is_inline,
-                              func_list[i]->is_noreturn);
-        }
-    }
-    return 1;
-}
-
-/* Validate and emit IR for global declarations */
-static int check_global_decls(stmt_t **glob_list, size_t gcount,
-                              symtable_t *globals, ir_builder_t *ir)
-{
-    for (size_t i = 0; i < gcount; i++) {
-        if (!check_global(glob_list[i], globals, ir)) {
-            error_print("Semantic error");
-            return 0;
-        }
-    }
-    return 1;
-}
-
-/* Validate function definitions and build IR for each body */
-static int check_function_defs(func_t **func_list, size_t fcount,
-                               symtable_t *funcs, symtable_t *globals,
-                               ir_builder_t *ir)
-{
-    for (size_t i = 0; i < fcount; i++) {
-        if (!check_func(func_list[i], funcs, globals, ir)) {
-            error_print("Semantic error");
-            return 0;
-        }
-    }
-    return 1;
-}
-
-/* Perform semantic analysis and IR generation */
-static int compile_semantic_impl(func_t **func_list, size_t fcount,
-                            stmt_t **glob_list, size_t gcount,
-                            symtable_t *funcs, symtable_t *globals,
-                            ir_builder_t *ir)
-{
-    symtable_init(globals);
-    ir_builder_init(ir);
-    int ok = register_function_prototypes(func_list, fcount, funcs);
-    if (ok)
-        ok = check_global_decls(glob_list, gcount, globals, ir);
-    if (ok)
-        ok = check_function_defs(func_list, fcount, funcs, globals, ir);
-
-    return ok;
-}
-
-/* Run IR optimizations */
-static int compile_optimize_impl(ir_builder_t *ir, const opt_config_t *cfg)
-{
-    if (cfg)
-        opt_run(ir, cfg);
-    return 1;
-}
-
-/* Initialize compilation context */
-static void compile_ctx_init(compile_context_t *ctx)
-{
-    memset(ctx, 0, sizeof(*ctx));
-    vector_init(&ctx->func_list_v, sizeof(func_t *));
-    vector_init(&ctx->glob_list_v, sizeof(stmt_t *));
-    symtable_init(&ctx->funcs);
-    symtable_init(&ctx->globals);
-    ir_builder_init(&ctx->ir);
-    vector_init(&ctx->deps, sizeof(char *));
-    ctx->pack_alignment = 0;
-    semantic_set_pack(0);
-}
-
-/* Free resources allocated during compilation */
-static void compile_ctx_cleanup(compile_context_t *ctx)
-{
-    for (size_t i = 0; i < ctx->func_list_v.count; i++)
-        ast_free_func(((func_t **)ctx->func_list_v.data)[i]);
-    for (size_t i = 0; i < ctx->glob_list_v.count; i++)
-        ast_free_stmt(((stmt_t **)ctx->glob_list_v.data)[i]);
-    vector_free(&ctx->func_list_v);
-    vector_free(&ctx->glob_list_v);
-    symtable_free(&ctx->funcs);
-    ir_builder_free(&ctx->ir);
-    symtable_free(&ctx->globals);
-
-    free_string_vector(&ctx->deps);
-
-    lexer_free_tokens(ctx->tokens, ctx->tok_count);
-    free(ctx->src_text);
-}
-
-/* Run tokenization stage */
-static int compile_tokenize_stage(compile_context_t *ctx, const char *source,
-                                  const cli_options_t *cli,
-                                  const vector_t *incdirs,
-                                  const vector_t *defines,
-                                  const vector_t *undefines)
-{
-    return compile_tokenize_impl(source, cli, incdirs, defines, undefines,
-                                 &ctx->src_text,
-                                 &ctx->tokens, &ctx->tok_count,
-                                 &ctx->stdin_tmp, &ctx->deps);
-}
-
-/* Run parsing stage */
-static int compile_parse_stage(compile_context_t *ctx)
-{
-    int ok = compile_parse_impl(ctx->tokens, ctx->tok_count,
-                                &ctx->func_list_v, &ctx->glob_list_v,
-                                &ctx->funcs);
-    lexer_free_tokens(ctx->tokens, ctx->tok_count);
-    free(ctx->src_text);
-    ctx->tokens = NULL;
-    ctx->src_text = NULL;
-    ctx->tok_count = 0;
-    return ok;
-}
-
-/* Run semantic analysis stage */
-static int compile_semantic_stage(compile_context_t *ctx)
-{
-    return compile_semantic_impl((func_t **)ctx->func_list_v.data,
-                                 ctx->func_list_v.count,
-                                 (stmt_t **)ctx->glob_list_v.data,
-                                 ctx->glob_list_v.count,
-                                 &ctx->funcs, &ctx->globals,
-                                 &ctx->ir);
-}
-
-/* Run optimization stage */
-static int compile_optimize_stage(compile_context_t *ctx,
-                                  const opt_config_t *cfg)
-{
-    return compile_optimize_impl(&ctx->ir, cfg);
-}
-
-/* Run output stage */
-static int compile_output_stage(compile_context_t *ctx, const char *output,
-                                int dump_ir, int dump_asm, int use_x86_64,
-                                int compile_obj, const cli_options_t *cli)
-{
-    return compile_output_impl(&ctx->ir, output, dump_ir, dump_asm,
-                               use_x86_64, compile_obj, cli);
-}
-
-/* --- Helpers for compile_single_unit --- */
-static void setup_compile_context(compile_context_t *ctx, const char *source,
-                                  const cli_options_t *cli)
-{
-    error_current_file = source ? source : "";
-    error_current_function = NULL;
-    label_init();
-    codegen_set_export(cli->link);
-    codegen_set_debug(cli->debug || cli->emit_dwarf);
-    codegen_set_dwarf(cli->emit_dwarf);
-    compile_ctx_init(ctx);
-}
-
-static int run_tokenization(compile_context_t *ctx, const char *source,
-                            const cli_options_t *cli)
-{
-    int ok = compile_tokenize_stage(ctx, source, cli,
-                                    &cli->include_dirs,
-                                    &cli->defines,
-                                    &cli->undefines);
-    if (ok && cli->dump_tokens) {
-        char *text = tokens_to_string(ctx->tokens, ctx->tok_count);
-        if (text) {
-            printf("%s", text);
-            free(text);
-        }
-    }
-    return ok;
-}
-
-static int run_parsing(compile_context_t *ctx, const cli_options_t *cli)
-{
-    int ok = compile_parse_stage(ctx);
-    if (ok && cli->dump_ast) {
-        char *text = ast_to_string((func_t **)ctx->func_list_v.data,
-                                   ctx->func_list_v.count,
-                                   (stmt_t **)ctx->glob_list_v.data,
-                                   ctx->glob_list_v.count);
-        if (text) {
-            printf("%s", text);
-            free(text);
-        }
-    }
-    return ok;
-}
-
-static int run_semantics(compile_context_t *ctx)
-{
-    return compile_semantic_stage(ctx);
-}
-
-static int run_optimization_and_output(compile_context_t *ctx,
-                                       const cli_options_t *cli,
-                                       const char *output,
-                                       int compile_obj)
-{
-    int ok = compile_optimize_stage(ctx, &cli->opt_cfg);
-    if (ok)
-        ok = compile_output_stage(ctx, output, cli->dump_ir,
-                                  cli->dump_asm, cli->use_x86_64,
-                                  compile_obj, cli);
-    return ok;
-}
-
-/* Emit assembly or an object file */
-
-/* Compile a single translation unit */
-#ifndef UNIT_TESTING
-static int compile_single_unit(const char *source, const cli_options_t *cli,
-                               const char *output, int compile_obj)
-{
-    int ok = 1;
-    compile_context_t ctx;
-
-    setup_compile_context(&ctx, source, cli);
-
-    ok = run_tokenization(&ctx, source, cli);
-    if (ok && !cli->dump_tokens)
-        ok = run_parsing(&ctx, cli);
-    if (ok && !cli->dump_ast && !cli->dump_tokens)
-        ok = run_semantics(&ctx);
-    if (ok && !cli->dump_ast && !cli->dump_tokens)
-        ok = run_optimization_and_output(&ctx, cli, output, compile_obj);
-
-    if (ok && cli->deps)
-        ok = write_dep_file(output ? output : source, &ctx.deps);
-
-    compile_ctx_cleanup(&ctx);
-    semantic_global_cleanup();
-
-    if (ctx.stdin_tmp) {
-        unlink(ctx.stdin_tmp);
-        free(ctx.stdin_tmp);
-    }
-
-    label_reset();
-
-    return ok;
-}
-
-int compile_unit(const char *source, const cli_options_t *cli,
-                 const char *output, int compile_obj)
-{
-    if (!cli->link && compile_obj && cli->sources.count > 1) {
-        int ok = 1;
-        for (size_t i = 0; i < cli->sources.count && ok; i++) {
-            const char *src = ((const char **)cli->sources.data)[i];
-            char *obj = vc_obj_name(src);
-            if (!obj) {
-                vc_oom();
-                return 0;
-            }
-            ok = compile_single_unit(src, cli, obj, 1);
-            free(obj);
-        }
-        return ok;
-    }
-
-    return compile_single_unit(source, cli, output, compile_obj);
-}
-#endif /* !UNIT_TESTING */
 
 /*
  * Assemble mkstemp template path using cli->obj_dir (or the process
@@ -602,6 +215,29 @@ int generate_dependencies(const cli_options_t *cli)
     }
     return 0;
 }
+
+#ifndef UNIT_TESTING
+int compile_unit(const char *source, const cli_options_t *cli,
+                 const char *output, int compile_obj)
+{
+    if (!cli->link && compile_obj && cli->sources.count > 1) {
+        int ok = 1;
+        for (size_t i = 0; i < cli->sources.count && ok; i++) {
+            const char *src = ((const char **)cli->sources.data)[i];
+            char *obj = vc_obj_name(src);
+            if (!obj) {
+                vc_oom();
+                return 0;
+            }
+            ok = compile_pipeline(src, cli, obj, 1);
+            free(obj);
+        }
+        return ok;
+    }
+
+    return compile_pipeline(source, cli, output, compile_obj);
+}
+#endif /* !UNIT_TESTING */
 
 
 

--- a/src/compile_stage.c
+++ b/src/compile_stage.c
@@ -1,0 +1,305 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "util.h"
+#include "cli.h"
+#include "token.h"
+#include "parser.h"
+#include "parser_core.h"
+#include "ast_stmt.h"
+#include "vector.h"
+#include "symtable.h"
+#include "semantic.h"
+#include "error.h"
+#include "ir_core.h"
+#include "ast_dump.h"
+#include "opt.h"
+#include "codegen.h"
+#include "label.h"
+#include "preproc.h"
+#include "command.h"
+#include "compile_stage.h"
+#include "compile.h"
+
+extern const char *error_current_file;
+extern const char *error_current_function;
+
+/* Stage implementations from other compilation units */
+int compile_tokenize_impl(const char *source, const cli_options_t *cli,
+                          const vector_t *incdirs,
+                          const vector_t *defines,
+                          const vector_t *undefines,
+                          char **out_src, token_t **out_toks,
+                          size_t *out_count, char **tmp_path,
+                          vector_t *deps);
+char *tokens_to_string(const token_t *toks, size_t count);
+int compile_parse_impl(token_t *toks, size_t count,
+                       vector_t *funcs_v, vector_t *globs_v,
+                       symtable_t *funcs);
+static int compile_semantic_impl(func_t **func_list, size_t fcount,
+                                 stmt_t **glob_list, size_t gcount,
+                                 symtable_t *funcs, symtable_t *globals,
+                                 ir_builder_t *ir);
+static int compile_optimize_impl(ir_builder_t *ir, const opt_config_t *cfg);
+int compile_output_impl(ir_builder_t *ir, const char *output,
+                        int dump_ir, int dump_asm, int use_x86_64,
+                        int compile, const cli_options_t *cli);
+int write_dep_file(const char *target, const vector_t *deps);
+
+/* Compilation context used by the pipeline */
+typedef struct compile_context {
+    char       *src_text;
+    token_t    *tokens;
+    size_t      tok_count;
+    char       *stdin_tmp;
+    vector_t    func_list_v;
+    vector_t    glob_list_v;
+    symtable_t  funcs;
+    symtable_t  globals;
+    ir_builder_t ir;
+    vector_t    deps;
+    size_t      pack_alignment;
+} compile_context_t;
+
+/* --- Semantic analysis helpers --------------------------------------- */
+static int register_function_prototypes(func_t **func_list, size_t fcount,
+                                        symtable_t *funcs)
+{
+    for (size_t i = 0; i < fcount; i++) {
+        symbol_t *existing = symtable_lookup(funcs, func_list[i]->name);
+        if (existing) {
+            int mismatch = existing->type != func_list[i]->return_type ||
+                           existing->param_count != func_list[i]->param_count ||
+                           existing->is_variadic != func_list[i]->is_variadic;
+            for (size_t j = 0; j < existing->param_count && !mismatch; j++)
+                if (existing->param_types[j] != func_list[i]->param_types[j])
+                    mismatch = 1;
+            if (mismatch) {
+                error_set(0, 0, error_current_file, error_current_function);
+                error_print("Semantic error");
+                return 0;
+            }
+            existing->is_prototype = 0;
+            if (func_list[i]->is_inline)
+                existing->is_inline = 1;
+            if (func_list[i]->is_noreturn)
+                existing->is_noreturn = 1;
+        } else {
+            size_t rsz = (func_list[i]->return_type == TYPE_STRUCT ||
+                          func_list[i]->return_type == TYPE_UNION) ? 4 : 0;
+            symtable_add_func(funcs, func_list[i]->name,
+                              func_list[i]->return_type,
+                              rsz,
+                              func_list[i]->param_elem_sizes,
+                              func_list[i]->param_types,
+                              func_list[i]->param_count,
+                              func_list[i]->is_variadic,
+                              0,
+                              func_list[i]->is_inline,
+                              func_list[i]->is_noreturn);
+        }
+    }
+    return 1;
+}
+
+static int check_global_decls(stmt_t **glob_list, size_t gcount,
+                              symtable_t *globals, ir_builder_t *ir)
+{
+    for (size_t i = 0; i < gcount; i++) {
+        if (!check_global(glob_list[i], globals, ir)) {
+            error_print("Semantic error");
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int check_function_defs(func_t **func_list, size_t fcount,
+                               symtable_t *funcs, symtable_t *globals,
+                               ir_builder_t *ir)
+{
+    for (size_t i = 0; i < fcount; i++) {
+        if (!check_func(func_list[i], funcs, globals, ir)) {
+            error_print("Semantic error");
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int compile_semantic_impl(func_t **func_list, size_t fcount,
+                            stmt_t **glob_list, size_t gcount,
+                            symtable_t *funcs, symtable_t *globals,
+                            ir_builder_t *ir)
+{
+    symtable_init(globals);
+    ir_builder_init(ir);
+    int ok = register_function_prototypes(func_list, fcount, funcs);
+    if (ok)
+        ok = check_global_decls(glob_list, gcount, globals, ir);
+    if (ok)
+        ok = check_function_defs(func_list, fcount, funcs, globals, ir);
+
+    return ok;
+}
+
+static int compile_optimize_impl(ir_builder_t *ir, const opt_config_t *cfg)
+{
+    if (cfg)
+        opt_run(ir, cfg);
+    return 1;
+}
+
+/* --- Context management ----------------------------------------------- */
+static void compile_ctx_init(compile_context_t *ctx)
+{
+    memset(ctx, 0, sizeof(*ctx));
+    vector_init(&ctx->func_list_v, sizeof(func_t *));
+    vector_init(&ctx->glob_list_v, sizeof(stmt_t *));
+    symtable_init(&ctx->funcs);
+    symtable_init(&ctx->globals);
+    ir_builder_init(&ctx->ir);
+    vector_init(&ctx->deps, sizeof(char *));
+    ctx->pack_alignment = 0;
+    semantic_set_pack(0);
+}
+
+static void compile_ctx_cleanup(compile_context_t *ctx)
+{
+    for (size_t i = 0; i < ctx->func_list_v.count; i++)
+        ast_free_func(((func_t **)ctx->func_list_v.data)[i]);
+    for (size_t i = 0; i < ctx->glob_list_v.count; i++)
+        ast_free_stmt(((stmt_t **)ctx->glob_list_v.data)[i]);
+    vector_free(&ctx->func_list_v);
+    vector_free(&ctx->glob_list_v);
+    symtable_free(&ctx->funcs);
+    ir_builder_free(&ctx->ir);
+    symtable_free(&ctx->globals);
+
+    free_string_vector(&ctx->deps);
+
+    lexer_free_tokens(ctx->tokens, ctx->tok_count);
+    free(ctx->src_text);
+}
+
+/* --- Stage wrappers ---------------------------------------------------- */
+static int compile_tokenize_stage(compile_context_t *ctx, const char *source,
+                                  const cli_options_t *cli,
+                                  const vector_t *incdirs,
+                                  const vector_t *defines,
+                                  const vector_t *undefines)
+{
+    return compile_tokenize_impl(source, cli, incdirs, defines, undefines,
+                                 &ctx->src_text,
+                                 &ctx->tokens, &ctx->tok_count,
+                                 &ctx->stdin_tmp, &ctx->deps);
+}
+
+static int compile_parse_stage(compile_context_t *ctx)
+{
+    int ok = compile_parse_impl(ctx->tokens, ctx->tok_count,
+                                &ctx->func_list_v, &ctx->glob_list_v,
+                                &ctx->funcs);
+    lexer_free_tokens(ctx->tokens, ctx->tok_count);
+    free(ctx->src_text);
+    ctx->tokens = NULL;
+    ctx->src_text = NULL;
+    ctx->tok_count = 0;
+    return ok;
+}
+
+static int compile_semantic_stage(compile_context_t *ctx)
+{
+    return compile_semantic_impl((func_t **)ctx->func_list_v.data,
+                                 ctx->func_list_v.count,
+                                 (stmt_t **)ctx->glob_list_v.data,
+                                 ctx->glob_list_v.count,
+                                 &ctx->funcs, &ctx->globals,
+                                 &ctx->ir);
+}
+
+static int compile_optimize_stage(compile_context_t *ctx,
+                                  const opt_config_t *cfg)
+{
+    return compile_optimize_impl(&ctx->ir, cfg);
+}
+
+static int compile_output_stage(compile_context_t *ctx, const char *output,
+                                int dump_ir, int dump_asm, int use_x86_64,
+                                int compile_obj, const cli_options_t *cli)
+{
+    return compile_output_impl(&ctx->ir, output, dump_ir, dump_asm,
+                               use_x86_64, compile_obj, cli);
+}
+
+/* --- Public API ------------------------------------------------------- */
+int compile_pipeline(const char *source, const cli_options_t *cli,
+                     const char *output, int compile_obj)
+{
+    int ok = 1;
+    compile_context_t ctx;
+
+    error_current_file = source ? source : "";
+    error_current_function = NULL;
+    label_init();
+    codegen_set_export(cli->link);
+    codegen_set_debug(cli->debug || cli->emit_dwarf);
+    codegen_set_dwarf(cli->emit_dwarf);
+    compile_ctx_init(&ctx);
+
+    ok = compile_tokenize_stage(&ctx, source, cli,
+                                &cli->include_dirs,
+                                &cli->defines,
+                                &cli->undefines);
+    if (ok && cli->dump_tokens) {
+        char *text = tokens_to_string(ctx.tokens, ctx.tok_count);
+        if (text) {
+            printf("%s", text);
+            free(text);
+        }
+    }
+
+    if (ok && !cli->dump_tokens) {
+        ok = compile_parse_stage(&ctx);
+        if (ok && cli->dump_ast) {
+            char *text = ast_to_string((func_t **)ctx.func_list_v.data,
+                                       ctx.func_list_v.count,
+                                       (stmt_t **)ctx.glob_list_v.data,
+                                       ctx.glob_list_v.count);
+            if (text) {
+                printf("%s", text);
+                free(text);
+            }
+        }
+    }
+
+    if (ok && !cli->dump_ast && !cli->dump_tokens)
+        ok = compile_semantic_stage(&ctx);
+
+    if (ok && !cli->dump_ast && !cli->dump_tokens) {
+        ok = compile_optimize_stage(&ctx, &cli->opt_cfg);
+        if (ok)
+            ok = compile_output_stage(&ctx, output, cli->dump_ir,
+                                      cli->dump_asm, cli->use_x86_64,
+                                      compile_obj, cli);
+    }
+
+    if (ok && cli->deps)
+        ok = write_dep_file(output ? output : source, &ctx.deps);
+
+    compile_ctx_cleanup(&ctx);
+    semantic_global_cleanup();
+
+    if (ctx.stdin_tmp) {
+        unlink(ctx.stdin_tmp);
+        free(ctx.stdin_tmp);
+    }
+
+    label_reset();
+
+    return ok;
+}
+


### PR DESCRIPTION
## Summary
- add a new `compile_stage` module that runs the full pipeline
- remove stage helpers from `compile.c` and use the new orchestrator
- update Makefile sources and headers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ea1df63b08324b365dd20035bcb73