### PR TITLE
Refactor preprocessor directive handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/codegen_float.c src/codegen_complex.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
            src/preproc_macros.c src/preproc_expr.c src/preproc_cond.c src/preproc_file.c \
-           src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_path.c
+           src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c
 
 # Optional optimization sources
 OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_licm.c src/opt_dce.c src/opt_inline.c src/opt_unreachable.c src/opt_alias.c
@@ -26,7 +26,7 @@ OBJ := $(SRC:.c=.o)
 HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_const.h include/ir_memory.h include/ir_control.h include/ir_builder.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
-    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_expr.h include/preproc_cond.h include/preproc_path.h include/parser_types.h include/parser_core.h include/startup.h include/compile_stage.h
+    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_includes.h include/preproc_expr.h include/preproc_cond.h include/preproc_path.h include/parser_types.h include/parser_core.h include/startup.h include/compile_stage.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man
@@ -264,6 +264,8 @@ src/preproc_file_io.o: src/preproc_file_io.c $(HDR)
 
 src/preproc_include.o: src/preproc_include.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_include.c -o src/preproc_include.o
+src/preproc_includes.o: src/preproc_includes.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_includes.c -o src/preproc_includes.o
 src/preproc_path.o: src/preproc_path.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_path.c -o src/preproc_path.o
 

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -50,7 +50,5 @@ int process_line(char *line, const char *dir, vector_t *macros,
 int process_file(const char *path, vector_t *macros, vector_t *conds,
                  strbuf_t *out, const vector_t *incdirs, vector_t *stack,
                  preproc_context_t *ctx, size_t idx);
-int add_macro(const char *name, const char *value, vector_t *params,
-              int variadic, vector_t *macros);
 
 #endif /* VC_PREPROC_FILE_H */

--- a/include/preproc_includes.h
+++ b/include/preproc_includes.h
@@ -1,0 +1,27 @@
+/*
+ * Directive wrappers for include and related directives.
+ */
+
+#ifndef VC_PREPROC_INCLUDES_H
+#define VC_PREPROC_INCLUDES_H
+
+#include "vector.h"
+#include "strbuf.h"
+#include "preproc_file.h"
+
+int handle_include_directive(char *line, const char *dir, vector_t *macros,
+                             vector_t *conds, strbuf_t *out,
+                             const vector_t *incdirs, vector_t *stack,
+                             preproc_context_t *ctx);
+
+int handle_line_directive(char *line, const char *dir, vector_t *macros,
+                          vector_t *conds, strbuf_t *out,
+                          const vector_t *incdirs, vector_t *stack,
+                          preproc_context_t *ctx);
+
+int handle_pragma_directive(char *line, const char *dir, vector_t *macros,
+                            vector_t *conds, strbuf_t *out,
+                            const vector_t *incdirs, vector_t *stack,
+                            preproc_context_t *ctx);
+
+#endif /* VC_PREPROC_INCLUDES_H */

--- a/include/preproc_macros.h
+++ b/include/preproc_macros.h
@@ -14,6 +14,7 @@
 
 #include "vector.h"
 #include "strbuf.h"
+#include "preproc_file.h"
 
 /*
  * Stored macro definition.
@@ -50,5 +51,18 @@ void preproc_set_location(const char *file, size_t line, size_t column);
 
 /* Set the current function name for __func__ expansion */
 void preproc_set_function(const char *name);
+
+/* Add a macro definition to the table */
+int add_macro(const char *name, const char *value, vector_t *params,
+              int variadic, vector_t *macros);
+
+/* Handle a '#define' directive when processing a line */
+int handle_define(char *line, vector_t *macros, vector_t *conds);
+
+/* Wrapper used by process_line for '#define' */
+int handle_define_directive(char *line, const char *dir, vector_t *macros,
+                            vector_t *conds, strbuf_t *out,
+                            const vector_t *incdirs, vector_t *stack,
+                            preproc_context_t *ctx);
 
 #endif /* VC_PREPROC_MACROS_H */

--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -1,0 +1,162 @@
+#define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "preproc_includes.h"
+#include "preproc_include.h"
+#include "preproc_cond.h"
+#include "preproc_file_io.h"
+#include "preproc_path.h"
+#include "semantic_global.h"
+#include "util.h"
+#include "vector.h"
+#include "strbuf.h"
+
+/* Advance P past spaces and tabs and return the updated pointer */
+static char *skip_ws(char *p)
+{
+    while (*p == ' ' || *p == '\t')
+        p++;
+    return p;
+}
+
+/* Return 1 if all conditional states on the stack are active */
+static int stack_active(vector_t *conds)
+{
+    for (size_t i = 0; i < conds->count; i++) {
+        cond_state_t *c = &((cond_state_t *)conds->data)[i];
+        if (!c->taking)
+            return 0;
+    }
+    return 1;
+}
+
+/* Wrapper used by directive handlers */
+static int is_active(vector_t *conds)
+{
+    return stack_active(conds);
+}
+
+/* Append a #pragma directive to the output when active */
+static int handle_pragma(char *line, vector_t *conds, strbuf_t *out)
+{
+    if (is_active(conds)) {
+        if (strbuf_append(out, line) != 0)
+            return 0;
+        if (strbuf_append(out, "\n") != 0)
+            return 0;
+    }
+    return 1;
+}
+
+int handle_include_directive(char *line, const char *dir, vector_t *macros,
+                             vector_t *conds, strbuf_t *out,
+                             const vector_t *incdirs, vector_t *stack,
+                             preproc_context_t *ctx)
+{
+    return handle_include(line, dir, macros, conds, out, incdirs, stack, ctx);
+}
+
+int handle_line_directive(char *line, const char *dir, vector_t *macros,
+                          vector_t *conds, strbuf_t *out,
+                          const vector_t *incdirs, vector_t *stack,
+                          preproc_context_t *ctx)
+{
+    (void)dir; (void)macros; (void)incdirs; (void)stack; (void)ctx;
+    char *p = line + 5;
+    p = skip_ws(p);
+    errno = 0;
+    char *end;
+    long long val = strtoll(p, &end, 10);
+    if (p == end || errno != 0 || val > INT_MAX || val <= 0) {
+        fprintf(stderr, "Invalid line number in #line directive\n");
+        return 0;
+    }
+    p = end;
+    int lineno = (int)val;
+    p = skip_ws(p);
+    char *fname = NULL;
+    if (*p == '"') {
+        p++;
+        char *fstart = p;
+        while (*p && *p != '"')
+            p++;
+        if (*p == '"')
+            fname = vc_strndup(fstart, (size_t)(p - fstart));
+    }
+    if (is_active(conds)) {
+        if (strbuf_appendf(out, "# %d", lineno) < 0) {
+            free(fname);
+            return 0;
+        }
+        if (fname && strbuf_appendf(out, " \"%s\"", fname) < 0) {
+            free(fname);
+            return 0;
+        }
+        if (strbuf_append(out, "\n") < 0) {
+            free(fname);
+            return 0;
+        }
+    }
+    free(fname);
+    return 1;
+}
+
+int handle_pragma_directive(char *line, const char *dir, vector_t *macros,
+                            vector_t *conds, strbuf_t *out,
+                            const vector_t *incdirs, vector_t *stack,
+                            preproc_context_t *ctx)
+{
+    (void)dir; (void)macros; (void)incdirs;
+    char *p = line + 7; /* skip '#pragma' */
+    p = skip_ws(p);
+    if (strncmp(p, "once", 4) == 0) {
+        p += 4;
+        p = skip_ws(p);
+        if (*p == '\0' && stack->count) {
+            const include_entry_t *e =
+                &((include_entry_t *)stack->data)[stack->count - 1];
+            const char *cur = e->path;
+            if (!pragma_once_add(ctx, cur))
+                return 0;
+        }
+    } else if (strncmp(p, "pack", 4) == 0) {
+        p += 4;
+        p = skip_ws(p);
+        if (strncmp(p, "(push", 5) == 0) {
+            p += 5; /* after '(push' */
+            if (*p == ',')
+                p++;
+            p = skip_ws(p);
+            errno = 0;
+            char *end;
+            long val = strtol(p, &end, 10);
+            if (errno == 0 && end != p) {
+                p = end;
+                p = skip_ws(p);
+                if (*p == ')') {
+                    vector_push(&ctx->pack_stack, &ctx->pack_alignment);
+                    ctx->pack_alignment = (size_t)val;
+                    semantic_set_pack(ctx->pack_alignment);
+                }
+            }
+        } else if (strncmp(p, "(pop)", 5) == 0) {
+            if (ctx->pack_stack.count) {
+                ctx->pack_alignment =
+                    ((size_t *)ctx->pack_stack.data)[ctx->pack_stack.count - 1];
+                ctx->pack_stack.count--;
+            } else {
+                ctx->pack_alignment = 0;
+            }
+            semantic_set_pack(ctx->pack_alignment);
+        }
+        (void)stack;
+        return 1; /* do not emit pragma line */
+    }
+    (void)stack;
+    return handle_pragma(line, conds, out);
+}
+

--- a/src/preproc_macros.c
+++ b/src/preproc_macros.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "preproc_macros.h"
+#include "preproc_cond.h"
 #include <stdio.h>
 #include "util.h"
 #include "vector.h"
@@ -563,5 +564,172 @@ void remove_macro(vector_t *macros, const char *name)
             i++;
         }
     }
+}
+
+/* Advance P past spaces and tabs and return the updated pointer */
+static char *skip_ws(char *p)
+{
+    while (*p == ' ' || *p == '\t')
+        p++;
+    return p;
+}
+
+/* Return 1 if all conditional states on the stack are active */
+static int stack_active(vector_t *conds)
+{
+    for (size_t i = 0; i < conds->count; i++) {
+        cond_state_t *c = &((cond_state_t *)conds->data)[i];
+        if (!c->taking)
+            return 0;
+    }
+    return 1;
+}
+
+/* Wrapper used by directive handlers */
+static int is_active(vector_t *conds)
+{
+    return stack_active(conds);
+}
+
+/* Free a vector of parameter names */
+static void free_param_vector(vector_t *v)
+{
+    for (size_t i = 0; i < v->count; i++)
+        free(((char **)v->data)[i]);
+    vector_free(v);
+}
+
+/* Split a comma separated list of parameters and append trimmed names */
+static int tokenize_param_list(char *list, vector_t *out)
+{
+    char *tok; char *sp;
+    tok = strtok_r(list, ",", &sp);
+    while (tok) {
+        while (*tok == ' ' || *tok == '\t')
+            tok++;
+        char *end = tok + strlen(tok);
+        while (end > tok && (end[-1] == ' ' || end[-1] == '\t'))
+            end--;
+        char *dup = vc_strndup(tok, (size_t)(end - tok));
+        if (!vector_push(out, &dup)) {
+            free(dup);
+            for (size_t i = 0; i < out->count; i++)
+                free(((char **)out->data)[i]);
+            vector_free(out);
+            vector_init(out, sizeof(char *));
+            return 0;
+        }
+        tok = strtok_r(NULL, ",", &sp);
+    }
+    return 1;
+}
+
+/* Parse a comma separated parameter list starting at *p */
+static char *parse_macro_params(char *p, vector_t *out, int *variadic)
+{
+    vector_init(out, sizeof(char *));
+    if (variadic)
+        *variadic = 0;
+    if (*p == '(') {
+        *p++ = '\0';
+        char *start = p;
+        while (*p && *p != ')')
+            p++;
+        if (*p == ')') {
+            char *plist = vc_strndup(start, (size_t)(p - start));
+            if (!tokenize_param_list(plist, out)) {
+                free(plist);
+                free_param_vector(out);
+                return NULL;
+            }
+            free(plist);
+            p++;
+        } else {
+            p = start - 1;
+            *p = '(';
+            free_param_vector(out);
+            return NULL;
+        }
+    } else if (*p) {
+        *p++ = '\0';
+    }
+    if (variadic && out->count) {
+        size_t last = out->count - 1;
+        char *name = ((char **)out->data)[last];
+        if (strcmp(name, "...") == 0) {
+            *variadic = 1;
+            free(name);
+            out->count--;
+        }
+    }
+    return p;
+}
+
+int add_macro(const char *name, const char *value, vector_t *params,
+              int variadic, vector_t *macros)
+{
+    macro_t m;
+    m.name = vc_strdup(name);
+    m.value = NULL;
+    vector_init(&m.params, sizeof(char *));
+    for (size_t i = 0; i < params->count; i++) {
+        char *pname = ((char **)params->data)[i];
+        if (!vector_push(&m.params, &pname)) {
+            free(pname);
+            for (size_t j = i + 1; j < params->count; j++)
+                free(((char **)params->data)[j]);
+            vector_free(params);
+            macro_free(&m);
+            vc_oom();
+            return 0;
+        }
+    }
+    vector_free(params);
+    m.variadic = variadic;
+    m.value = vc_strdup(value);
+    if (!vector_push(macros, &m)) {
+        for (size_t i = 0; i < m.params.count; i++)
+            free(((char **)m.params.data)[i]);
+        m.params.count = 0;
+        macro_free(&m);
+        vc_oom();
+        return 0;
+    }
+    return 1;
+}
+
+int handle_define(char *line, vector_t *macros, vector_t *conds)
+{
+    char *n = line + 7;
+    n = skip_ws(n);
+    char *name = n;
+    while (*n && !isspace((unsigned char)*n) && *n != '(')
+        n++;
+    vector_t params;
+    int variadic = 0;
+    n = parse_macro_params(n, &params, &variadic);
+    if (!n) {
+        free_param_vector(&params);
+        fprintf(stderr, "Missing ')' in macro definition\n");
+        return 0;
+    }
+    n = skip_ws(n);
+    char *val = *n ? n : "";
+    int ok = 1;
+    if (is_active(conds)) {
+        ok = add_macro(name, val, &params, variadic, macros);
+    } else {
+        free_param_vector(&params);
+    }
+    return ok;
+}
+
+int handle_define_directive(char *line, const char *dir, vector_t *macros,
+                            vector_t *conds, strbuf_t *out,
+                            const vector_t *incdirs, vector_t *stack,
+                            preproc_context_t *ctx)
+{
+    (void)dir; (void)out; (void)incdirs; (void)stack; (void)ctx;
+    return handle_define(line, macros, conds);
 }
 


### PR DESCRIPTION
## Summary
- move macro definition parsing into `preproc_macros.c`
- extract include/pragma/line directives into new `preproc_includes.c`
- expose new helpers via `preproc_includes.h`
- update build files and headers

## Testing
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_686ee3a6542c8324a0292e9e68bb07a6