### PR TITLE
Refactor expression parser helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc
 # Core compiler sources
 
-CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/compile_tokenize.c src/compile_parse.c src/compile_output.c src/startup.c src/command.c src/cli.c src/cli_env.c src/cli_opts.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_expr_primary.c src/parser_expr_binary.c src/parser_init.c \
+CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/compile_tokenize.c src/compile_parse.c src/compile_output.c src/startup.c src/command.c src/cli.c src/cli_env.c src/cli_opts.c src/lexer.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_expr_primary.c src/parser_expr_binary.c src/parser_expr_ops.c src/parser_expr_literal.c src/parser_init.c \
            src/parser_decl_var.c src/parser_decl_struct.c src/parser_decl_enum.c \
            src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
@@ -115,7 +115,13 @@ src/parser_expr_primary.o: src/parser_expr_primary.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/parser_expr_primary.c -o src/parser_expr_primary.o
 
 src/parser_expr_binary.o: src/parser_expr_binary.c $(HDR)
-	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/parser_expr_binary.c -o src/parser_expr_binary.o
+		$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/parser_expr_binary.c -o src/parser_expr_binary.o
+
+src/parser_expr_ops.o: src/parser_expr_ops.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/parser_expr_ops.c -o src/parser_expr_ops.o
+
+src/parser_expr_literal.o: src/parser_expr_literal.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/parser_expr_literal.c -o src/parser_expr_literal.o
 
 src/parser_init.o: src/parser_init.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/parser_init.c -o src/parser_init.o

--- a/include/parser_expr_literal.h
+++ b/include/parser_expr_literal.h
@@ -1,0 +1,10 @@
+#ifndef VC_PARSER_EXPR_LITERAL_H
+#define VC_PARSER_EXPR_LITERAL_H
+
+#include "parser.h"
+#include "parser_types.h"
+#include "ast_expr.h"
+
+expr_t *parse_literal(parser_t *p);
+
+#endif /* VC_PARSER_EXPR_LITERAL_H */

--- a/include/parser_expr_ops.h
+++ b/include/parser_expr_ops.h
@@ -1,0 +1,14 @@
+#ifndef VC_PARSER_EXPR_OPS_H
+#define VC_PARSER_EXPR_OPS_H
+
+#include "parser.h"
+#include "parser_types.h"
+#include "ast_expr.h"
+
+expr_t *parse_prefix_expr(parser_t *p);
+expr_t *parse_cast(parser_t *p);
+int parse_type(parser_t *p, type_kind_t *out_type, size_t *out_size,
+               size_t *elem_size);
+expr_t *parse_postfix_expr(parser_t *p);
+
+#endif /* VC_PARSER_EXPR_OPS_H */

--- a/include/parser_expr_primary.h
+++ b/include/parser_expr_primary.h
@@ -7,5 +7,7 @@
 
 /* Parse a primary expression including unary operators */
 expr_t *parse_primary(parser_t *p);
+/* Helper used by postfix parser */
+expr_t *parse_base_term(parser_t *p);
 
 #endif /* VC_PARSER_EXPR_PRIMARY_H */

--- a/src/parser_expr_literal.c
+++ b/src/parser_expr_literal.c
@@ -1,0 +1,84 @@
+#include <stdlib.h>
+#include <string.h>
+#include "parser.h"
+#include "parser_types.h"
+#include "ast_expr.h"
+#include "util.h"
+#include "parser_expr_literal.h"
+
+/* Parse a possibly concatenated string literal. */
+static expr_t *parse_string_literal(parser_t *p)
+{
+    token_t *tok = peek(p);
+    if (!tok || (tok->type != TOK_STRING && tok->type != TOK_WIDE_STRING))
+        return NULL;
+
+    int is_wide = (tok->type == TOK_WIDE_STRING);
+    size_t line = tok->line;
+    size_t column = tok->column;
+
+    size_t len = strlen(tok->lexeme);
+    char *buf = vc_strdup(tok->lexeme);
+    if (!buf)
+        return NULL;
+    p->pos++;
+
+    while (p->pos < p->count) {
+        token_t *next = &p->tokens[p->pos];
+        if (next->type != tok->type)
+            break;
+        size_t nlen = strlen(next->lexeme);
+        buf = vc_realloc_or_exit(buf, len + nlen + 1);
+        memcpy(buf + len, next->lexeme, nlen + 1);
+        len += nlen;
+        p->pos++;
+    }
+
+    expr_t *res = is_wide ?
+        ast_make_wstring(buf, line, column) :
+        ast_make_string(buf, line, column);
+    free(buf);
+    return res;
+}
+
+expr_t *parse_literal(parser_t *p)
+{
+    token_t *tok = peek(p);
+    if (!tok)
+        return NULL;
+    if (tok->type == TOK_NUMBER) {
+        size_t save = p->pos;
+        token_t *num_tok = tok;
+        p->pos++; /* consume number */
+        token_t *op_tok = peek(p);
+        if (op_tok && (op_tok->type == TOK_PLUS || op_tok->type == TOK_MINUS)) {
+            p->pos++; /* consume +/- */
+            token_t *imag_tok = peek(p);
+            if (imag_tok && imag_tok->type == TOK_IMAG_NUMBER) {
+                p->pos++; /* consume imag */
+                double real = strtod(num_tok->lexeme, NULL);
+                double imag = strtod(imag_tok->lexeme, NULL);
+                if (op_tok->type == TOK_MINUS)
+                    imag = -imag;
+                return ast_make_complex_literal(real, imag,
+                                               num_tok->line, num_tok->column);
+            }
+        }
+        p->pos = save;
+    }
+    if (match(p, TOK_IMAG_NUMBER)) {
+        double imag = strtod(tok->lexeme, NULL);
+        return ast_make_complex_literal(0.0, imag, tok->line, tok->column);
+    }
+    if (match(p, TOK_NUMBER))
+        return ast_make_number(tok->lexeme, tok->line, tok->column);
+    expr_t *s = parse_string_literal(p);
+    if (s)
+        return s;
+    if (match(p, TOK_CHAR))
+        return ast_make_char(tok->lexeme[0], tok->line, tok->column);
+    if (match(p, TOK_WIDE_CHAR))
+        return ast_make_wchar(tok->lexeme[0], tok->line, tok->column);
+    return NULL;
+}
+

--- a/src/parser_expr_ops.c
+++ b/src/parser_expr_ops.c
@@ -1,0 +1,297 @@
+#include <stdlib.h>
+#include <string.h>
+#include "parser.h"
+#include "parser_types.h"
+#include "ast_expr.h"
+#include "util.h"
+#include "error.h"
+#include "parser_expr_primary.h"
+#include "parser_expr_ops.h"
+
+/* --- Postfix operators --- */
+
+static expr_t *parse_index_op(parser_t *p, expr_t *base)
+{
+    if (!match(p, TOK_LBRACKET))
+        return base;
+
+    token_t *lb = &p->tokens[p->pos - 1];
+    expr_t *idx = parser_parse_expr(p);
+    if (!idx || !match(p, TOK_RBRACKET)) {
+        ast_free_expr(base);
+        ast_free_expr(idx);
+        return NULL;
+    }
+
+    return ast_make_index(base, idx, lb->line, lb->column);
+}
+
+static expr_t *parse_member_op(parser_t *p, expr_t *base)
+{
+    if (!match(p, TOK_DOT) && !match(p, TOK_ARROW))
+        return base;
+
+    int via_ptr = (p->tokens[p->pos - 1].type == TOK_ARROW);
+    token_t *id = peek(p);
+    if (!id || id->type != TOK_IDENT) {
+        ast_free_expr(base);
+        return NULL;
+    }
+    p->pos++;
+    return ast_make_member(base, id->lexeme, via_ptr, id->line, id->column);
+}
+
+static expr_t *parse_postincdec(parser_t *p, expr_t *base)
+{
+    if (match(p, TOK_INC)) {
+        token_t *tok = &p->tokens[p->pos - 1];
+        return ast_make_unary(UNOP_POSTINC, base, tok->line, tok->column);
+    }
+    if (match(p, TOK_DEC)) {
+        token_t *tok = &p->tokens[p->pos - 1];
+        return ast_make_unary(UNOP_POSTDEC, base, tok->line, tok->column);
+    }
+    return base;
+}
+
+static expr_t *apply_postfix_ops(parser_t *p, expr_t *base)
+{
+    while (1) {
+        expr_t *next = base;
+
+        next = parse_index_op(p, next);
+        if (!next)
+            return NULL;
+        if (next != base) {
+            base = next;
+            continue;
+        }
+
+        next = parse_member_op(p, next);
+        if (!next)
+            return NULL;
+        if (next != base) {
+            base = next;
+            continue;
+        }
+
+        next = parse_postincdec(p, next);
+        if (!next)
+            return NULL;
+        if (next != base) {
+            base = next;
+            continue;
+        }
+
+        break;
+    }
+    return base;
+}
+
+expr_t *parse_postfix_expr(parser_t *p)
+{
+    expr_t *base = parse_base_term(p);
+    if (!base)
+        return NULL;
+    return apply_postfix_ops(p, base);
+}
+
+/* --- Prefix operators --- */
+
+static expr_t *parse_preinc(parser_t *p)
+{
+    token_t *op_tok = &p->tokens[p->pos - 1];
+    expr_t *op = parse_prefix_expr(p);
+    if (!op)
+        return NULL;
+    return ast_make_unary(UNOP_PREINC, op, op_tok->line, op_tok->column);
+}
+
+static expr_t *parse_predec(parser_t *p)
+{
+    token_t *op_tok = &p->tokens[p->pos - 1];
+    expr_t *op = parse_prefix_expr(p);
+    if (!op)
+        return NULL;
+    return ast_make_unary(UNOP_PREDEC, op, op_tok->line, op_tok->column);
+}
+
+static expr_t *parse_deref(parser_t *p)
+{
+    token_t *op_tok = &p->tokens[p->pos - 1];
+    expr_t *op = parse_prefix_expr(p);
+    if (!op)
+        return NULL;
+    return ast_make_unary(UNOP_DEREF, op, op_tok->line, op_tok->column);
+}
+
+static expr_t *parse_addr(parser_t *p)
+{
+    token_t *op_tok = &p->tokens[p->pos - 1];
+    expr_t *op = parse_prefix_expr(p);
+    if (!op)
+        return NULL;
+    return ast_make_unary(UNOP_ADDR, op, op_tok->line, op_tok->column);
+}
+
+static expr_t *parse_neg(parser_t *p)
+{
+    token_t *op_tok = &p->tokens[p->pos - 1];
+    expr_t *op = parse_prefix_expr(p);
+    if (!op)
+        return NULL;
+    return ast_make_unary(UNOP_NEG, op, op_tok->line, op_tok->column);
+}
+
+static expr_t *parse_not(parser_t *p)
+{
+    token_t *op_tok = &p->tokens[p->pos - 1];
+    expr_t *op = parse_prefix_expr(p);
+    if (!op)
+        return NULL;
+    return ast_make_unary(UNOP_NOT, op, op_tok->line, op_tok->column);
+}
+
+static expr_t *parse_sizeof(parser_t *p)
+{
+    token_t *kw = &p->tokens[p->pos - 1];
+    if (!match(p, TOK_LPAREN))
+        return NULL;
+    size_t save = p->pos;
+    type_kind_t t; size_t sz; size_t esz;
+    if (parse_type(p, &t, &sz, &esz) && match(p, TOK_RPAREN))
+        return ast_make_sizeof_type(t, sz, esz, kw->line, kw->column);
+    p->pos = save;
+    expr_t *e = parser_parse_expr(p);
+    if (!e || !match(p, TOK_RPAREN)) {
+        ast_free_expr(e);
+        return NULL;
+    }
+    return ast_make_sizeof_expr(e, kw->line, kw->column);
+}
+
+static expr_t *parse_alignof(parser_t *p)
+{
+    token_t *kw = &p->tokens[p->pos - 1];
+    if (!match(p, TOK_LPAREN))
+        return NULL;
+    size_t save = p->pos;
+    type_kind_t t; size_t sz; size_t esz;
+    if (parse_type(p, &t, &sz, &esz) && match(p, TOK_RPAREN))
+        return ast_make_alignof_type(t, sz, esz, kw->line, kw->column);
+    p->pos = save;
+    expr_t *e = parser_parse_expr(p);
+    if (!e || !match(p, TOK_RPAREN)) {
+        ast_free_expr(e);
+        return NULL;
+    }
+    return ast_make_alignof_expr(e, kw->line, kw->column);
+}
+
+static expr_t *parse_prefix_operator(parser_t *p)
+{
+    static const struct {
+        token_type_t tok;
+        expr_t *(*fn)(parser_t *);
+    } table[] = {
+        { TOK_INC,       parse_preinc },
+        { TOK_DEC,       parse_predec },
+        { TOK_STAR,      parse_deref },
+        { TOK_AMP,       parse_addr },
+        { TOK_MINUS,     parse_neg },
+        { TOK_NOT,       parse_not },
+        { TOK_KW_SIZEOF, parse_sizeof },
+        { TOK_KW_ALIGNOF, parse_alignof }
+    };
+
+    token_t *tok = peek(p);
+    if (!tok)
+        return NULL;
+
+    for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
+        if (match(p, table[i].tok))
+            return table[i].fn(p);
+    }
+
+    return NULL;
+}
+
+int parse_type(parser_t *p, type_kind_t *out_type, size_t *out_size,
+               size_t *elem_size)
+{
+    size_t save = p->pos;
+    type_kind_t t;
+    if (!parse_basic_type(p, &t))
+        return 0;
+    size_t esz = basic_type_size(t);
+    if (match(p, TOK_STAR))
+        t = TYPE_PTR;
+    size_t arr = 0;
+    if (match(p, TOK_LBRACKET)) {
+        token_t *num = peek(p);
+        if (!num || num->type != TOK_NUMBER) {
+            p->pos = save;
+            return 0;
+        }
+        p->pos++;
+        if (!vc_strtoul_size(num->lexeme, &arr)) {
+            error_set(num->line, num->column,
+                      error_current_file, error_current_function);
+            error_print("Integer constant out of range");
+            p->pos = save;
+            return 0;
+        }
+        if (!match(p, TOK_RBRACKET)) {
+            p->pos = save;
+            return 0;
+        }
+        t = TYPE_ARRAY;
+    }
+    if (out_type)
+        *out_type = t;
+    if (out_size)
+        *out_size = arr;
+    if (elem_size)
+        *elem_size = esz;
+    return 1;
+}
+
+expr_t *parse_cast(parser_t *p)
+{
+    size_t save = p->pos;
+    if (!match(p, TOK_LPAREN))
+        return NULL;
+
+    token_t *lp = &p->tokens[p->pos - 1];
+    type_kind_t t; size_t sz; size_t esz;
+
+    if (!parse_type(p, &t, &sz, &esz) || !match(p, TOK_RPAREN)) {
+        p->pos = save;
+        return NULL;
+    }
+
+    expr_t *inner = parse_cast(p);
+    if (!inner)
+        inner = parse_prefix_expr(p);
+    if (!inner) {
+        p->pos = save;
+        return NULL;
+    }
+
+    expr_t *res = ast_make_cast(t, sz, esz, inner, lp->line, lp->column);
+    if (!res) {
+        ast_free_expr(inner);
+        p->pos = save;
+    }
+    return res;
+}
+
+expr_t *parse_prefix_expr(parser_t *p)
+{
+    expr_t *op = parse_prefix_operator(p);
+    if (op)
+        return op;
+
+    return parse_postfix_expr(p);
+}
+

--- a/src/parser_expr_primary.c
+++ b/src/parser_expr_primary.c
@@ -15,29 +15,16 @@
 #include "ast_clone.h"
 #include "error.h"
 #include "parser_expr_primary.h"
+#include "parser_expr_literal.h"
+#include "parser_expr_ops.h"
 
 
 /* Forward declaration from parser_expr.c */
 expr_t *parser_parse_expr(parser_t *p);
 
-static expr_t *parse_prefix_expr(parser_t *p);
-static expr_t *parse_prefix_operator(parser_t *p);
-static expr_t *parse_cast(parser_t *p);
-static expr_t *parse_preinc(parser_t *p);
-static expr_t *parse_predec(parser_t *p);
-static expr_t *parse_deref(parser_t *p);
-static expr_t *parse_addr(parser_t *p);
-static expr_t *parse_neg(parser_t *p);
-static expr_t *parse_not(parser_t *p);
-static expr_t *parse_sizeof(parser_t *p);
-static expr_t *parse_alignof(parser_t *p);
 static expr_t *parse_offsetof(parser_t *p);
 static int parse_struct_union_tag(parser_t *p, type_kind_t *out_type,
                                   char **out_tag);
-static int parse_type(parser_t *p, type_kind_t *out_type, size_t *out_size,
-                      size_t *elem_size);
-static expr_t *apply_postfix_ops(parser_t *p, expr_t *base);
-static int parse_offsetof_members(parser_t *p, vector_t *names);
 
 /*
  * Free all expr_t pointers stored in a vector and release the vector
@@ -95,86 +82,6 @@ static int parse_argument_list(parser_t *p, vector_t *out_args)
     return 1;
 }
 
-/* Parse numeric, string and character literals. */
-/*
- * Parse a possibly concatenated string literal. Adjacent TOK_STRING or
- * TOK_WIDE_STRING tokens are merged into a single expression node.
- */
-static expr_t *parse_string_literal(parser_t *p)
-{
-    token_t *tok = peek(p);
-    if (!tok || (tok->type != TOK_STRING && tok->type != TOK_WIDE_STRING))
-        return NULL;
-
-    int is_wide = (tok->type == TOK_WIDE_STRING);
-    size_t line = tok->line;
-    size_t column = tok->column;
-
-    size_t len = strlen(tok->lexeme);
-    char *buf = vc_strdup(tok->lexeme);
-    if (!buf)
-        return NULL;
-    p->pos++;
-
-    while (p->pos < p->count) {
-        token_t *next = &p->tokens[p->pos];
-        if (next->type != tok->type)
-            break;
-        size_t nlen = strlen(next->lexeme);
-        buf = vc_realloc_or_exit(buf, len + nlen + 1);
-        memcpy(buf + len, next->lexeme, nlen + 1);
-        len += nlen;
-        p->pos++;
-    }
-
-    expr_t *res = is_wide ?
-        ast_make_wstring(buf, line, column) :
-        ast_make_string(buf, line, column);
-    free(buf);
-    return res;
-}
-
-static expr_t *parse_literal(parser_t *p)
-{
-    token_t *tok = peek(p);
-    if (!tok)
-        return NULL;
-    if (tok->type == TOK_NUMBER) {
-        size_t save = p->pos;
-        token_t *num_tok = tok;
-        p->pos++; /* consume number */
-        token_t *op_tok = peek(p);
-        if (op_tok && (op_tok->type == TOK_PLUS || op_tok->type == TOK_MINUS)) {
-            p->pos++; /* consume +/- */
-            token_t *imag_tok = peek(p);
-            if (imag_tok && imag_tok->type == TOK_IMAG_NUMBER) {
-                p->pos++; /* consume imag */
-                double real = strtod(num_tok->lexeme, NULL);
-                double imag = strtod(imag_tok->lexeme, NULL);
-                if (op_tok->type == TOK_MINUS)
-                    imag = -imag;
-                return ast_make_complex_literal(real, imag,
-                                               num_tok->line, num_tok->column);
-            }
-        }
-        p->pos = save;
-    }
-    if (match(p, TOK_IMAG_NUMBER)) {
-        double imag = strtod(tok->lexeme, NULL);
-        return ast_make_complex_literal(0.0, imag, tok->line, tok->column);
-    }
-    if (match(p, TOK_NUMBER))
-        return ast_make_number(tok->lexeme, tok->line, tok->column);
-    expr_t *s = parse_string_literal(p);
-    if (s)
-        return s;
-    if (match(p, TOK_CHAR))
-        return ast_make_char(tok->lexeme[0], tok->line, tok->column);
-    if (match(p, TOK_WIDE_CHAR))
-        return ast_make_wchar(tok->lexeme[0], tok->line, tok->column);
-    return NULL;
-}
-
 /* Parse an identifier or function call expression. */
 static expr_t *parse_identifier_expr(parser_t *p)
 {
@@ -205,93 +112,84 @@ static expr_t *parse_identifier_expr(parser_t *p)
     match(p, TOK_IDENT);
     return ast_make_ident(tok->lexeme, tok->line, tok->column);
 }
-
-/* Parse a single array indexing operation. */
-static expr_t *parse_index_op(parser_t *p, expr_t *base)
+static int parse_struct_union_tag(parser_t *p, type_kind_t *out_type,
+                                  char **out_tag)
 {
-    if (!match(p, TOK_LBRACKET))
-        return base;
-
-    token_t *lb = &p->tokens[p->pos - 1];
-    expr_t *idx = parser_parse_expr(p);
-    if (!idx || !match(p, TOK_RBRACKET)) {
-        ast_free_expr(base);
-        ast_free_expr(idx);
-        return NULL;
-    }
-
-    return ast_make_index(base, idx, lb->line, lb->column);
-}
-
-/* Parse a single struct/union member access. */
-static expr_t *parse_member_op(parser_t *p, expr_t *base)
-{
-    if (!match(p, TOK_DOT) && !match(p, TOK_ARROW))
-        return base;
-
-    int via_ptr = (p->tokens[p->pos - 1].type == TOK_ARROW);
+    size_t save = p->pos;
+    type_kind_t t;
+    if (match(p, TOK_KW_STRUCT))
+        t = TYPE_STRUCT;
+    else if (match(p, TOK_KW_UNION))
+        t = TYPE_UNION;
+    else
+        return 0;
     token_t *id = peek(p);
     if (!id || id->type != TOK_IDENT) {
-        ast_free_expr(base);
-        return NULL;
+        p->pos = save;
+        return 0;
     }
     p->pos++;
-    return ast_make_member(base, id->lexeme, via_ptr, id->line, id->column);
+    if (out_type)
+        *out_type = t;
+    if (out_tag)
+        *out_tag = vc_strdup(id->lexeme);
+    return 1;
 }
 
-/* Parse a single postfix increment or decrement. */
-static expr_t *parse_postincdec(parser_t *p, expr_t *base)
+static int parse_offsetof_members(parser_t *p, vector_t *names_v)
 {
-    if (match(p, TOK_INC)) {
-        token_t *tok = &p->tokens[p->pos - 1];
-        return ast_make_unary(UNOP_POSTINC, base, tok->line, tok->column);
+    token_t *id = peek(p);
+    if (!id || id->type != TOK_IDENT)
+        return 0;
+    p->pos++;
+    char *dup = vc_strdup(id->lexeme);
+    if (!dup || !vector_push(names_v, &dup)) {
+        free(dup);
+        return 0;
     }
-    if (match(p, TOK_DEC)) {
-        token_t *tok = &p->tokens[p->pos - 1];
-        return ast_make_unary(UNOP_POSTDEC, base, tok->line, tok->column);
+    while (match(p, TOK_DOT)) {
+        id = peek(p);
+        if (!id || id->type != TOK_IDENT)
+            return 0;
+        p->pos++;
+        dup = vc_strdup(id->lexeme);
+        if (!dup || !vector_push(names_v, &dup)) {
+            free(dup);
+            return 0;
+        }
     }
-    return base;
+    return 1;
 }
 
-/* Apply postfix operations like indexing and member access. */
-static expr_t *apply_postfix_ops(parser_t *p, expr_t *base)
+static expr_t *parse_offsetof(parser_t *p)
 {
-    while (1) {
-        expr_t *next = base;
-
-        next = parse_index_op(p, next);
-        if (!next)
-            return NULL;
-        if (next != base) {
-            base = next;
-            continue;
-        }
-
-        next = parse_member_op(p, next);
-        if (!next)
-            return NULL;
-        if (next != base) {
-            base = next;
-            continue;
-        }
-
-        next = parse_postincdec(p, next);
-        if (!next)
-            return NULL;
-        if (next != base) {
-            base = next;
-            continue;
-        }
-
-        break;
+    token_t *kw = &p->tokens[p->pos - 1];
+    if (!match(p, TOK_LPAREN))
+        return NULL;
+    type_kind_t t; char *tag = NULL;
+    if (!parse_struct_union_tag(p, &t, &tag))
+        return NULL;
+    if (!match(p, TOK_COMMA)) {
+        free(tag);
+        return NULL;
     }
-    return base;
+    vector_t names_v; vector_init(&names_v, sizeof(char *));
+    if (!parse_offsetof_members(p, &names_v) || !match(p, TOK_RPAREN)) {
+        for (size_t i = 0; i < names_v.count; i++)
+            free(((char **)names_v.data)[i]);
+        vector_free(&names_v); free(tag); return NULL;
+    }
+    char **arr = (char **)names_v.data;
+    size_t count = names_v.count;
+    expr_t *res = ast_make_offsetof(t, tag, arr, count, kw->line, kw->column);
+    if (!res) {
+        for (size_t i = 0; i < count; i++)
+            free(arr[i]);
+        free(arr); free(tag); return NULL;
+    }
+    return res;
 }
 
-/*
- * Parse a compound literal of the form '(type){...}'.
- * On success the returned expression represents the temporary object.
- */
 static expr_t *parse_compound_literal(parser_t *p)
 {
     size_t save = p->pos;
@@ -323,7 +221,7 @@ static expr_t *parse_compound_literal(parser_t *p)
  * calls and array indexing.  Prefix unary operators are also handled
  * here.  The returned expr_t represents the parsed sub-expression.
  */
-static expr_t *parse_base_term(parser_t *p)
+expr_t *parse_base_term(parser_t *p)
 {
     expr_t *base = parse_literal(p);
     if (!base)
@@ -341,267 +239,6 @@ static expr_t *parse_base_term(parser_t *p)
     return base;
 }
 
-/* Apply any postfix operators to a base term. */
-static expr_t *parse_postfix_expr(parser_t *p)
-{
-    expr_t *base = parse_base_term(p);
-    if (!base)
-        return NULL;
-    return apply_postfix_ops(p, base);
-}
-
-/* Prefix operator helpers */
-static expr_t *parse_preinc(parser_t *p)
-{
-    token_t *op_tok = &p->tokens[p->pos - 1];
-    expr_t *op = parse_prefix_expr(p);
-    if (!op)
-        return NULL;
-    return ast_make_unary(UNOP_PREINC, op, op_tok->line, op_tok->column);
-}
-
-static expr_t *parse_predec(parser_t *p)
-{
-    token_t *op_tok = &p->tokens[p->pos - 1];
-    expr_t *op = parse_prefix_expr(p);
-    if (!op)
-        return NULL;
-    return ast_make_unary(UNOP_PREDEC, op, op_tok->line, op_tok->column);
-}
-
-static expr_t *parse_deref(parser_t *p)
-{
-    token_t *op_tok = &p->tokens[p->pos - 1];
-    expr_t *op = parse_prefix_expr(p);
-    if (!op)
-        return NULL;
-    return ast_make_unary(UNOP_DEREF, op, op_tok->line, op_tok->column);
-}
-
-static expr_t *parse_addr(parser_t *p)
-{
-    token_t *op_tok = &p->tokens[p->pos - 1];
-    expr_t *op = parse_prefix_expr(p);
-    if (!op)
-        return NULL;
-    return ast_make_unary(UNOP_ADDR, op, op_tok->line, op_tok->column);
-}
-
-static expr_t *parse_neg(parser_t *p)
-{
-    token_t *op_tok = &p->tokens[p->pos - 1];
-    expr_t *op = parse_prefix_expr(p);
-    if (!op)
-        return NULL;
-    return ast_make_unary(UNOP_NEG, op, op_tok->line, op_tok->column);
-}
-
-static expr_t *parse_not(parser_t *p)
-{
-    token_t *op_tok = &p->tokens[p->pos - 1];
-    expr_t *op = parse_prefix_expr(p);
-    if (!op)
-        return NULL;
-    return ast_make_unary(UNOP_NOT, op, op_tok->line, op_tok->column);
-}
-
-static expr_t *parse_sizeof(parser_t *p)
-{
-    token_t *kw = &p->tokens[p->pos - 1];
-    if (!match(p, TOK_LPAREN))
-        return NULL;
-    size_t save = p->pos;
-    type_kind_t t; size_t sz; size_t esz;
-    if (parse_type(p, &t, &sz, &esz) && match(p, TOK_RPAREN))
-        return ast_make_sizeof_type(t, sz, esz, kw->line, kw->column);
-    p->pos = save;
-    expr_t *e = parser_parse_expr(p);
-    if (!e || !match(p, TOK_RPAREN)) {
-        ast_free_expr(e);
-        return NULL;
-    }
-    return ast_make_sizeof_expr(e, kw->line, kw->column);
-}
-
-static expr_t *parse_alignof(parser_t *p)
-{
-    token_t *kw = &p->tokens[p->pos - 1];
-    if (!match(p, TOK_LPAREN))
-        return NULL;
-    size_t save = p->pos;
-    type_kind_t t; size_t sz; size_t esz;
-    if (parse_type(p, &t, &sz, &esz) && match(p, TOK_RPAREN))
-        return ast_make_alignof_type(t, sz, esz, kw->line, kw->column);
-    p->pos = save;
-    expr_t *e = parser_parse_expr(p);
-    if (!e || !match(p, TOK_RPAREN)) {
-        ast_free_expr(e);
-        return NULL;
-    }
-    return ast_make_alignof_expr(e, kw->line, kw->column);
-}
-
-/*
- * Check for a prefix operator and dispatch to the
- * corresponding helper. Returns NULL if no operator
- * is present.
- */
-static expr_t *parse_prefix_operator(parser_t *p)
-{
-    static const struct {
-        token_type_t tok;
-        expr_t *(*fn)(parser_t *);
-    } table[] = {
-        { TOK_INC,       parse_preinc },
-        { TOK_DEC,       parse_predec },
-        { TOK_STAR,      parse_deref },
-        { TOK_AMP,       parse_addr },
-        { TOK_MINUS,     parse_neg },
-        { TOK_NOT,       parse_not },
-        { TOK_KW_SIZEOF, parse_sizeof },
-        { TOK_KW_ALIGNOF, parse_alignof }
-    };
-
-    token_t *tok = peek(p);
-    if (!tok)
-        return NULL;
-
-    for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
-        if (match(p, table[i].tok))
-            return table[i].fn(p);
-    }
-
-    return NULL;
-}
-
-/* Parse 'struct tag' or 'union tag' and return the tag name. */
-static int parse_struct_union_tag(parser_t *p, type_kind_t *out_type,
-                                  char **out_tag)
-{
-    size_t save = p->pos;
-    type_kind_t t;
-    if (match(p, TOK_KW_STRUCT))
-        t = TYPE_STRUCT;
-    else if (match(p, TOK_KW_UNION))
-        t = TYPE_UNION;
-    else
-        return 0;
-
-    token_t *id = peek(p);
-    if (!id || id->type != TOK_IDENT) {
-        p->pos = save;
-        return 0;
-    }
-    p->pos++;
-    if (out_type)
-        *out_type = t;
-    if (out_tag)
-        *out_tag = vc_strdup(id->lexeme);
-    return 1;
-}
-
-/* Parse the member path for an offsetof expression into a vector. */
-static int parse_offsetof_members(parser_t *p, vector_t *names_v)
-{
-    token_t *id = peek(p);
-    if (!id || id->type != TOK_IDENT)
-        return 0;
-    p->pos++;
-    char *dup = vc_strdup(id->lexeme);
-    if (!dup || !vector_push(names_v, &dup)) {
-        free(dup);
-        return 0;
-    }
-
-    while (match(p, TOK_DOT)) {
-        id = peek(p);
-        if (!id || id->type != TOK_IDENT)
-            return 0;
-        p->pos++;
-        dup = vc_strdup(id->lexeme);
-        if (!dup || !vector_push(names_v, &dup)) {
-            free(dup);
-            return 0;
-        }
-    }
-
-    return 1;
-}
-
-/* Parse an offsetof builtin expression. */
-static expr_t *parse_offsetof(parser_t *p)
-{
-    token_t *kw = &p->tokens[p->pos - 1];
-    if (!match(p, TOK_LPAREN))
-        return NULL;
-
-    type_kind_t t; char *tag = NULL;
-    if (!parse_struct_union_tag(p, &t, &tag))
-        return NULL;
-    if (!match(p, TOK_COMMA)) {
-        free(tag);
-        return NULL;
-    }
-
-    vector_t names_v; vector_init(&names_v, sizeof(char *));
-    if (!parse_offsetof_members(p, &names_v) || !match(p, TOK_RPAREN)) {
-        for (size_t i = 0; i < names_v.count; i++)
-            free(((char **)names_v.data)[i]);
-        vector_free(&names_v); free(tag); return NULL;
-    }
-
-    char **arr = (char **)names_v.data;
-    size_t count = names_v.count;
-    expr_t *res = ast_make_offsetof(t, tag, arr, count, kw->line, kw->column);
-    if (!res) {
-        for (size_t i = 0; i < count; i++)
-            free(arr[i]);
-        free(arr); free(tag); return NULL;
-    }
-    return res;
-}
-
-/* Parse a cast expression '(type)expr'. */
-static expr_t *parse_cast(parser_t *p)
-{
-    size_t save = p->pos;
-    if (!match(p, TOK_LPAREN))
-        return NULL;
-
-    token_t *lp = &p->tokens[p->pos - 1];
-    type_kind_t t; size_t sz; size_t esz;
-
-    if (!parse_type(p, &t, &sz, &esz) || !match(p, TOK_RPAREN)) {
-        p->pos = save;
-        return NULL;
-    }
-
-    expr_t *inner = parse_cast(p);
-    if (!inner)
-        inner = parse_prefix_expr(p);
-    if (!inner) {
-        p->pos = save;
-        return NULL;
-    }
-
-    expr_t *res = ast_make_cast(t, sz, esz, inner, lp->line, lp->column);
-    if (!res) {
-        ast_free_expr(inner);
-        p->pos = save;
-    }
-    return res;
-}
-
-/* Handle prefix unary operators before a primary expression. */
-static expr_t *parse_prefix_expr(parser_t *p)
-{
-    expr_t *op = parse_prefix_operator(p);
-    if (op)
-        return op;
-
-    return parse_postfix_expr(p);
-}
-
 /* Wrapper to start prefix expression parsing. */
 expr_t *parse_primary(parser_t *p)
 {
@@ -609,46 +246,5 @@ expr_t *parse_primary(parser_t *p)
     if (cast)
         return cast;
     return parse_prefix_expr(p);
-}
-
-/* Parse a basic type specification used by sizeof. */
-static int parse_type(parser_t *p, type_kind_t *out_type, size_t *out_size,
-                      size_t *elem_size)
-{
-    size_t save = p->pos;
-    type_kind_t t;
-    if (!parse_basic_type(p, &t))
-        return 0;
-    size_t esz = basic_type_size(t);
-    if (match(p, TOK_STAR))
-        t = TYPE_PTR;
-    size_t arr = 0;
-    if (match(p, TOK_LBRACKET)) {
-        token_t *num = peek(p);
-        if (!num || num->type != TOK_NUMBER) {
-            p->pos = save;
-            return 0;
-        }
-        p->pos++;
-        if (!vc_strtoul_size(num->lexeme, &arr)) {
-            error_set(num->line, num->column,
-                      error_current_file, error_current_function);
-            error_print("Integer constant out of range");
-            p->pos = save;
-            return 0;
-        }
-        if (!match(p, TOK_RBRACKET)) {
-            p->pos = save;
-            return 0;
-        }
-        t = TYPE_ARRAY;
-    }
-    if (out_type)
-        *out_type = t;
-    if (out_size)
-        *out_size = arr;
-    if (elem_size)
-        *elem_size = esz;
-    return 1;
 }
 


### PR DESCRIPTION
## Summary
- extract literal parsing helpers into `parser_expr_literal.c`
- move prefix/postfix operator parsing into `parser_expr_ops.c`
- trim `parser_expr_primary.c` to core helpers
- update headers and Makefile for the new modules

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686ee3d1256c83249c6979bd180921d9