### PR TITLE
Organize control flow semantic helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/parser_decl_var.c src/parser_decl_struct.c src/parser_decl_enum.c \
            src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
-           src/semantic_loops.c src/semantic_switch.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
+           src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
@@ -23,7 +23,7 @@ EXTRA_SRC ?=
 # Final source list
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
-HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_switch.h include/semantic_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_init.h include/semantic_global.h \
+HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_control.h include/semantic_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_const.h include/ir_memory.h include/ir_control.h include/ir_builder.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_includes.h include/preproc_expr.h include/preproc_cond.h include/preproc_path.h include/parser_types.h include/parser_core.h include/startup.h include/compile_stage.h
@@ -159,8 +159,8 @@ src/semantic_call.o: src/semantic_call.c $(HDR)
 src/semantic_loops.o: src/semantic_loops.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_loops.c -o src/semantic_loops.o
 
-src/semantic_switch.o: src/semantic_switch.c $(HDR)
-	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_switch.c -o src/semantic_switch.o
+src/semantic_control.o: src/semantic_control.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_control.c -o src/semantic_control.o
 src/semantic_init.o: src/semantic_init.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_init.c -o src/semantic_init.o
 

--- a/include/semantic.h
+++ b/include/semantic.h
@@ -12,7 +12,7 @@
 #include "semantic_expr.h"
 #include "semantic_stmt.h"
 #include "semantic_loops.h"
-#include "semantic_switch.h"
+#include "semantic_control.h"
 #include "semantic_global.h"
 #include "semantic_inline.h"
 

--- a/include/semantic_control.h
+++ b/include/semantic_control.h
@@ -1,14 +1,14 @@
 /*
- * Switch statement and label table helpers.
- * Provides label table utilities and routines for validating
- * switch statements while emitting the necessary IR branches.
+ * Control flow statement helpers.
+ * Provides label table utilities along with routines for validating
+ * if/else and switch statements while emitting the necessary IR.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
 
-#ifndef VC_SEMANTIC_SWITCH_H
-#define VC_SEMANTIC_SWITCH_H
+#ifndef VC_SEMANTIC_CONTROL_H
+#define VC_SEMANTIC_CONTROL_H
 
 #include "ast_stmt.h"
 #include "ir_core.h"
@@ -37,9 +37,15 @@ const char *label_table_get(label_table_t *t, const char *name);
 /* Get or add a label and return its IR name */
 const char *label_table_get_or_add(label_table_t *t, const char *name);
 
+/* Check an if/else statement and emit IR */
+int check_if_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                  label_table_t *labels, ir_builder_t *ir,
+                  type_kind_t func_ret_type,
+                  const char *break_label, const char *continue_label);
+
 /* Check a switch statement and emit IR */
 int check_switch_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                       label_table_t *labels, ir_builder_t *ir,
                       type_kind_t func_ret_type);
 
-#endif /* VC_SEMANTIC_SWITCH_H */
+#endif /* VC_SEMANTIC_CONTROL_H */

--- a/include/semantic_loops.h
+++ b/include/semantic_loops.h
@@ -13,7 +13,7 @@
 #include "ast_stmt.h"
 #include "ir_core.h"
 #include "symtable.h"
-#include "semantic_switch.h"
+#include "semantic_control.h"
 
 /* Check a while loop and emit IR */
 int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include "semantic_global.h"
 #include "semantic_stmt.h"
-#include "semantic_switch.h"
+#include "semantic_control.h"
 #include "consteval.h"
 #include "semantic_expr.h"
 #include "semantic_init.h"


### PR DESCRIPTION
## Summary
- consolidate switch and if statement logic in semantic_control
- update semantic headers and includes for new control module

## Testing
- `make -j4`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ef7dd2a108324b5989045de38761e