### PR TITLE
Refactor semantic expression helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ BIN = vc
 CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/compile_tokenize.c src/compile_parse.c src/compile_output.c src/startup.c src/command.c src/cli.c src/cli_env.c src/cli_opts.c src/lexer.c src/lexer_ident.c src/lexer_scan_numeric.c src/ast_expr.c src/ast_stmt.c src/ast_clone.c src/parser_core.c src/parser_toplevel.c src/parser_toplevel_func.c src/parser_toplevel_var.c src/symtable_core.c src/symtable_globals.c src/symtable_struct.c src/parser_expr.c src/parser_expr_primary.c src/parser_expr_binary.c src/parser_expr_ops.c src/parser_expr_literal.c src/parser_init.c \
            src/parser_decl_var.c src/parser_decl_struct.c src/parser_decl_enum.c \
            src/parser_flow.c src/parser_stmt.c src/parser_types.c \
-           src/semantic_expr.c src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
+           src/semantic_expr.c src/semantic_expr_const.c src/semantic_expr_cast.c \
+           src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c \
@@ -156,6 +157,12 @@ src/parser_types.o: src/parser_types.c $(HDR)
 
 src/semantic_expr.o: src/semantic_expr.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_expr.c -o src/semantic_expr.o
+
+src/semantic_expr_const.o: src/semantic_expr_const.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_expr_const.c -o src/semantic_expr_const.o
+	
+src/semantic_expr_cast.o: src/semantic_expr_cast.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_expr_cast.c -o src/semantic_expr_cast.o
 
 src/semantic_arith.o: src/semantic_arith.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_arith.c -o src/semantic_arith.o

--- a/src/semantic_expr_cast.c
+++ b/src/semantic_expr_cast.c
@@ -1,0 +1,49 @@
+/*
+ * Cast and type conversion helpers.
+ * Implements semantic checks for explicit casts between primitive types.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "semantic_expr.h"
+#include "error.h"
+
+/*
+ * Validate a type cast expression. The operand expression is evaluated
+ * and checked for compatibility with the destination type. No IR is
+ * emitted for the conversion itself as primitive types share the same
+ * representation.
+ */
+type_kind_t check_cast_expr(expr_t *expr, symtable_t *vars,
+                            symtable_t *funcs, ir_builder_t *ir,
+                            ir_value_t *out)
+{
+    ir_value_t val;
+    type_kind_t src = check_expr(expr->cast.expr, vars, funcs, ir, &val);
+    type_kind_t dst = expr->cast.type;
+
+    if (src == TYPE_UNKNOWN)
+        return TYPE_UNKNOWN;
+
+    if (src == dst ||
+        ((is_intlike(src) || src == TYPE_PTR) &&
+         (is_intlike(dst) || dst == TYPE_PTR)) ||
+        (is_floatlike(src) && (is_floatlike(dst) || is_intlike(dst))) ||
+        (is_floatlike(dst) && is_intlike(src)) ||
+        (is_complexlike(src) && src == dst)) {
+        if (out)
+            *out = val;
+        return dst;
+    }
+
+    error_set(expr->line, expr->column, error_current_file,
+              error_current_function);
+    if (out)
+        *out = (ir_value_t){0};
+    return TYPE_UNKNOWN;
+}
+

--- a/src/semantic_expr_const.c
+++ b/src/semantic_expr_const.c
@@ -1,0 +1,95 @@
+/*
+ * Literal and constant expression helpers.
+ * Validates number, string, character and complex literals and
+ * emits the corresponding constant IR values.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <limits.h>
+#include <errno.h>
+#include "semantic_expr.h"
+#include "error.h"
+#include "ir_core.h"
+
+/*
+ * Validate a numeric literal and emit a constant IR value.  The returned
+ * type depends on the literal's size.
+ */
+type_kind_t check_number_expr(expr_t *expr, symtable_t *vars,
+                              symtable_t *funcs, ir_builder_t *ir,
+                              ir_value_t *out)
+{
+    (void)vars; (void)funcs;
+    errno = 0;
+    long long val = strtoll(expr->number.value, NULL, 0);
+    if (errno != 0) {
+        error_set(expr->line, expr->column, error_current_file,
+                  error_current_function);
+        if (out)
+            *out = (ir_value_t){0};
+        return TYPE_UNKNOWN;
+    }
+    if (out)
+        *out = ir_build_const(ir, val);
+    if (expr->number.long_count == 2)
+        return expr->number.is_unsigned ? TYPE_ULLONG : TYPE_LLONG;
+    if (expr->number.long_count == 1)
+        return expr->number.is_unsigned ? TYPE_ULONG : TYPE_LONG;
+    if (expr->number.is_unsigned)
+        return TYPE_UINT;
+    if (val > INT_MAX || val < INT_MIN)
+        return TYPE_LLONG;
+    return TYPE_INT;
+}
+
+/*
+ * Validate a string literal and build its constant representation in the IR.
+ * The resulting value has pointer type.
+ */
+type_kind_t check_string_expr(expr_t *expr, symtable_t *vars,
+                              symtable_t *funcs, ir_builder_t *ir,
+                              ir_value_t *out)
+{
+    (void)vars; (void)funcs;
+    const char *text = expr->string.value;
+    if (out) {
+        if (expr->string.is_wide)
+            *out = ir_build_wstring(ir, text);
+        else
+            *out = ir_build_string(ir, text);
+    }
+    return TYPE_PTR;
+}
+
+/*
+ * Validate a character literal and emit a constant integer IR value.
+ */
+type_kind_t check_char_expr(expr_t *expr, symtable_t *vars,
+                           symtable_t *funcs, ir_builder_t *ir,
+                           ir_value_t *out)
+{
+    (void)vars; (void)funcs;
+    if (out)
+        *out = ir_build_const(ir, (int)expr->ch.value);
+    return expr->ch.is_wide ? TYPE_INT : TYPE_CHAR;
+}
+
+/*
+ * Validate a complex literal and emit a constant IR value.
+ */
+type_kind_t check_complex_literal(expr_t *expr, symtable_t *vars,
+                                  symtable_t *funcs, ir_builder_t *ir,
+                                  ir_value_t *out)
+{
+    (void)vars; (void)funcs;
+    if (out)
+        *out = ir_build_cplx_const(ir, expr->complex_lit.real,
+                                   expr->complex_lit.imag);
+    return TYPE_DOUBLE_COMPLEX;
+}
+


### PR DESCRIPTION
## Summary
- split literal helpers to `semantic_expr_const.c`
- move cast validation to `semantic_expr_cast.c`
- keep general expression logic in `semantic_expr.c`
- update `Makefile` for new sources

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f07fdddd483249879b7e583df7bca