### PR TITLE
Move layout helpers into dedicated module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_expr_const.c src/semantic_expr_cast.c \
            src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
-           src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
+           src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_layout.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
@@ -23,7 +23,7 @@ EXTRA_SRC ?=
 # Final source list
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
-HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_control.h include/semantic_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_init.h include/semantic_global.h \
+HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_control.h include/semantic_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_layout.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_const.h include/ir_memory.h include/ir_control.h include/ir_builder.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h include/lexer_internal.h \
     include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_includes.h include/preproc_expr.h include/preproc_cond.h include/preproc_path.h include/parser_types.h include/parser_core.h include/startup.h include/compile_stage.h
@@ -187,6 +187,8 @@ src/semantic_var.o: src/semantic_var.c $(HDR)
 
 src/semantic_stmt.o: src/semantic_stmt.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_stmt.c -o src/semantic_stmt.o
+src/semantic_layout.o: src/semantic_layout.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_layout.c -o src/semantic_layout.o
 src/semantic_inline.o: src/semantic_inline.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_inline.c -o src/semantic_inline.o
 

--- a/include/semantic_global.h
+++ b/include/semantic_global.h
@@ -14,9 +14,6 @@
 #include "ir_core.h"
 #include "symtable.h"
 
-size_t layout_union_members(union_member_t *members, size_t count);
-size_t layout_struct_members(struct_member_t *members, size_t count);
-
 /* Current maximum alignment for struct packing */
 extern size_t semantic_pack_alignment;
 void semantic_set_pack(size_t align);

--- a/include/semantic_layout.h
+++ b/include/semantic_layout.h
@@ -1,0 +1,29 @@
+/*
+ * Layout and metadata helpers for structs and unions.
+ * Provides routines shared across semantic phases for
+ * computing member offsets and copying declaration metadata.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_SEMANTIC_LAYOUT_H
+#define VC_SEMANTIC_LAYOUT_H
+
+#include "ast_stmt.h"
+#include "symtable.h"
+
+size_t layout_union_members(union_member_t *members, size_t count);
+size_t layout_struct_members(struct_member_t *members, size_t count);
+
+int compute_union_layout(stmt_t *decl, symtable_t *globals);
+int compute_struct_layout(stmt_t *decl, symtable_t *globals);
+
+int copy_union_metadata(symbol_t *sym, union_member_t *members,
+                        size_t count, size_t total);
+int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
+                         size_t count, size_t total);
+int copy_aggregate_metadata(stmt_t *decl, symbol_t *sym,
+                            symtable_t *globals);
+
+#endif /* VC_SEMANTIC_LAYOUT_H */

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -16,6 +16,7 @@
 #include "consteval.h"
 #include "semantic_expr.h"
 #include "semantic_init.h"
+#include "semantic_layout.h"
 #include "symtable.h"
 #include "ir_global.h"
 #include "util.h"
@@ -34,70 +35,6 @@ void semantic_set_pack(size_t align)
     semantic_pack_alignment = align;
 }
 
-/*
- * Lay out union members sequentially and return the size of the largest
- * member.  Offsets are assigned in declaration order so that later code
- * can address the correct union fields.
- */
-size_t layout_union_members(union_member_t *members, size_t count)
-{
-    size_t max = 0;
-    for (size_t i = 0; i < count; i++) {
-        members[i].offset = 0;
-        members[i].bit_offset = 0;
-        if (members[i].elem_size > max)
-            max = members[i].elem_size;
-    }
-    return max;
-}
-
-/*
- * Compute byte offsets for struct members sequentially and return the
- * total size of the struct.  Each member's offset accumulates the size
- * of the previous ones.
- */
-size_t layout_struct_members(struct_member_t *members, size_t count)
-{
-    size_t byte_off = 0;
-    unsigned bit_off = 0;
-    size_t pack = semantic_pack_alignment ? semantic_pack_alignment : SIZE_MAX;
-
-    for (size_t i = 0; i < count; i++) {
-        if (members[i].bit_width == 0) {
-            size_t align = members[i].elem_size;
-            if (align > pack)
-                align = pack;
-            if (bit_off)
-                byte_off++, bit_off = 0;
-            if (align > 1) {
-                size_t rem = byte_off % align;
-                if (rem)
-                    byte_off += align - rem;
-            }
-            members[i].offset = byte_off;
-            members[i].bit_offset = 0;
-            if (!members[i].is_flexible)
-                byte_off += members[i].elem_size;
-        } else {
-            members[i].offset = byte_off;
-            members[i].bit_offset = bit_off;
-            bit_off += members[i].bit_width;
-            byte_off += bit_off / 8;
-            bit_off %= 8;
-        }
-    }
-
-    if (bit_off)
-        byte_off++;
-
-    if (pack != SIZE_MAX && pack > 1) {
-        size_t rem = byte_off % pack;
-        if (rem)
-            byte_off += pack - rem;
-    }
-
-    return byte_off;
-}
 
 
 /*
@@ -263,44 +200,6 @@ static int check_static_assert_stmt(stmt_t *stmt, symtable_t *globals)
  * union members are assigned offsets and the resulting element size is stored
  * back into the declaration for later use.
  */
-/* Compute layout for a union variable declaration */
-static int compute_union_layout(stmt_t *decl, symtable_t *globals)
-{
-    if (decl->var_decl.member_count) {
-        size_t max = layout_union_members(decl->var_decl.members,
-                                          decl->var_decl.member_count);
-        decl->var_decl.elem_size = max;
-    } else if (decl->var_decl.tag) {
-        symbol_t *utype = symtable_lookup_union(globals, decl->var_decl.tag);
-        if (!utype) {
-            error_set(decl->line, decl->column, error_current_file,
-                      error_current_function);
-            return 0;
-        }
-        decl->var_decl.elem_size = utype->total_size;
-    }
-    return 1;
-}
-
-/* Compute layout for a struct variable declaration */
-static int compute_struct_layout(stmt_t *decl, symtable_t *globals)
-{
-    if (decl->var_decl.member_count) {
-        size_t total =
-            layout_struct_members((struct_member_t *)decl->var_decl.members,
-                                  decl->var_decl.member_count);
-        decl->var_decl.elem_size = total;
-    } else if (decl->var_decl.tag) {
-        symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
-        if (!stype) {
-            error_set(decl->line, decl->column, error_current_file,
-                      error_current_function);
-            return 0;
-        }
-        decl->var_decl.elem_size = stype->struct_total_size;
-    }
-    return 1;
-}
 
 static int compute_global_layout(stmt_t *decl, symtable_t *globals)
 {
@@ -308,92 +207,6 @@ static int compute_global_layout(stmt_t *decl, symtable_t *globals)
         return compute_union_layout(decl, globals);
     if (decl->var_decl.type == TYPE_STRUCT)
         return compute_struct_layout(decl, globals);
-    return 1;
-}
-
-/*
- * Copy union member metadata from the parsed declaration to the newly created
- * symbol.  Allocates arrays and duplicates member names.  Returns non-zero on
- * success.
- */
-static int copy_union_metadata(symbol_t *sym, union_member_t *members,
-                               size_t count, size_t total)
-{
-    sym->total_size = total;
-    if (!count)
-        return 1;
-    sym->members = malloc(count * sizeof(*sym->members));
-    if (!sym->members)
-        return 0;
-    sym->member_count = count;
-    for (size_t i = 0; i < count; i++) {
-        union_member_t *m = &members[i];
-        sym->members[i].name = vc_strdup(m->name);
-        sym->members[i].type = m->type;
-        sym->members[i].elem_size = m->elem_size;
-        sym->members[i].offset = m->offset;
-        sym->members[i].bit_width = m->bit_width;
-        sym->members[i].bit_offset = m->bit_offset;
-        sym->members[i].is_flexible = m->is_flexible;
-    }
-    return 1;
-}
-
-/*
- * Copy struct member metadata from the parsed declaration to the symbol.  The
- * member array is duplicated and offsets preserved.  Returns non-zero on
- * success.
- */
-static int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
-                                size_t count, size_t total)
-{
-    sym->struct_total_size = total;
-    if (!count)
-        return 1;
-    sym->struct_members = malloc(count * sizeof(*sym->struct_members));
-    if (!sym->struct_members)
-        return 0;
-    sym->struct_member_count = count;
-    for (size_t i = 0; i < count; i++) {
-        struct_member_t *m = &members[i];
-        sym->struct_members[i].name = vc_strdup(m->name);
-        sym->struct_members[i].type = m->type;
-        sym->struct_members[i].elem_size = m->elem_size;
-        sym->struct_members[i].offset = m->offset;
-        sym->struct_members[i].bit_width = m->bit_width;
-        sym->struct_members[i].bit_offset = m->bit_offset;
-        sym->struct_members[i].is_flexible = m->is_flexible;
-    }
-    return 1;
-}
-
-/*
- * Copy aggregate member metadata from the declaration to the inserted symbol
- * record.  Dispatches to the struct or union helper and returns non-zero on
- * success.
- */
-static int copy_aggregate_metadata(stmt_t *decl, symbol_t *sym, symtable_t *globals)
-{
-    if (decl->var_decl.type == TYPE_UNION)
-        return copy_union_metadata(sym, decl->var_decl.members,
-                                   decl->var_decl.member_count,
-                                   decl->var_decl.elem_size);
-
-    if (decl->var_decl.type == TYPE_STRUCT) {
-        if (decl->var_decl.member_count == 0 && decl->var_decl.tag) {
-            symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
-            if (!stype)
-                return 0;
-            return copy_struct_metadata(sym, stype->struct_members,
-                                        stype->struct_member_count,
-                                        stype->struct_total_size);
-        }
-        return copy_struct_metadata(sym,
-                                    (struct_member_t *)decl->var_decl.members,
-                                    decl->var_decl.member_count,
-                                    decl->var_decl.elem_size);
-    }
-
     return 1;
 }
 

--- a/src/semantic_layout.c
+++ b/src/semantic_layout.c
@@ -1,0 +1,196 @@
+/*
+ * Shared layout helpers used by semantic analysis.
+ * Implements algorithms for assigning member offsets and
+ * duplicating struct/union metadata.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <stdint.h>
+#include "semantic_layout.h"
+#include "util.h"
+#include "error.h"
+
+/* Active struct packing alignment (0 means natural) */
+extern size_t semantic_pack_alignment;
+
+/*
+ * Lay out union members sequentially and return the size of the largest
+ * member. Offsets are assigned in declaration order.
+ */
+size_t layout_union_members(union_member_t *members, size_t count)
+{
+    size_t max = 0;
+    for (size_t i = 0; i < count; i++) {
+        members[i].offset = 0;
+        members[i].bit_offset = 0;
+        if (members[i].elem_size > max)
+            max = members[i].elem_size;
+    }
+    return max;
+}
+
+/*
+ * Compute byte offsets for struct members sequentially and return the
+ * total size of the struct. Packing is honoured via semantic_pack_alignment.
+ */
+size_t layout_struct_members(struct_member_t *members, size_t count)
+{
+    size_t byte_off = 0;
+    unsigned bit_off = 0;
+    size_t pack = semantic_pack_alignment ? semantic_pack_alignment : SIZE_MAX;
+
+    for (size_t i = 0; i < count; i++) {
+        if (members[i].bit_width == 0) {
+            size_t align = members[i].elem_size;
+            if (align > pack)
+                align = pack;
+            if (bit_off)
+                byte_off++, bit_off = 0;
+            if (align > 1) {
+                size_t rem = byte_off % align;
+                if (rem)
+                    byte_off += align - rem;
+            }
+            members[i].offset = byte_off;
+            members[i].bit_offset = 0;
+            if (!members[i].is_flexible)
+                byte_off += members[i].elem_size;
+        } else {
+            members[i].offset = byte_off;
+            members[i].bit_offset = bit_off;
+            bit_off += members[i].bit_width;
+            byte_off += bit_off / 8;
+            bit_off %= 8;
+        }
+    }
+
+    if (bit_off)
+        byte_off++;
+
+    if (pack != SIZE_MAX && pack > 1) {
+        size_t rem = byte_off % pack;
+        if (rem)
+            byte_off += pack - rem;
+    }
+
+    return byte_off;
+}
+
+/* Compute layout for a union variable declaration */
+int compute_union_layout(stmt_t *decl, symtable_t *globals)
+{
+    if (decl->var_decl.member_count) {
+        size_t max = layout_union_members(decl->var_decl.members,
+                                          decl->var_decl.member_count);
+        decl->var_decl.elem_size = max;
+    } else if (decl->var_decl.tag) {
+        symbol_t *utype = symtable_lookup_union(globals, decl->var_decl.tag);
+        if (!utype) {
+            error_set(decl->line, decl->column, error_current_file,
+                      error_current_function);
+            return 0;
+        }
+        decl->var_decl.elem_size = utype->total_size;
+    }
+    return 1;
+}
+
+/* Compute layout for a struct variable declaration */
+int compute_struct_layout(stmt_t *decl, symtable_t *globals)
+{
+    if (decl->var_decl.member_count) {
+        size_t total = layout_struct_members((struct_member_t *)decl->var_decl.members,
+                                             decl->var_decl.member_count);
+        decl->var_decl.elem_size = total;
+    } else if (decl->var_decl.tag) {
+        symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
+        if (!stype) {
+            error_set(decl->line, decl->column, error_current_file,
+                      error_current_function);
+            return 0;
+        }
+        decl->var_decl.elem_size = stype->struct_total_size;
+    }
+    return 1;
+}
+
+/* Copy union member metadata from a declaration to a symbol */
+int copy_union_metadata(symbol_t *sym, union_member_t *members,
+                        size_t count, size_t total)
+{
+    sym->total_size = total;
+    if (!count)
+        return 1;
+    sym->members = malloc(count * sizeof(*sym->members));
+    if (!sym->members)
+        return 0;
+    sym->member_count = count;
+    for (size_t i = 0; i < count; i++) {
+        union_member_t *m = &members[i];
+        sym->members[i].name = vc_strdup(m->name);
+        sym->members[i].type = m->type;
+        sym->members[i].elem_size = m->elem_size;
+        sym->members[i].offset = m->offset;
+        sym->members[i].bit_width = m->bit_width;
+        sym->members[i].bit_offset = m->bit_offset;
+        sym->members[i].is_flexible = m->is_flexible;
+    }
+    return 1;
+}
+
+/* Copy struct member metadata from a declaration to a symbol */
+int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
+                         size_t count, size_t total)
+{
+    sym->struct_total_size = total;
+    if (!count)
+        return 1;
+    sym->struct_members = malloc(count * sizeof(*sym->struct_members));
+    if (!sym->struct_members)
+        return 0;
+    sym->struct_member_count = count;
+    for (size_t i = 0; i < count; i++) {
+        struct_member_t *m = &members[i];
+        sym->struct_members[i].name = vc_strdup(m->name);
+        sym->struct_members[i].type = m->type;
+        sym->struct_members[i].elem_size = m->elem_size;
+        sym->struct_members[i].offset = m->offset;
+        sym->struct_members[i].bit_width = m->bit_width;
+        sym->struct_members[i].bit_offset = m->bit_offset;
+        sym->struct_members[i].is_flexible = m->is_flexible;
+    }
+    return 1;
+}
+
+/* Copy aggregate member metadata from a declaration to a symbol */
+int copy_aggregate_metadata(stmt_t *decl, symbol_t *sym,
+                            symtable_t *globals)
+{
+    if (decl->var_decl.type == TYPE_UNION)
+        return copy_union_metadata(sym, decl->var_decl.members,
+                                   decl->var_decl.member_count,
+                                   decl->var_decl.elem_size);
+
+    if (decl->var_decl.type == TYPE_STRUCT) {
+        if (decl->var_decl.member_count == 0 && decl->var_decl.tag) {
+            symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
+            if (!stype)
+                return 0;
+            return copy_struct_metadata(sym, stype->struct_members,
+                                        stype->struct_member_count,
+                                        stype->struct_total_size);
+        }
+        return copy_struct_metadata(sym,
+                                    (struct_member_t *)decl->var_decl.members,
+                                    decl->var_decl.member_count,
+                                    decl->var_decl.elem_size);
+    }
+
+    return 1;
+}
+

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -17,6 +17,7 @@
 #include "semantic_expr.h"
 #include "semantic_init.h"
 #include "semantic_var.h"
+#include "semantic_layout.h"
 #include "semantic_global.h"
 #include "ir_global.h"
 #include "symtable.h"


### PR DESCRIPTION
## Summary
- add new `semantic_layout.c`/`semantic_layout.h` containing layout and metadata utilities
- update semantic passes to include the new header
- compile new file via Makefile

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f2aaef23c8324adb33724ddfea527