### PR TITLE
Refactor x86 helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
-           src/codegen_float.c src/codegen_complex.c \
+           src/codegen_float.c src/codegen_complex.c src/codegen_x86.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
            src/preproc_expand.c src/preproc_table.c src/preproc_expr.c src/preproc_cond.c src/preproc_file.c \
            src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c
@@ -238,6 +238,9 @@ src/codegen_arith_float.o: src/codegen_arith_float.c $(HDR)
 
 src/codegen_complex.o: src/codegen_complex.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_complex.c -o src/codegen_complex.o
+
+src/codegen_x86.o: src/codegen_x86.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_x86.c -o src/codegen_x86.o
 
 
 src/codegen_branch.o: src/codegen_branch.c $(HDR)

--- a/include/codegen_x86.h
+++ b/include/codegen_x86.h
@@ -1,0 +1,21 @@
+#ifndef VC_CODEGEN_X86_H
+#define VC_CODEGEN_X86_H
+
+#include "strbuf.h"
+#include "ir_core.h"
+#include "regalloc.h"
+#include "cli.h"
+
+const char *x86_reg_str(int reg, asm_syntax_t syntax);
+const char *x86_fmt_reg(const char *name, asm_syntax_t syntax);
+const char *x86_loc_str(char buf[32], regalloc_t *ra, int id, int x64,
+                        asm_syntax_t syntax);
+
+void x86_emit_mov(strbuf_t *sb, const char *sfx,
+                  const char *src, const char *dest,
+                  asm_syntax_t syntax);
+void x86_emit_op(strbuf_t *sb, const char *op, const char *sfx,
+                 const char *src, const char *dest,
+                 asm_syntax_t syntax);
+
+#endif /* VC_CODEGEN_X86_H */

--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -8,47 +8,10 @@
 #include "codegen_arith_int.h"
 #include "codegen_arith_float.h"
 #include "codegen_float.h"
-#include "regalloc_x86.h"
+#include "codegen_x86.h"
 #include "label.h"
 
 #define SCRATCH_REG 0
-
-static const char *reg_str(int reg, asm_syntax_t syntax)
-{
-    const char *name = regalloc_reg_name(reg);
-    if (syntax == ASM_INTEL && name[0] == '%')
-        return name + 1;
-    return name;
-}
-
-static const char *fmt_reg(const char *name, asm_syntax_t syntax)
-{
-    if (syntax == ASM_INTEL && name[0] == '%')
-        return name + 1;
-    return name;
-}
-
-static const char *loc_str(char buf[32], regalloc_t *ra, int id, int x64,
-                           asm_syntax_t syntax)
-{
-    if (!ra || id <= 0)
-        return "";
-    int loc = ra->loc[id];
-    if (loc >= 0)
-        return reg_str(loc, syntax);
-    if (x64) {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[rbp-%d]", -loc * 8);
-        else
-            snprintf(buf, 32, "-%d(%%rbp)", -loc * 8);
-    } else {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[ebp-%d]", -loc * 4);
-        else
-            snprintf(buf, 32, "-%d(%%ebp)", -loc * 4);
-    }
-    return buf;
-}
 
 void emit_ptr_add(strbuf_t *sb, ir_instr_t *ins,
                   regalloc_t *ra, int x64,
@@ -58,28 +21,20 @@ void emit_ptr_add(strbuf_t *sb, ir_instr_t *ins,
     char b2[32];
     const char *sfx = x64 ? "q" : "l";
     int scale = ins->imm;
-    if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src2, x64, syntax));
-    else
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src2, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax),
+                 syntax);
     if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    imul%s %s, %d\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax), scale);
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax), scale);
     else
         strbuf_appendf(sb, "    imul%s $%d, %s\n", sfx, scale,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    add%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-    else
-        strbuf_appendf(sb, "    add%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    x86_emit_op(sb, "add", sfx,
+                x86_loc_str(b1, ra, ins->src1, x64, syntax),
+                x86_loc_str(b2, ra, ins->dest, x64, syntax),
+                syntax);
 }
 
 void emit_ptr_diff(strbuf_t *sb, ir_instr_t *ins,
@@ -92,25 +47,18 @@ void emit_ptr_diff(strbuf_t *sb, ir_instr_t *ins,
     int esz = ins->imm;
     int shift = 0;
     while ((esz >>= 1) > 0) shift++;
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    sub%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src2, x64, syntax));
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    x86_emit_op(sb, "sub", sfx,
+                x86_loc_str(b1, ra, ins->src2, x64, syntax),
+                x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    sar%s %s, %d\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax), shift);
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-        strbuf_appendf(sb, "    sub%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax), shift);
+    else
         strbuf_appendf(sb, "    sar%s $%d, %s\n", sfx, shift,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
 }
 
 void emit_int_arith(strbuf_t *sb, ir_instr_t *ins,
@@ -122,24 +70,15 @@ void emit_int_arith(strbuf_t *sb, ir_instr_t *ins,
     char mem[32];
     const char *sfx = x64 ? "q" : "l";
     int dest_spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
-    const char *dest_reg = dest_spill ? reg_str(SCRATCH_REG, syntax)
-                                      : loc_str(destb, ra, ins->dest, x64, syntax);
-    const char *dest_mem = loc_str(mem, ra, ins->dest, x64, syntax);
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest_reg,
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, dest_reg,
-                       loc_str(b1, ra, ins->src2, x64, syntax));
-        if (dest_spill)
-            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest_mem, dest_reg);
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax), dest_reg);
-        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax), dest_reg);
-        if (dest_spill)
-            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest_reg, dest_mem);
-    }
+    const char *dest_reg = dest_spill ? x86_reg_str(SCRATCH_REG, syntax)
+                                      : x86_loc_str(destb, ra, ins->dest, x64, syntax);
+    const char *dest_mem = x86_loc_str(mem, ra, ins->dest, x64, syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax), dest_reg, syntax);
+    x86_emit_op(sb, op, sfx,
+                x86_loc_str(b1, ra, ins->src2, x64, syntax), dest_reg, syntax);
+    if (dest_spill)
+        x86_emit_mov(sb, sfx, dest_reg, dest_mem, syntax);
 }
 
 void emit_div(strbuf_t *sb, ir_instr_t *ins,
@@ -149,24 +88,18 @@ void emit_div(strbuf_t *sb, ir_instr_t *ins,
     char b1[32];
     char b2[32];
     const char *sfx = x64 ? "q" : "l";
-    const char *ax = fmt_reg(x64 ? "%rax" : "%eax", syntax);
-    if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, ax,
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-    else
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax), ax);
+    const char *ax = x86_fmt_reg(x64 ? "%rax" : "%eax", syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax), ax,
+                 syntax);
     strbuf_appendf(sb, "    %s\n", x64 ? "cqto" : "cltd");
     strbuf_appendf(sb, "    idiv%s %s\n", sfx,
-                   loc_str(b1, ra, ins->src2, x64, syntax));
+                   x86_loc_str(b1, ra, ins->src2, x64, syntax));
     if (ra && ra->loc[ins->dest] >= 0 &&
         strcmp(regalloc_reg_name(ra->loc[ins->dest]), ax) != 0) {
-        if (syntax == ASM_INTEL)
-            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                           loc_str(b2, ra, ins->dest, x64, syntax), ax);
-        else
-            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, ax,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+        x86_emit_mov(sb, sfx, ax,
+                     x86_loc_str(b2, ra, ins->dest, x64, syntax),
+                     syntax);
     }
 }
 
@@ -177,27 +110,20 @@ void emit_mod(strbuf_t *sb, ir_instr_t *ins,
     char b1[32];
     char b2[32];
     const char *sfx = x64 ? "q" : "l";
-    const char *ax = fmt_reg(x64 ? "%rax" : "%eax", syntax);
-    if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, ax,
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-    else
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax), ax);
+    const char *ax = x86_fmt_reg(x64 ? "%rax" : "%eax", syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax), ax,
+                 syntax);
     strbuf_appendf(sb, "    %s\n", x64 ? "cqto" : "cltd");
     strbuf_appendf(sb, "    idiv%s %s\n", sfx,
-                   loc_str(b1, ra, ins->src2, x64, syntax));
+                   x86_loc_str(b1, ra, ins->src2, x64, syntax));
     if (ra && ra->loc[ins->dest] >= 0 &&
         strcmp(regalloc_reg_name(ra->loc[ins->dest]),
                x64 ? "%rdx" : "%edx") != 0) {
-        if (syntax == ASM_INTEL)
-            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                           loc_str(b2, ra, ins->dest, x64, syntax),
-                           fmt_reg(x64 ? "%rdx" : "%edx", syntax));
-        else
-            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                           fmt_reg(x64 ? "%rdx" : "%edx", syntax),
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+        x86_emit_mov(sb, sfx,
+                     x86_fmt_reg(x64 ? "%rdx" : "%edx", syntax),
+                     x86_loc_str(b2, ra, ins->dest, x64, syntax),
+                     syntax);
     }
 }
 
@@ -208,24 +134,18 @@ void emit_shift(strbuf_t *sb, ir_instr_t *ins,
     char b1[32];
     char b2[32];
     const char *sfx = x64 ? "q" : "l";
-    const char *cx = fmt_reg(x64 ? "%rcx" : "%ecx", syntax);
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, cx,
-                       loc_str(b1, ra, ins->src2, x64, syntax));
+    const char *cx = x86_fmt_reg(x64 ? "%rcx" : "%ecx", syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src2, x64, syntax), cx, syntax);
+    if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, cx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax), cx);
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    else
         strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, "%cl",
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
 }
 
 void emit_bitwise(strbuf_t *sb, ir_instr_t *ins,
@@ -235,21 +155,12 @@ void emit_bitwise(strbuf_t *sb, ir_instr_t *ins,
     char b1[32];
     char b2[32];
     const char *sfx = x64 ? "q" : "l";
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src2, x64, syntax));
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    x86_emit_op(sb, op, sfx,
+                x86_loc_str(b1, ra, ins->src2, x64, syntax),
+                x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
 }
 
 void emit_cmp(strbuf_t *sb, ir_instr_t *ins,
@@ -269,28 +180,16 @@ void emit_cmp(strbuf_t *sb, ir_instr_t *ins,
     case IR_CMPGE: cc = "ge"; break;
     default: break;
     }
-    const char *al = fmt_reg("%al", syntax);
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src2, x64, syntax));
-        strbuf_appendf(sb, "    set%s %s\n", cc, al);
-        strbuf_appendf(sb, "    %s %s, %s\n", x64 ? "movzbq" : "movzbl",
-                       al, loc_str(b2, ra, ins->dest, x64, syntax));
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-        strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-        strbuf_appendf(sb, "    set%s %s\n", cc, al);
-        strbuf_appendf(sb, "    %s %s, %s\n", x64 ? "movzbq" : "movzbl",
-                       al, loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+    const char *al = x86_fmt_reg("%al", syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
+                   x86_loc_str(b1, ra, ins->src2, x64, syntax),
+                   x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    strbuf_appendf(sb, "    set%s %s\n", cc, al);
+    strbuf_appendf(sb, "    %s %s, %s\n", x64 ? "movzbq" : "movzbl", al,
+                   x86_loc_str(b2, ra, ins->dest, x64, syntax));
 }
 
 void emit_logand(strbuf_t *sb, ir_instr_t *ins,
@@ -306,45 +205,37 @@ void emit_logand(strbuf_t *sb, ir_instr_t *ins,
     if (!label_format_suffix("L", id, "_false", fl) ||
         !label_format_suffix("L", id, "_end", end))
         return;
-    const char *al = fmt_reg("%al", syntax);
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
+    const char *al = x86_fmt_reg("%al", syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    cmp%s %s, 0\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    else
         strbuf_appendf(sb, "    cmp%s $0, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "    je %s\n", fl);
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src2, x64, syntax));
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src2, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    cmp%s %s, 0\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    else
         strbuf_appendf(sb, "    cmp%s $0, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "    setne %s\n", al);
     strbuf_appendf(sb, "    %s %s, %s\n", x64 ? "movzbq" : "movzbl", al,
-                   loc_str(b2, ra, ins->dest, x64, syntax));
+                   x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "    jmp %s\n", end);
     strbuf_appendf(sb, "%s:\n", fl);
     if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    mov%s %s, 0\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     else
         strbuf_appendf(sb, "    mov%s $0, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "%s:\n", end);
 }
 
@@ -361,45 +252,37 @@ void emit_logor(strbuf_t *sb, ir_instr_t *ins,
     if (!label_format_suffix("L", id, "_true", tl) ||
         !label_format_suffix("L", id, "_end", end))
         return;
-    const char *al = fmt_reg("%al", syntax);
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
+    const char *al = x86_fmt_reg("%al", syntax);
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    cmp%s %s, 0\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    else
         strbuf_appendf(sb, "    cmp%s $0, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "    jne %s\n", tl);
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src2, x64, syntax));
+    x86_emit_mov(sb, sfx,
+                 x86_loc_str(b1, ra, ins->src2, x64, syntax),
+                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+    if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    cmp%s %s, 0\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    } else {
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    else
         strbuf_appendf(sb, "    cmp%s $0, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
-    }
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "    setne %s\n", al);
     strbuf_appendf(sb, "    %s %s, %s\n", x64 ? "movzbq" : "movzbl", al,
-                   loc_str(b2, ra, ins->dest, x64, syntax));
+                   x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "    jmp %s\n", end);
     strbuf_appendf(sb, "%s:\n", tl);
     if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    mov%s %s, 1\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     else
         strbuf_appendf(sb, "    mov%s $1, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "%s:\n", end);
 }
 

--- a/src/codegen_x86.c
+++ b/src/codegen_x86.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include "codegen_x86.h"
+#include "regalloc_x86.h"
+
+const char *x86_reg_str(int reg, asm_syntax_t syntax)
+{
+    const char *name = regalloc_reg_name(reg);
+    if (syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
+}
+
+const char *x86_fmt_reg(const char *name, asm_syntax_t syntax)
+{
+    if (syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
+}
+
+const char *x86_loc_str(char buf[32], regalloc_t *ra, int id, int x64,
+                        asm_syntax_t syntax)
+{
+    if (!ra || id <= 0)
+        return "";
+    int loc = ra->loc[id];
+    if (loc >= 0)
+        return x86_reg_str(loc, syntax);
+    if (x64) {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[rbp-%d]", -loc * 8);
+        else
+            snprintf(buf, 32, "-%d(%%rbp)", -loc * 8);
+    } else {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[ebp-%d]", -loc * 4);
+        else
+            snprintf(buf, 32, "-%d(%%ebp)", -loc * 4);
+    }
+    return buf;
+}
+
+void x86_emit_mov(strbuf_t *sb, const char *sfx,
+                  const char *src, const char *dest,
+                  asm_syntax_t syntax)
+{
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest, src);
+    else
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, src, dest);
+}
+
+void x86_emit_op(strbuf_t *sb, const char *op, const char *sfx,
+                 const char *src, const char *dest,
+                 asm_syntax_t syntax)
+{
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, dest, src);
+    else
+        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, src, dest);
+}
+


### PR DESCRIPTION
## Summary
- share x86 codegen helpers and cleanup codegen_arith_int
- add new `codegen_x86` helper module
- update build rules for new module

## Testing
- `make -j$(nproc)`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f2afc43948324a65d84040a8f97bb