### PR TITLE
Refactor stmt handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/parser_flow.c src/parser_stmt.c src/parser_types.c \
            src/semantic_expr.c src/semantic_expr_const.c src/semantic_expr_cast.c \
            src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
-           src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c src/semantic_layout.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
+           src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c \
+           src/semantic_block.c src/semantic_decl.c src/semantic_expr_stmt.c src/semantic_label.c src/semantic_return.c src/semantic_static_assert.c \
+           src/semantic_layout.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
            src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c src/codegen_x86.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
@@ -187,10 +189,22 @@ src/semantic_var.o: src/semantic_var.c $(HDR)
 
 src/semantic_stmt.o: src/semantic_stmt.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_stmt.c -o src/semantic_stmt.o
+src/semantic_block.o: src/semantic_block.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_block.c -o src/semantic_block.o
+src/semantic_decl.o: src/semantic_decl.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_decl.c -o src/semantic_decl.o
+src/semantic_expr_stmt.o: src/semantic_expr_stmt.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_expr_stmt.c -o src/semantic_expr_stmt.o
+src/semantic_label.o: src/semantic_label.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_label.c -o src/semantic_label.o
+src/semantic_return.o: src/semantic_return.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_return.c -o src/semantic_return.o
+src/semantic_static_assert.o: src/semantic_static_assert.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_static_assert.c -o src/semantic_static_assert.o
 src/semantic_layout.o: src/semantic_layout.c $(HDR)
-	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_layout.c -o src/semantic_layout.o
+	        $(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_layout.c -o src/semantic_layout.o
 src/semantic_inline.o: src/semantic_inline.c $(HDR)
-	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_inline.c -o src/semantic_inline.o
+		$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_inline.c -o src/semantic_inline.o
 
 
 src/semantic_global.o: src/semantic_global.c $(HDR)

--- a/include/symtable.h
+++ b/include/symtable.h
@@ -129,4 +129,7 @@ symbol_t *symtable_lookup(symtable_t *table, const char *name);
 /* Search only the `globals` list. */
 symbol_t *symtable_lookup_global(symtable_t *table, const char *name);
 
+/* Remove all symbols added after old_head from the table */
+void symtable_pop_scope(symtable_t *table, symbol_t *old_head);
+
 #endif /* VC_SYMTABLE_H */

--- a/src/semantic_block.c
+++ b/src/semantic_block.c
@@ -1,0 +1,23 @@
+#include "semantic_stmt.h"
+#include "semantic_control.h"
+#include "symtable.h"
+#include "ir_core.h"
+
+int stmt_block_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                       label_table_t *labels, ir_builder_t *ir,
+                       type_kind_t func_ret_type,
+                       const char *break_label,
+                       const char *continue_label)
+{
+    symbol_t *old_head = vars->head;
+    for (size_t i = 0; i < stmt->block.count; i++) {
+        if (!check_stmt(stmt->block.stmts[i], vars, funcs, labels, ir,
+                        func_ret_type, break_label, continue_label)) {
+            symtable_pop_scope(vars, old_head);
+            return 0;
+        }
+    }
+    symtable_pop_scope(vars, old_head);
+    return 1;
+}
+

--- a/src/semantic_control.c
+++ b/src/semantic_control.c
@@ -228,6 +228,24 @@ int check_switch_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     return ok;
 }
 
+int stmt_if_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                    label_table_t *labels, ir_builder_t *ir,
+                    type_kind_t func_ret_type,
+                    const char *break_label, const char *continue_label)
+{
+    return check_if_stmt(stmt, vars, funcs, labels, ir, func_ret_type,
+                         break_label, continue_label);
+}
+
+int stmt_switch_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                        label_table_t *labels, ir_builder_t *ir,
+                        type_kind_t func_ret_type,
+                        const char *break_label, const char *continue_label)
+{
+    (void)break_label; (void)continue_label;
+    return check_switch_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
+}
+
 /*
  * Validate an if/else statement and emit the corresponding IR.
  * The condition is evaluated once to decide which branch executes and

--- a/src/semantic_decl.c
+++ b/src/semantic_decl.c
@@ -1,0 +1,219 @@
+#include <stdlib.h>
+#include <string.h>
+#include "semantic_stmt.h"
+#include "semantic_var.h"
+#include "semantic_layout.h"
+#include "consteval.h"
+#include "semantic_control.h"
+#include "ir_core.h"
+#include "label.h"
+#include "error.h"
+
+static int check_enum_decl_stmt(stmt_t *stmt, symtable_t *vars)
+{
+    int next = 0;
+    for (size_t i = 0; i < stmt->enum_decl.count; i++) {
+        enumerator_t *e = &stmt->enum_decl.items[i];
+        long long val = next;
+        if (e->value) {
+            if (!eval_const_expr(e->value, vars, 0, &val)) {
+                error_set(e->value->line, e->value->column, error_current_file,
+                          error_current_function);
+                return 0;
+            }
+        }
+        if (!symtable_add_enum(vars, e->name, (int)val)) {
+            error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+            return 0;
+        }
+        next = (int)val + 1;
+    }
+    if (stmt->enum_decl.tag && stmt->enum_decl.tag[0])
+        symtable_add_enum_tag(vars, stmt->enum_decl.tag);
+    return 1;
+}
+
+static int check_struct_decl_stmt(stmt_t *stmt, symtable_t *vars)
+{
+    size_t total = layout_struct_members(stmt->struct_decl.members,
+                                         stmt->struct_decl.count);
+    if (!symtable_add_struct(vars, stmt->struct_decl.tag,
+                             stmt->struct_decl.members,
+                             stmt->struct_decl.count)) {
+        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+        return 0;
+    }
+    symbol_t *stype = symtable_lookup_struct(vars, stmt->struct_decl.tag);
+    if (stype)
+        stype->struct_total_size = total;
+    return 1;
+}
+
+static int check_union_decl_stmt(stmt_t *stmt, symtable_t *vars)
+{
+    size_t max = layout_union_members(stmt->union_decl.members,
+                                      stmt->union_decl.count);
+    (void)max;
+    if (!symtable_add_union(vars, stmt->union_decl.tag,
+                            stmt->union_decl.members,
+                            stmt->union_decl.count)) {
+        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+        return 0;
+    }
+    return 1;
+}
+
+static int check_typedef_stmt(stmt_t *stmt, symtable_t *vars)
+{
+    if (!symtable_add_typedef(vars, stmt->typedef_decl.name,
+                              stmt->typedef_decl.type,
+                              stmt->typedef_decl.array_size,
+                              stmt->typedef_decl.elem_size)) {
+        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+        return 0;
+    }
+    return 1;
+}
+
+static symbol_t *insert_var_symbol(stmt_t *stmt, symtable_t *vars,
+                                   const char *ir_name)
+{
+    if (stmt->var_decl.align_expr) {
+        long long aval;
+        if (!eval_const_expr(stmt->var_decl.align_expr, vars, 0, &aval) ||
+            aval <= 0 || (aval & (aval - 1))) {
+            error_set(stmt->var_decl.align_expr->line,
+                      stmt->var_decl.align_expr->column,
+                      error_current_file, error_current_function);
+            error_print("Invalid alignment");
+            return NULL;
+        }
+        stmt->var_decl.alignment = (size_t)aval;
+    }
+    if (!symtable_add(vars, stmt->var_decl.name, ir_name,
+                      stmt->var_decl.type,
+                      stmt->var_decl.array_size,
+                      stmt->var_decl.elem_size,
+                      stmt->var_decl.alignment,
+                      stmt->var_decl.is_static,
+                      stmt->var_decl.is_register,
+                      stmt->var_decl.is_const,
+                      stmt->var_decl.is_volatile,
+                      stmt->var_decl.is_restrict))
+        return NULL;
+
+    symbol_t *sym = symtable_lookup(vars, stmt->var_decl.name);
+    if (stmt->var_decl.init_list && stmt->var_decl.type == TYPE_ARRAY &&
+        stmt->var_decl.array_size == 0) {
+        stmt->var_decl.array_size = stmt->var_decl.init_count;
+        sym->array_size = stmt->var_decl.array_size;
+    }
+
+    return sym;
+}
+
+static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
+{
+    char ir_name_buf[32];
+    const char *ir_name = stmt->var_decl.name;
+    if (stmt->var_decl.is_static) {
+        if (!label_format("__static", label_next_id(), ir_name_buf))
+            return NULL;
+        ir_name = ir_name_buf;
+    }
+
+    if (!compute_var_layout(stmt, vars))
+        return NULL;
+    if (stmt->var_decl.is_const && !stmt->var_decl.init &&
+        !stmt->var_decl.init_list) {
+        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+        return NULL;
+    }
+    symbol_t *sym = insert_var_symbol(stmt, vars, ir_name);
+    if (!sym) {
+        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+        return NULL;
+    }
+
+    sym->func_ret_type = stmt->var_decl.func_ret_type;
+    sym->func_param_count = stmt->var_decl.func_param_count;
+    sym->func_variadic = stmt->var_decl.func_variadic;
+    if (stmt->var_decl.func_param_count) {
+        sym->func_param_types = malloc(sym->func_param_count * sizeof(type_kind_t));
+        if (!sym->func_param_types)
+            return NULL;
+        for (size_t i = 0; i < sym->func_param_count; i++)
+            sym->func_param_types[i] = stmt->var_decl.func_param_types[i];
+    }
+
+    return sym;
+}
+
+static int check_var_decl_stmt(stmt_t *stmt, symtable_t *vars,
+                               symtable_t *funcs, ir_builder_t *ir)
+{
+    symbol_t *sym = register_var_symbol(stmt, vars);
+    if (!sym)
+        return 0;
+    if (stmt->var_decl.type == TYPE_ARRAY && stmt->var_decl.array_size == 0 &&
+        stmt->var_decl.size_expr) {
+        if (!handle_vla_size(stmt, sym, vars, funcs, ir))
+            return 0;
+    }
+    return emit_var_initializer(stmt, sym, vars, funcs, ir);
+}
+
+int stmt_typedef_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                         label_table_t *labels, ir_builder_t *ir,
+                         type_kind_t func_ret_type,
+                         const char *break_label,
+                         const char *continue_label)
+{
+    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
+    (void)break_label; (void)continue_label;
+    return check_typedef_stmt(stmt, vars);
+}
+
+int stmt_enum_decl_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                           label_table_t *labels, ir_builder_t *ir,
+                           type_kind_t func_ret_type,
+                           const char *break_label,
+                           const char *continue_label)
+{
+    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
+    (void)break_label; (void)continue_label;
+    return check_enum_decl_stmt(stmt, vars);
+}
+
+int stmt_struct_decl_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                             label_table_t *labels, ir_builder_t *ir,
+                             type_kind_t func_ret_type,
+                             const char *break_label,
+                             const char *continue_label)
+{
+    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
+    (void)break_label; (void)continue_label;
+    return check_struct_decl_stmt(stmt, vars);
+}
+
+int stmt_union_decl_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                            label_table_t *labels, ir_builder_t *ir,
+                            type_kind_t func_ret_type,
+                            const char *break_label,
+                            const char *continue_label)
+{
+    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
+    (void)break_label; (void)continue_label;
+    return check_union_decl_stmt(stmt, vars);
+}
+
+int stmt_var_decl_handler(stmt_t *stmt, symtable_t *vars,
+                          symtable_t *funcs, label_table_t *labels,
+                          ir_builder_t *ir, type_kind_t func_ret_type,
+                          const char *break_label,
+                          const char *continue_label)
+{
+    (void)labels; (void)func_ret_type; (void)break_label; (void)continue_label;
+    return check_var_decl_stmt(stmt, vars, funcs, ir);
+}
+

--- a/src/semantic_expr_stmt.c
+++ b/src/semantic_expr_stmt.c
@@ -1,0 +1,21 @@
+#include "semantic_stmt.h"
+#include "semantic_expr.h"
+#include "semantic_control.h"
+#include "ir_core.h"
+
+static int check_expr_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                           ir_builder_t *ir)
+{
+    ir_value_t tmp;
+    return check_expr(stmt->expr.expr, vars, funcs, ir, &tmp) != TYPE_UNKNOWN;
+}
+
+int stmt_expr_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                      label_table_t *labels, ir_builder_t *ir,
+                      type_kind_t func_ret_type,
+                      const char *break_label,
+                      const char *continue_label)
+{
+    (void)labels; (void)func_ret_type; (void)break_label; (void)continue_label;
+    return check_expr_stmt(stmt, vars, funcs, ir);
+}

--- a/src/semantic_label.c
+++ b/src/semantic_label.c
@@ -1,0 +1,43 @@
+#include "semantic_stmt.h"
+#include "semantic_control.h"
+#include "ir_core.h"
+#include "error.h"
+
+static int handle_label_stmt(stmt_t *stmt, label_table_t *labels,
+                             ir_builder_t *ir)
+{
+    const char *ir_name = label_table_get_or_add(labels, stmt->label.name);
+    ir_build_label(ir, ir_name);
+    return 1;
+}
+
+static int check_goto_stmt(stmt_t *stmt, label_table_t *labels,
+                           ir_builder_t *ir)
+{
+    const char *ir_name = label_table_get_or_add(labels, stmt->goto_stmt.name);
+    ir_build_br(ir, ir_name);
+    return 1;
+}
+
+int stmt_label_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                       label_table_t *labels, ir_builder_t *ir,
+                       type_kind_t func_ret_type,
+                       const char *break_label,
+                       const char *continue_label)
+{
+    (void)vars; (void)funcs; (void)func_ret_type;
+    (void)break_label; (void)continue_label;
+    return handle_label_stmt(stmt, labels, ir);
+}
+
+int stmt_goto_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                      label_table_t *labels, ir_builder_t *ir,
+                      type_kind_t func_ret_type,
+                      const char *break_label,
+                      const char *continue_label)
+{
+    (void)vars; (void)funcs; (void)func_ret_type;
+    (void)break_label; (void)continue_label;
+    return check_goto_stmt(stmt, labels, ir);
+}
+

--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -16,7 +16,6 @@
 extern int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                       void *labels, ir_builder_t *ir, type_kind_t func_ret_type,
                       const char *break_label, const char *continue_label);
-extern void symtable_pop_scope(symtable_t *table, symbol_t *old_head);
 
 /*
  * Perform semantic checks for a while loop.  The condition is
@@ -162,5 +161,57 @@ int check_continue_stmt(stmt_t *stmt, const char *continue_label,
                         ir_builder_t *ir)
 {
     return handle_loop_stmt(stmt, continue_label, ir);
+}
+
+int stmt_while_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                       label_table_t *labels, ir_builder_t *ir,
+                       type_kind_t func_ret_type,
+                       const char *break_label,
+                       const char *continue_label)
+{
+    (void)break_label; (void)continue_label;
+    return check_while_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
+}
+
+int stmt_do_while_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                          label_table_t *labels, ir_builder_t *ir,
+                          type_kind_t func_ret_type,
+                          const char *break_label,
+                          const char *continue_label)
+{
+    (void)break_label; (void)continue_label;
+    return check_do_while_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
+}
+
+int stmt_for_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                     label_table_t *labels, ir_builder_t *ir,
+                     type_kind_t func_ret_type,
+                     const char *break_label,
+                     const char *continue_label)
+{
+    (void)break_label; (void)continue_label;
+    return check_for_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
+}
+
+int stmt_break_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                       label_table_t *labels, ir_builder_t *ir,
+                       type_kind_t func_ret_type,
+                       const char *break_label,
+                       const char *continue_label)
+{
+    (void)vars; (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
+    (void)continue_label;
+    return check_break_stmt(stmt, break_label, ir);
+}
+
+int stmt_continue_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                          label_table_t *labels, ir_builder_t *ir,
+                          type_kind_t func_ret_type,
+                          const char *break_label,
+                          const char *continue_label)
+{
+    (void)vars; (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
+    (void)break_label;
+    return check_continue_stmt(stmt, continue_label, ir);
 }
 

--- a/src/semantic_return.c
+++ b/src/semantic_return.c
@@ -1,0 +1,92 @@
+#include "semantic_stmt.h"
+#include "semantic_expr.h"
+#include "symtable.h"
+#include "semantic_control.h"
+#include "ir_core.h"
+#include "error.h"
+
+static int validate_struct_return(stmt_t *stmt, symtable_t *vars,
+                                  symtable_t *funcs, type_kind_t expr_type,
+                                  type_kind_t func_ret_type)
+{
+    if (expr_type != func_ret_type) {
+        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+                  error_current_file, error_current_function);
+        return 0;
+    }
+
+    symbol_t *func_sym = symtable_lookup(funcs,
+                                         error_current_function ?
+                                         error_current_function : "");
+    size_t expected = func_sym ? func_sym->ret_struct_size : 0;
+    size_t actual = 0;
+
+    if (stmt->ret.expr->kind == EXPR_IDENT) {
+        symbol_t *vsym = symtable_lookup(vars, stmt->ret.expr->ident.name);
+        if (vsym)
+            actual = (expr_type == TYPE_STRUCT)
+                ? vsym->struct_total_size : vsym->total_size;
+    } else if (stmt->ret.expr->kind == EXPR_CALL) {
+        symbol_t *fsym = symtable_lookup(funcs, stmt->ret.expr->call.name);
+        if (!fsym)
+            fsym = symtable_lookup(vars, stmt->ret.expr->call.name);
+        if (fsym)
+            actual = fsym->ret_struct_size;
+    } else if (stmt->ret.expr->kind == EXPR_COMPLIT) {
+        actual = stmt->ret.expr->compound.elem_size;
+    }
+
+    if (expected && actual && expected != actual) {
+        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+                  error_current_file, error_current_function);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
+                              symtable_t *funcs, ir_builder_t *ir,
+                              type_kind_t func_ret_type)
+{
+    if (!stmt->ret.expr) {
+        if (func_ret_type != TYPE_VOID) {
+            error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+            return 0;
+        }
+        ir_value_t zero = ir_build_const(ir, 0);
+        ir_build_return(ir, zero);
+        return 1;
+    }
+
+    ir_value_t val;
+    type_kind_t vt = check_expr(stmt->ret.expr, vars, funcs, ir, &val);
+    if (vt == TYPE_UNKNOWN) {
+        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+                  error_current_file, error_current_function);
+        return 0;
+    }
+
+    if (func_ret_type == TYPE_STRUCT || func_ret_type == TYPE_UNION) {
+        if (!validate_struct_return(stmt, vars, funcs, vt, func_ret_type))
+            return 0;
+        ir_value_t ret_ptr = ir_build_load_param(ir, 0);
+        ir_build_store_ptr(ir, ret_ptr, val);
+        ir_build_return_agg(ir, ret_ptr);
+        return 1;
+    }
+
+    ir_build_return(ir, val);
+    return 1;
+}
+
+int stmt_return_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                        label_table_t *labels, ir_builder_t *ir,
+                        type_kind_t func_ret_type,
+                        const char *break_label,
+                        const char *continue_label)
+{
+    (void)labels; (void)break_label; (void)continue_label;
+    return handle_return_stmt(stmt, vars, funcs, ir, func_ret_type);
+}
+

--- a/src/semantic_static_assert.c
+++ b/src/semantic_static_assert.c
@@ -1,0 +1,34 @@
+#include "semantic_stmt.h"
+#include "semantic_control.h"
+#include "ir_core.h"
+#include "consteval.h"
+#include "error.h"
+
+static int check_static_assert_stmt(stmt_t *stmt, symtable_t *vars)
+{
+    long long val;
+    if (!eval_const_expr(stmt->static_assert.expr, vars, 0, &val)) {
+        error_set(stmt->static_assert.expr->line, stmt->static_assert.expr->column,
+                  error_current_file, error_current_function);
+        return 0;
+    }
+    if (val == 0) {
+        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+        error_print(stmt->static_assert.message);
+        return 0;
+    }
+    return 1;
+}
+
+int stmt_static_assert_handler(stmt_t *stmt, symtable_t *vars,
+                               symtable_t *funcs, label_table_t *labels,
+                               ir_builder_t *ir,
+                               type_kind_t func_ret_type,
+                               const char *break_label,
+                               const char *continue_label)
+{
+    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
+    (void)break_label; (void)continue_label;
+    return check_static_assert_stmt(stmt, vars);
+}
+

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -1,701 +1,121 @@
 /*
- * Implementation of statement semantic checking.
- * Handles all statement kinds and emits IR reflecting their
- * control flow and side effects.
+ * Statement dispatch and unreachable warning helpers.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
 #include "semantic_stmt.h"
 #include "semantic_loops.h"
 #include "semantic_control.h"
-#include "consteval.h"
-#include "semantic_expr.h"
-#include "semantic_init.h"
-#include "semantic_var.h"
-#include "semantic_layout.h"
-#include "semantic_global.h"
-#include "ir_global.h"
-#include "symtable.h"
-#include "util.h"
 #include "label.h"
 #include "error.h"
-#include <limits.h>
+#include <string.h>
 
 bool semantic_warn_unreachable = true;
 
-
-
-/*
- * Remove all symbols added after old_head from the table.  Each entry
- * beyond the saved head is popped off the list and its memory is
- * released, effectively restoring the previous scope.
- */
-void symtable_pop_scope(symtable_t *table, symbol_t *old_head)
-{
-    while (table->head != old_head) {
-        symbol_t *sym = table->head;
-        table->head = sym->next;
-        free(sym->name);
-        free(sym->param_types);
-        free(sym);
-    }
-}
-/*
- * Validate an enum declaration and register its members.  Constant
- * values are evaluated, enumerators are inserted into the symbol
- * table sequentially and an optional tag is recorded.
- */
-static int check_enum_decl_stmt(stmt_t *stmt, symtable_t *vars)
-{
-    int next = 0;
-    for (size_t i = 0; i < stmt->enum_decl.count; i++) {
-        enumerator_t *e = &stmt->enum_decl.items[i];
-        long long val = next;
-        if (e->value) {
-            if (!eval_const_expr(e->value, vars, 0, &val)) {
-                error_set(e->value->line, e->value->column, error_current_file, error_current_function);
-                return 0;
-            }
-        }
-        if (!symtable_add_enum(vars, e->name, (int)val)) {
-            error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-            return 0;
-        }
-        next = (int)val + 1;
-    }
-    if (stmt->enum_decl.tag && stmt->enum_decl.tag[0])
-        symtable_add_enum_tag(vars, stmt->enum_decl.tag);
-    return 1;
-}
-/*
- * Validate a struct declaration and store layout information.  Member
- * offsets are calculated, the type is registered in the symbol table
- * and the total size is recorded for later use.
- */
-static int check_struct_decl_stmt(stmt_t *stmt, symtable_t *vars)
-{
-    size_t total = layout_struct_members(stmt->struct_decl.members,
-                                         stmt->struct_decl.count);
-    if (!symtable_add_struct(vars, stmt->struct_decl.tag,
-                             stmt->struct_decl.members,
-                             stmt->struct_decl.count)) {
-        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        return 0;
-    }
-    symbol_t *stype = symtable_lookup_struct(vars, stmt->struct_decl.tag);
-    if (stype)
-        stype->struct_total_size = total;
-    return 1;
-}
-/*
- * Validate a union declaration and record its size.  Member offsets are
- * calculated and the type is inserted into the symbol table so that
- * later references know the union layout.
- */
-static int check_union_decl_stmt(stmt_t *stmt, symtable_t *vars)
-{
-    size_t max = layout_union_members(stmt->union_decl.members,
-                                      stmt->union_decl.count);
-    (void)max;
-    if (!symtable_add_union(vars, stmt->union_decl.tag,
-                            stmt->union_decl.members,
-                            stmt->union_decl.count)) {
-        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        return 0;
-    }
-    return 1;
-}
-/*
- * Register a typedef alias in the symbol table.  The alias name and
- * type information are stored so that future declarations can refer to
- * the typedef.
- */
-static int check_typedef_stmt(stmt_t *stmt, symtable_t *vars)
-{
-    if (!symtable_add_typedef(vars, stmt->typedef_decl.name,
-                              stmt->typedef_decl.type,
-                              stmt->typedef_decl.array_size,
-                              stmt->typedef_decl.elem_size)) {
-        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        return 0;
-    }
-    return 1;
-}
-
-
-/*
- * Insert the variable into the given symbol table using the provided
- * IR name.  If successful the inserted symbol is returned, otherwise
- * NULL is returned.
- */
-static symbol_t *insert_var_symbol(stmt_t *stmt, symtable_t *vars,
-                                   const char *ir_name)
-{
-    if (stmt->var_decl.align_expr) {
-        long long aval;
-        if (!eval_const_expr(stmt->var_decl.align_expr, vars, 0, &aval) ||
-            aval <= 0 || (aval & (aval - 1))) {
-            error_set(stmt->var_decl.align_expr->line,
-                      stmt->var_decl.align_expr->column,
-                      error_current_file, error_current_function);
-            error_print("Invalid alignment");
-            return NULL;
-        }
-        stmt->var_decl.alignment = (size_t)aval;
-    }
-    if (!symtable_add(vars, stmt->var_decl.name, ir_name,
-                      stmt->var_decl.type,
-                      stmt->var_decl.array_size,
-                      stmt->var_decl.elem_size,
-                      stmt->var_decl.alignment,
-                      stmt->var_decl.is_static,
-                      stmt->var_decl.is_register,
-                      stmt->var_decl.is_const,
-                      stmt->var_decl.is_volatile,
-                      stmt->var_decl.is_restrict))
-        return NULL;
-
-    symbol_t *sym = symtable_lookup(vars, stmt->var_decl.name);
-    if (stmt->var_decl.init_list && stmt->var_decl.type == TYPE_ARRAY &&
-        stmt->var_decl.array_size == 0) {
-        stmt->var_decl.array_size = stmt->var_decl.init_count;
-        sym->array_size = stmt->var_decl.array_size;
-    }
-
-    return sym;
-}
-
-/*
- * Register the variable symbol in the current scope.
- * Handles static name mangling, computes layout information for
- * aggregate types and inserts the symbol into the table.
- * Returns the inserted symbol or NULL on failure.
- */
-static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
-{
-    char ir_name_buf[32];
-    const char *ir_name = stmt->var_decl.name;
-    if (stmt->var_decl.is_static) {
-        if (!label_format("__static", label_next_id(), ir_name_buf))
-            return NULL;
-        ir_name = ir_name_buf;
-    }
-
-    if (!compute_var_layout(stmt, vars))
-        return NULL;
-    if (stmt->var_decl.is_const && !stmt->var_decl.init &&
-        !stmt->var_decl.init_list) {
-        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        return NULL;
-    }
-    symbol_t *sym = insert_var_symbol(stmt, vars, ir_name);
-    if (!sym) {
-        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        return NULL;
-    }
-
-    sym->func_ret_type = stmt->var_decl.func_ret_type;
-    sym->func_param_count = stmt->var_decl.func_param_count;
-    sym->func_variadic = stmt->var_decl.func_variadic;
-    if (stmt->var_decl.func_param_count) {
-        sym->func_param_types = malloc(sym->func_param_count * sizeof(type_kind_t));
-        if (!sym->func_param_types)
-            return NULL;
-        for (size_t i = 0; i < sym->func_param_count; i++)
-            sym->func_param_types[i] = stmt->var_decl.func_param_types[i];
-    }
-
-    return sym;
-}
-
-/*
- * Copy union member metadata from the parsed declaration to the symbol.
- * Allocates new member arrays and duplicates names. Returns non-zero on
- * success.
- */
-static int check_var_decl_stmt(stmt_t *stmt, symtable_t *vars,
-                               symtable_t *funcs, ir_builder_t *ir)
-{
-    symbol_t *sym = register_var_symbol(stmt, vars);
-    if (!sym)
-        return 0;
-    if (stmt->var_decl.type == TYPE_ARRAY && stmt->var_decl.array_size == 0 &&
-        stmt->var_decl.size_expr) {
-        if (!handle_vla_size(stmt, sym, vars, funcs, ir))
-            return 0;
-    }
-    return emit_var_initializer(stmt, sym, vars, funcs, ir);
-}
-/*
- * Perform semantic checking and emit IR for an if/else statement.  The
- * condition expression is evaluated and used to branch to either the
- * then or else part.  Both branches are validated and finally control
- * converges at a common end label.
- */
-
-
-/*
- * Validate a struct or union return expression. The type must match
- * the function signature and the size of the returned aggregate must
- * agree with the expected size recorded for the function. Returns
- * non-zero on success.
- */
-static int validate_struct_return(stmt_t *stmt, symtable_t *vars,
-                                  symtable_t *funcs, type_kind_t expr_type,
-                                  type_kind_t func_ret_type)
-{
-    if (expr_type != func_ret_type) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
-                  error_current_file, error_current_function);
-        return 0;
-    }
-
-    symbol_t *func_sym = symtable_lookup(funcs,
-                                         error_current_function ?
-                                         error_current_function : "");
-    size_t expected = func_sym ? func_sym->ret_struct_size : 0;
-    size_t actual = 0;
-
-    if (stmt->ret.expr->kind == EXPR_IDENT) {
-        symbol_t *vsym = symtable_lookup(vars, stmt->ret.expr->ident.name);
-        if (vsym)
-            actual = (expr_type == TYPE_STRUCT)
-                ? vsym->struct_total_size : vsym->total_size;
-    } else if (stmt->ret.expr->kind == EXPR_CALL) {
-        symbol_t *fsym = symtable_lookup(funcs, stmt->ret.expr->call.name);
-        if (!fsym)
-            fsym = symtable_lookup(vars, stmt->ret.expr->call.name);
-        if (fsym)
-            actual = fsym->ret_struct_size;
-    } else if (stmt->ret.expr->kind == EXPR_COMPLIT) {
-        actual = stmt->ret.expr->compound.elem_size;
-    }
-
-    if (expected && actual && expected != actual) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
-                  error_current_file, error_current_function);
-        return 0;
-    }
-
-    return 1;
-}
-
-/*
- * Handle a return statement. The optional expression is validated
- * and emitted as the function result. For void functions a zero
- * constant is returned when no expression is present.
- */
-static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
-                              symtable_t *funcs, ir_builder_t *ir,
-                              type_kind_t func_ret_type)
-{
-    if (!stmt->ret.expr) {
-        if (func_ret_type != TYPE_VOID) {
-            error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-            return 0;
-        }
-        ir_value_t zero = ir_build_const(ir, 0);
-        ir_build_return(ir, zero);
-        return 1;
-    }
-
-    ir_value_t val;
-    type_kind_t vt = check_expr(stmt->ret.expr, vars, funcs, ir, &val);
-    if (vt == TYPE_UNKNOWN) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
-                  error_current_file, error_current_function);
-        return 0;
-    }
-
-    if (func_ret_type == TYPE_STRUCT || func_ret_type == TYPE_UNION) {
-        if (!validate_struct_return(stmt, vars, funcs, vt, func_ret_type))
-            return 0;
-        ir_value_t ret_ptr = ir_build_load_param(ir, 0);
-        ir_build_store_ptr(ir, ret_ptr, val);
-        ir_build_return_agg(ir, ret_ptr);
-        return 1;
-    }
-
-    ir_build_return(ir, val);
-    return 1;
-}
-
-
-/*
- * Handle a label statement. The label name is recorded in the table
- * and a corresponding IR label is emitted.
- */
-static int handle_label_stmt(stmt_t *stmt, label_table_t *labels,
-                             ir_builder_t *ir)
-{
-    const char *ir_name = label_table_get_or_add(labels, stmt->label.name);
-    ir_build_label(ir, ir_name);
-    return 1;
-}
-
-/*
- * Validate an expression statement by evaluating the expression and
- * discarding the result.
- */
-static int check_expr_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                           ir_builder_t *ir)
-{
-    ir_value_t tmp;
-    return check_expr(stmt->expr.expr, vars, funcs, ir, &tmp) != TYPE_UNKNOWN;
-}
-
-/*
- * Wrapper around the return statement handler used by check_stmt.
- */
-static int check_return_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                             ir_builder_t *ir, type_kind_t func_ret_type)
-{
-    return handle_return_stmt(stmt, vars, funcs, ir, func_ret_type);
-}
-
-/*
- * Wrapper used to validate an if/else statement.
- */
-static int check_if_stmt_wrapper(stmt_t *stmt, symtable_t *vars,
-                                 symtable_t *funcs, label_table_t *labels,
-                                 ir_builder_t *ir, type_kind_t func_ret_type,
-                                 const char *break_label,
-                                 const char *continue_label)
-{
-    return check_if_stmt(stmt, vars, funcs, labels, ir, func_ret_type,
-                         break_label, continue_label);
-}
-
-/*
- * Wrapper used to validate a while loop.
- */
-static int check_while_stmt_wrapper(stmt_t *stmt, symtable_t *vars,
-                                    symtable_t *funcs, label_table_t *labels,
-                                    ir_builder_t *ir,
-                                    type_kind_t func_ret_type)
-{
-    return check_while_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
-}
-
-/*
- * Wrapper used to validate a do-while loop.
- */
-static int check_do_while_stmt_wrapper(stmt_t *stmt, symtable_t *vars,
-                                       symtable_t *funcs,
-                                       label_table_t *labels,
-                                       ir_builder_t *ir,
-                                       type_kind_t func_ret_type)
-{
-    return check_do_while_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
-}
-
-/*
- * Wrapper used to validate a for loop.
- */
-static int check_for_stmt_wrapper(stmt_t *stmt, symtable_t *vars,
-                                  symtable_t *funcs, label_table_t *labels,
-                                  ir_builder_t *ir,
-                                  type_kind_t func_ret_type)
-{
-    return check_for_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
-}
-
-/*
- * Wrapper used to validate a switch statement.
- */
-static int check_switch_stmt_wrapper(stmt_t *stmt, symtable_t *vars,
-                                     symtable_t *funcs,
-                                     label_table_t *labels,
-                                     ir_builder_t *ir,
-                                     type_kind_t func_ret_type)
-{
-    return check_switch_stmt(stmt, vars, funcs, labels, ir, func_ret_type);
-}
-
-/*
- * Validate a goto statement by resolving the target label and
- * emitting a branch.
- */
-static int check_goto_stmt(stmt_t *stmt, label_table_t *labels,
-                           ir_builder_t *ir)
-{
-    const char *ir_name = label_table_get_or_add(labels, stmt->goto_stmt.name);
-    ir_build_br(ir, ir_name);
-    return 1;
-}
-
-
-/* Evaluate a _Static_assert expression and emit an error if zero */
-static int check_static_assert_stmt(stmt_t *stmt, symtable_t *vars)
-{
-    long long val;
-    if (!eval_const_expr(stmt->static_assert.expr, vars, 0, &val)) {
-        error_set(stmt->static_assert.expr->line, stmt->static_assert.expr->column,
-                  error_current_file, error_current_function);
-        return 0;
-    }
-    if (val == 0) {
-        error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        error_print(stmt->static_assert.message);
-        return 0;
-    }
-    return 1;
-}
-
-/*
- * Validate a compound statement by recursively checking each contained
- * statement and restoring the variable scope on exit.
- */
-static int check_block_stmt_wrapper(stmt_t *stmt, symtable_t *vars,
-                                    symtable_t *funcs, label_table_t *labels,
-                                    ir_builder_t *ir,
-                                    type_kind_t func_ret_type,
-                                    const char *break_label,
-                                    const char *continue_label)
-{
-    symbol_t *old_head = vars->head;
-    for (size_t i = 0; i < stmt->block.count; i++) {
-        if (!check_stmt(stmt->block.stmts[i], vars, funcs, labels, ir,
-                        func_ret_type, break_label, continue_label)) {
-            symtable_pop_scope(vars, old_head);
-            return 0;
-        }
-    }
-    symtable_pop_scope(vars, old_head);
-    return 1;
-}
-
-/*
- * Wrapper for enum declarations.
- */
-static int check_enum_decl_stmt_wrapper(stmt_t *stmt, symtable_t *vars)
-{
-    return check_enum_decl_stmt(stmt, vars);
-}
-
-/*
- * Wrapper for struct declarations.
- */
-static int check_struct_decl_stmt_wrapper(stmt_t *stmt, symtable_t *vars)
-{
-    return check_struct_decl_stmt(stmt, vars);
-}
-
-/*
- * Wrapper for union declarations.
- */
-static int check_union_decl_stmt_wrapper(stmt_t *stmt, symtable_t *vars)
-{
-    return check_union_decl_stmt(stmt, vars);
-}
-
-/*
- * Wrapper for typedef declarations.
- */
-static int check_typedef_stmt_wrapper(stmt_t *stmt, symtable_t *vars)
-{
-    return check_typedef_stmt(stmt, vars);
-}
-
-/*
- * Wrapper for variable declarations.
- */
-static int check_var_decl_stmt_wrapper(stmt_t *stmt, symtable_t *vars,
-                                       symtable_t *funcs, ir_builder_t *ir)
-{
-    return check_var_decl_stmt(stmt, vars, funcs, ir);
-}
-
-typedef int (*stmt_handler_fn)(stmt_t *stmt, symtable_t *vars,
-                               symtable_t *funcs, label_table_t *labels,
-                               ir_builder_t *ir, type_kind_t func_ret_type,
-                               const char *break_label,
-                               const char *continue_label);
-
-/* Dispatch wrappers matching stmt_handler_fn */
-static int stmt_expr_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                             label_table_t *labels, ir_builder_t *ir,
-                             type_kind_t func_ret_type, const char *break_label,
-                             const char *continue_label)
-{
-    (void)labels; (void)func_ret_type; (void)break_label; (void)continue_label;
-    return check_expr_stmt(stmt, vars, funcs, ir);
-}
-
-static int stmt_return_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                               label_table_t *labels, ir_builder_t *ir,
-                               type_kind_t func_ret_type,
-                               const char *break_label,
-                               const char *continue_label)
-{
-    (void)labels; (void)break_label; (void)continue_label;
-    return check_return_stmt(stmt, vars, funcs, ir, func_ret_type);
-}
-
-static int stmt_var_decl_handler(stmt_t *stmt, symtable_t *vars,
-                                 symtable_t *funcs, label_table_t *labels,
-                                 ir_builder_t *ir, type_kind_t func_ret_type,
-                                 const char *break_label,
-                                 const char *continue_label)
-{
-    (void)labels; (void)func_ret_type; (void)break_label; (void)continue_label;
-    return check_var_decl_stmt_wrapper(stmt, vars, funcs, ir);
-}
-
-static int stmt_while_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                              label_table_t *labels, ir_builder_t *ir,
-                              type_kind_t func_ret_type,
-                              const char *break_label,
-                              const char *continue_label)
-{
-    (void)break_label; (void)continue_label;
-    return check_while_stmt_wrapper(stmt, vars, funcs, labels, ir,
-                                    func_ret_type);
-}
-
-static int stmt_do_while_handler(stmt_t *stmt, symtable_t *vars,
-                                 symtable_t *funcs, label_table_t *labels,
-                                 ir_builder_t *ir, type_kind_t func_ret_type,
-                                 const char *break_label,
-                                 const char *continue_label)
-{
-    (void)break_label; (void)continue_label;
-    return check_do_while_stmt_wrapper(stmt, vars, funcs, labels, ir,
-                                       func_ret_type);
-}
-
-static int stmt_for_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                            label_table_t *labels, ir_builder_t *ir,
-                            type_kind_t func_ret_type,
-                            const char *break_label,
-                            const char *continue_label)
-{
-    (void)break_label; (void)continue_label;
-    return check_for_stmt_wrapper(stmt, vars, funcs, labels, ir,
-                                  func_ret_type);
-}
-
-static int stmt_switch_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                               label_table_t *labels, ir_builder_t *ir,
-                               type_kind_t func_ret_type,
-                               const char *break_label,
-                               const char *continue_label)
-{
-    (void)break_label; (void)continue_label;
-    return check_switch_stmt_wrapper(stmt, vars, funcs, labels, ir,
-                                     func_ret_type);
-}
-
-static int stmt_label_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
-                              label_table_t *labels, ir_builder_t *ir,
-                              type_kind_t func_ret_type,
-                              const char *break_label,
-                              const char *continue_label)
-{
-    (void)vars; (void)funcs; (void)func_ret_type;
-    (void)break_label; (void)continue_label;
-    return handle_label_stmt(stmt, labels, ir);
-}
-
-static int stmt_goto_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+/* Handlers implemented in dedicated modules */
+extern int stmt_expr_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                              label_table_t *labels, ir_builder_t *ir,
                              type_kind_t func_ret_type,
                              const char *break_label,
-                             const char *continue_label)
-{
-    (void)vars; (void)funcs; (void)func_ret_type;
-    (void)break_label; (void)continue_label;
-    return check_goto_stmt(stmt, labels, ir);
-}
-
-static int stmt_static_assert_handler(stmt_t *stmt, symtable_t *vars,
+                             const char *continue_label);
+extern int stmt_return_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                               label_table_t *labels, ir_builder_t *ir,
+                               type_kind_t func_ret_type,
+                               const char *break_label,
+                               const char *continue_label);
+extern int stmt_var_decl_handler(stmt_t *stmt, symtable_t *vars,
+                                 symtable_t *funcs, label_table_t *labels,
+                                 ir_builder_t *ir, type_kind_t func_ret_type,
+                                 const char *break_label,
+                                 const char *continue_label);
+extern int stmt_if_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                           label_table_t *labels, ir_builder_t *ir,
+                           type_kind_t func_ret_type,
+                           const char *break_label,
+                           const char *continue_label);
+extern int stmt_while_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                              label_table_t *labels, ir_builder_t *ir,
+                              type_kind_t func_ret_type,
+                              const char *break_label,
+                              const char *continue_label);
+extern int stmt_do_while_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                                 label_table_t *labels, ir_builder_t *ir,
+                                 type_kind_t func_ret_type,
+                                 const char *break_label,
+                                 const char *continue_label);
+extern int stmt_for_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                            label_table_t *labels, ir_builder_t *ir,
+                            type_kind_t func_ret_type,
+                            const char *break_label,
+                            const char *continue_label);
+extern int stmt_switch_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                               label_table_t *labels, ir_builder_t *ir,
+                               type_kind_t func_ret_type,
+                               const char *break_label,
+                               const char *continue_label);
+extern int stmt_break_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                              label_table_t *labels, ir_builder_t *ir,
+                              type_kind_t func_ret_type,
+                              const char *break_label,
+                              const char *continue_label);
+extern int stmt_continue_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                                 label_table_t *labels, ir_builder_t *ir,
+                                 type_kind_t func_ret_type,
+                                 const char *break_label,
+                                 const char *continue_label);
+extern int stmt_label_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                              label_table_t *labels, ir_builder_t *ir,
+                              type_kind_t func_ret_type,
+                              const char *break_label,
+                              const char *continue_label);
+extern int stmt_goto_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                             label_table_t *labels, ir_builder_t *ir,
+                             type_kind_t func_ret_type,
+                             const char *break_label,
+                             const char *continue_label);
+extern int stmt_static_assert_handler(stmt_t *stmt, symtable_t *vars,
                                       symtable_t *funcs, label_table_t *labels,
                                       ir_builder_t *ir,
                                       type_kind_t func_ret_type,
                                       const char *break_label,
-                                      const char *continue_label)
-{
-    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
-    (void)break_label; (void)continue_label;
-    return check_static_assert_stmt(stmt, vars);
-}
-
-static int stmt_typedef_handler(stmt_t *stmt, symtable_t *vars,
-                                symtable_t *funcs, label_table_t *labels,
-                                ir_builder_t *ir, type_kind_t func_ret_type,
+                                      const char *continue_label);
+extern int stmt_typedef_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                                label_table_t *labels, ir_builder_t *ir,
+                                type_kind_t func_ret_type,
                                 const char *break_label,
-                                const char *continue_label)
-{
-    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
-    (void)break_label; (void)continue_label;
-    return check_typedef_stmt_wrapper(stmt, vars);
-}
-
-static int stmt_enum_decl_handler(stmt_t *stmt, symtable_t *vars,
-                                  symtable_t *funcs, label_table_t *labels,
-                                  ir_builder_t *ir, type_kind_t func_ret_type,
+                                const char *continue_label);
+extern int stmt_enum_decl_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                                  label_table_t *labels, ir_builder_t *ir,
+                                  type_kind_t func_ret_type,
                                   const char *break_label,
-                                  const char *continue_label)
-{
-    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
-    (void)break_label; (void)continue_label;
-    return check_enum_decl_stmt_wrapper(stmt, vars);
-}
-
-static int stmt_struct_decl_handler(stmt_t *stmt, symtable_t *vars,
-                                    symtable_t *funcs, label_table_t *labels,
-                                    ir_builder_t *ir, type_kind_t func_ret_type,
+                                  const char *continue_label);
+extern int stmt_struct_decl_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                                    label_table_t *labels, ir_builder_t *ir,
+                                    type_kind_t func_ret_type,
                                     const char *break_label,
-                                    const char *continue_label)
-{
-    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
-    (void)break_label; (void)continue_label;
-    return check_struct_decl_stmt_wrapper(stmt, vars);
-}
-
-static int stmt_union_decl_handler(stmt_t *stmt, symtable_t *vars,
-                                   symtable_t *funcs, label_table_t *labels,
-                                   ir_builder_t *ir, type_kind_t func_ret_type,
+                                    const char *continue_label);
+extern int stmt_union_decl_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                                   label_table_t *labels, ir_builder_t *ir,
+                                   type_kind_t func_ret_type,
                                    const char *break_label,
-                                   const char *continue_label)
-{
-    (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
-    (void)break_label; (void)continue_label;
-    return check_union_decl_stmt_wrapper(stmt, vars);
-}
-
-static int stmt_break_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
+                                   const char *continue_label);
+extern int stmt_block_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                               label_table_t *labels, ir_builder_t *ir,
                               type_kind_t func_ret_type,
                               const char *break_label,
-                              const char *continue_label)
-{
-    (void)vars; (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
-    (void)continue_label;
-    return check_break_stmt(stmt, break_label, ir);
-}
+                              const char *continue_label);
 
-static int stmt_continue_handler(stmt_t *stmt, symtable_t *vars,
-                                 symtable_t *funcs, label_table_t *labels,
-                                 ir_builder_t *ir, type_kind_t func_ret_type,
-                                 const char *break_label,
-                                 const char *continue_label)
-{
-    (void)vars; (void)funcs; (void)labels; (void)ir; (void)func_ret_type;
-    (void)break_label;
-    return check_continue_stmt(stmt, continue_label, ir);
-}
+typedef int (*stmt_handler_fn)(stmt_t *, symtable_t *, symtable_t *,
+                               label_table_t *, ir_builder_t *,
+                               type_kind_t, const char *, const char *);
 
 static stmt_handler_fn stmt_handlers[] = {
     [STMT_EXPR]        = stmt_expr_handler,
     [STMT_RETURN]      = stmt_return_handler,
     [STMT_VAR_DECL]    = stmt_var_decl_handler,
-    [STMT_IF]          = check_if_stmt_wrapper,
+    [STMT_IF]          = stmt_if_handler,
     [STMT_WHILE]       = stmt_while_handler,
     [STMT_DO_WHILE]    = stmt_do_while_handler,
     [STMT_FOR]         = stmt_for_handler,
@@ -709,17 +129,9 @@ static stmt_handler_fn stmt_handlers[] = {
     [STMT_ENUM_DECL]   = stmt_enum_decl_handler,
     [STMT_STRUCT_DECL] = stmt_struct_decl_handler,
     [STMT_UNION_DECL]  = stmt_union_decl_handler,
-    [STMT_BLOCK]       = check_block_stmt_wrapper,
+    [STMT_BLOCK]       = stmt_block_handler,
 };
 
-
-
-/*
- * Validate a single statement.  Depending on the statement kind this
- * routine dispatches to the appropriate helper.  Loop labels provide
- * targets for break and continue statements.  Emits IR as a side
- * effect and returns non-zero on success.
- */
 int check_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                void *label_tab, ir_builder_t *ir, type_kind_t func_ret_type,
                const char *break_label, const char *continue_label)
@@ -791,3 +203,4 @@ void warn_unreachable_function(func_t *func, symtable_t *funcs)
         }
     }
 }
+

--- a/src/symtable_core.c
+++ b/src/symtable_core.c
@@ -221,3 +221,15 @@ int symtable_add_typedef_global(symtable_t *table, const char *name,
     return 1;
 }
 
+/* Remove all symbols added after old_head from the table */
+void symtable_pop_scope(symtable_t *table, symbol_t *old_head)
+{
+    while (table->head != old_head) {
+        symbol_t *sym = table->head;
+        table->head = sym->next;
+        free(sym->name);
+        free(sym->param_types);
+        free(sym);
+    }
+}
+


### PR DESCRIPTION
## Summary
- split statement handlers into their own source files
- keep `check_stmt` as a dispatcher only
- update build rules and symbol table helper

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f2ea622088324b70ed189f9088281