### PR TITLE
Refactor preprocessor modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/codegen.c src/codegen_mem.c src/codegen_loadstore.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c src/codegen_x86.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
-           src/preproc_expand.c src/preproc_table.c src/preproc_expr.c src/preproc_cond.c src/preproc_file.c \
+           src/preproc_expand.c src/preproc_builtin.c src/preproc_args.c src/preproc_table.c src/preproc_expr.c src/preproc_cond.c src/preproc_file.c \
            src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c
 
 # Optional optimization sources
@@ -278,6 +278,12 @@ src/label.o: src/label.c $(HDR)
 
 src/preproc_expand.o: src/preproc_expand.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_expand.c -o src/preproc_expand.o
+src/preproc_builtin.o: src/preproc_builtin.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_builtin.c -o src/preproc_builtin.o
+
+src/preproc_args.o: src/preproc_args.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_args.c -o src/preproc_args.o
+
 
 src/preproc_table.o: src/preproc_table.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_table.c -o src/preproc_table.o

--- a/include/preproc_args.h
+++ b/include/preproc_args.h
@@ -1,0 +1,15 @@
+/*
+ * Helper functions for macro argument processing.
+ */
+
+#ifndef VC_PREPROC_ARGS_H
+#define VC_PREPROC_ARGS_H
+
+#include "vector.h"
+
+int parse_macro_args(const char *line, size_t *pos, vector_t *out);
+int gather_varargs(vector_t *args, size_t fixed,
+                   char ***out_ap, char **out_va);
+void free_arg_vector(vector_t *v);
+
+#endif /* VC_PREPROC_ARGS_H */

--- a/include/preproc_builtin.h
+++ b/include/preproc_builtin.h
@@ -1,0 +1,17 @@
+/*
+ * Builtin macro handling utilities.
+ */
+
+#ifndef VC_PREPROC_BUILTIN_H
+#define VC_PREPROC_BUILTIN_H
+
+#include "strbuf.h"
+
+void preproc_set_location(const char *file, size_t line, size_t column);
+void preproc_set_function(const char *name);
+size_t preproc_get_line(void);
+size_t preproc_get_column(void);
+int handle_builtin_macro(const char *name, size_t len, size_t end,
+                         size_t column, strbuf_t *out, size_t *pos);
+
+#endif /* VC_PREPROC_BUILTIN_H */

--- a/src/preproc_args.c
+++ b/src/preproc_args.c
@@ -1,0 +1,122 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_args.h"
+#include "strbuf.h"
+#include "util.h"
+#include "vector.h"
+
+/* Duplicate an argument substring trimming surrounding whitespace. */
+static char *dup_arg_segment(const char *line, size_t start, size_t end)
+{
+    while (start < end && (line[start] == ' ' || line[start] == '\t'))
+        start++;
+    while (end > start && (line[end - 1] == ' ' || line[end - 1] == '\t'))
+        end--;
+    return vc_strndup(line + start, end - start);
+}
+
+/* Scan for the next argument delimiter updating nesting level. */
+static char find_arg_delim(const char *line, size_t *p, int *nest,
+                           size_t *out_end)
+{
+    for (;; (*p)++) {
+        char c = line[*p];
+        if (c == '\0')
+            return 0;
+        if (c == '(') {
+            (*nest)++;
+            continue;
+        }
+        if (c == ')') {
+            if (*nest > 0) {
+                (*nest)--;
+                continue;
+            }
+            *out_end = *p;
+            return ')';
+        }
+        if (c == ',' && *nest == 0) {
+            *out_end = *p;
+            return ',';
+        }
+    }
+}
+
+int parse_macro_args(const char *line, size_t *pos, vector_t *out)
+{
+    size_t p = *pos;
+    vector_init(out, sizeof(char *));
+    while (line[p] == ' ' || line[p] == '\t')
+        p++;
+    if (line[p] != '(')
+        return 0;
+    p++;
+    while (line[p] == ' ' || line[p] == '\t')
+        p++;
+    if (line[p] == ')') {
+        *pos = p + 1;
+        return 1;
+    }
+
+    size_t arg_start = p;
+    int nest = 0;
+    for (;;) {
+        size_t end;
+        char delim = find_arg_delim(line, &p, &nest, &end);
+        if (!delim)
+            break;
+        char *dup = dup_arg_segment(line, arg_start, end);
+        if (!dup || !vector_push(out, &dup)) {
+            free(dup);
+            goto fail;
+        }
+        if (delim == ')') {
+            *pos = end + 1;
+            return 1;
+        }
+        p++;
+        while (line[p] == ' ' || line[p] == '\t')
+            p++;
+        arg_start = p;
+    }
+fail:
+    for (size_t i = 0; i < out->count; i++)
+        free(((char **)out->data)[i]);
+    vector_free(out);
+    return 0;
+}
+
+int gather_varargs(vector_t *args, size_t fixed,
+                   char ***out_ap, char **out_va)
+{
+    strbuf_t sb;
+    strbuf_init(&sb);
+    for (size_t i = fixed; i < args->count; i++) {
+        if (i > fixed)
+            strbuf_append(&sb, ",");
+        strbuf_append(&sb, ((char **)args->data)[i]);
+    }
+    char *va = vc_strdup(sb.data ? sb.data : "");
+    strbuf_free(&sb);
+    char **ap = malloc((fixed + 1) * sizeof(char *));
+    if (!ap) {
+        vc_oom();
+        free(va);
+        return 0;
+    }
+    for (size_t i = 0; i < fixed; i++)
+        ap[i] = ((char **)args->data)[i];
+    ap[fixed] = va;
+    *out_ap = ap;
+    *out_va = va;
+    return 1;
+}
+
+void free_arg_vector(vector_t *v)
+{
+    for (size_t i = 0; i < v->count; i++)
+        free(((char **)v->data)[i]);
+    vector_free(v);
+}
+

--- a/src/preproc_builtin.c
+++ b/src/preproc_builtin.c
@@ -1,0 +1,82 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "preproc_builtin.h"
+#include "util.h"
+
+static const char *builtin_file = "";
+static size_t builtin_line = 0;
+static size_t builtin_column = 1;
+static const char *builtin_func = NULL;
+
+static const char build_date[] = __DATE__;
+static const char build_time[] = __TIME__;
+
+void preproc_set_location(const char *file, size_t line, size_t column)
+{
+    if (file)
+        builtin_file = file;
+    builtin_line = line;
+    builtin_column = column;
+}
+
+void preproc_set_function(const char *name)
+{
+    builtin_func = name;
+}
+
+size_t preproc_get_line(void)
+{
+    return builtin_line;
+}
+
+size_t preproc_get_column(void)
+{
+    return builtin_column;
+}
+
+int handle_builtin_macro(const char *name, size_t len, size_t end,
+                         size_t column, strbuf_t *out, size_t *pos)
+{
+    if (len == 8) {
+        if (strncmp(name, "__FILE__", 8) == 0) {
+            preproc_set_location(NULL, builtin_line, column);
+            strbuf_appendf(out, "\"%s\"", builtin_file);
+            *pos = end;
+            return 1;
+        } else if (strncmp(name, "__LINE__", 8) == 0) {
+            preproc_set_location(NULL, builtin_line, column);
+            strbuf_appendf(out, "%zu", builtin_line);
+            *pos = end;
+            return 1;
+        } else if (strncmp(name, "__DATE__", 8) == 0) {
+            preproc_set_location(NULL, builtin_line, column);
+            strbuf_appendf(out, "\"%s\"", build_date);
+            *pos = end;
+            return 1;
+        } else if (strncmp(name, "__TIME__", 8) == 0) {
+            preproc_set_location(NULL, builtin_line, column);
+            strbuf_appendf(out, "\"%s\"", build_time);
+            *pos = end;
+            return 1;
+        } else if (strncmp(name, "__STDC__", 8) == 0) {
+            preproc_set_location(NULL, builtin_line, column);
+            strbuf_append(out, "1");
+            *pos = end;
+            return 1;
+        } else if (strncmp(name, "__func__", 8) == 0) {
+            if (builtin_func) {
+                preproc_set_location(NULL, builtin_line, column);
+                strbuf_appendf(out, "\"%s\"", builtin_func);
+                *pos = end;
+                return 1;
+            }
+        }
+    } else if (len == 16 && strncmp(name, "__STDC_VERSION__", 16) == 0) {
+        preproc_set_location(NULL, builtin_line, column);
+        strbuf_append(out, "199901L");
+        *pos = end;
+        return 1;
+    }
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- split macro argument helpers into `preproc_args.c`
- move builtin macro handling into `preproc_builtin.c`
- update `preproc_expand.c` to use the new helpers
- add headers and makefile rules for the new modules

## Testing
- `make clean`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f318ef8548324b191090734a48f55