### PR TITLE
Add token names API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/codegen_float.c src/codegen_complex.c src/codegen_x86.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
            src/preproc_expand.c src/preproc_builtin.c src/preproc_args.c src/preproc_table.c src/preproc_expr.c src/preproc_cond.c src/preproc_file.c \
-           src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c
+           src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+           src/token_names.c
 
 # Optional optimization sources
 OPT_SRC = src/opt.c src/opt_constprop.c src/opt_cse.c src/opt_fold.c src/opt_licm.c src/opt_dce.c src/opt_inline.c src/opt_inline_helpers.c src/opt_unreachable.c src/opt_alias.c
@@ -25,7 +26,7 @@ EXTRA_SRC ?=
 # Final source list
 SRC = $(CORE_SRC) $(OPT_SRC) $(EXTRA_SRC)
 OBJ := $(SRC:.c=.o)
-HDR = include/token.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_control.h include/semantic_stmt.h include/semantic_decl_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_layout.h include/semantic_init.h include/semantic_global.h \
+HDR = include/token.h include/token_names.h include/ast.h include/ast_clone.h include/ast_expr.h include/ast_stmt.h include/parser.h include/symtable.h include/semantic.h     include/consteval.h include/semantic_expr.h include/semantic_arith.h include/semantic_mem.h include/semantic_call.h include/semantic_loops.h include/semantic_control.h include/semantic_stmt.h include/semantic_decl_stmt.h include/semantic_inline.h include/semantic_var.h include/semantic_layout.h include/semantic_init.h include/semantic_global.h \
     include/ir_core.h include/ir_const.h include/ir_memory.h include/ir_control.h include/ir_builder.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h include/lexer_internal.h \
     include/opt_inline_helpers.h \
@@ -295,6 +296,9 @@ src/ast_dump.o: src/ast_dump.c $(HDR)
 
 src/label.o: src/label.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/label.c -o src/label.o
+
+src/token_names.o: src/token_names.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/token_names.c -o src/token_names.o
 
 src/preproc_expand.o: src/preproc_expand.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_expand.c -o src/preproc_expand.o

--- a/include/token_names.h
+++ b/include/token_names.h
@@ -1,0 +1,16 @@
+/*
+ * Token name lookup helpers.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_TOKEN_NAMES_H
+#define VC_TOKEN_NAMES_H
+
+#include "token.h"
+
+/* Map a token type to a human readable name used in diagnostics */
+const char *token_name(token_type_t type);
+
+#endif /* VC_TOKEN_NAMES_H */

--- a/src/parser_core.c
+++ b/src/parser_core.c
@@ -15,6 +15,7 @@
 #include "ast_expr.h"
 #include "util.h"
 #include "symtable.h"
+#include "token_names.h"
 #include <string.h>
 
 
@@ -84,114 +85,7 @@ static size_t lookup_aggr_size(symtable_t *symtab, type_kind_t t,
     return (t == TYPE_STRUCT) ? sym->struct_total_size : sym->total_size;
 }
 
-/* Table mapping token_type_t values to the textual names used in diagnostics.
- * The index of each entry corresponds directly to its token_type_t value.
- * When adding new tokens, update both the token_type_t enum in token.h and
- * this table to keep them in sync. */
-static const char *token_names[] = {
-    [TOK_EOF] = "end of file",
-    [TOK_IDENT] = "identifier",
-    [TOK_NUMBER] = "number",
-    [TOK_IMAG_NUMBER] = "imaginary number",
-    [TOK_STRING] = "string",
-    [TOK_CHAR] = "character",
-    [TOK_WIDE_STRING] = "L\"string\"",
-    [TOK_WIDE_CHAR] = "L'char'",
-    [TOK_KW_INT] = "\"int\"",
-    [TOK_KW_CHAR] = "\"char\"",
-    [TOK_KW_FLOAT] = "\"float\"",
-    [TOK_KW_DOUBLE] = "\"double\"",
-    [TOK_KW_SHORT] = "\"short\"",
-    [TOK_KW_LONG] = "\"long\"",
-    [TOK_KW_BOOL] = "\"bool\"",
-    [TOK_KW_UNSIGNED] = "\"unsigned\"",
-    [TOK_KW_VOID] = "\"void\"",
-    [TOK_KW_ENUM] = "\"enum\"",
-    [TOK_KW_STRUCT] = "\"struct\"",
-    [TOK_KW_UNION] = "\"union\"",
-    [TOK_KW_TYPEDEF] = "\"typedef\"",
-    [TOK_KW_STATIC] = "\"static\"",
-    [TOK_KW_EXTERN] = "\"extern\"",
-    [TOK_KW_CONST] = "\"const\"",
-    [TOK_KW_VOLATILE] = "\"volatile\"",
-    [TOK_KW_RESTRICT] = "\"restrict\"",
-    [TOK_KW_REGISTER] = "\"register\"",
-    [TOK_KW_INLINE] = "\"inline\"",
-    [TOK_KW_NORETURN] = "\"_Noreturn\"",
-    [TOK_KW_STATIC_ASSERT] = "\"_Static_assert\"",
-    [TOK_KW_RETURN] = "\"return\"",
-    [TOK_KW_IF] = "\"if\"",
-    [TOK_KW_ELSE] = "\"else\"",
-    [TOK_KW_DO] = "\"do\"",
-    [TOK_KW_WHILE] = "\"while\"",
-    [TOK_KW_FOR] = "\"for\"",
-    [TOK_KW_BREAK] = "\"break\"",
-    [TOK_KW_CONTINUE] = "\"continue\"",
-    [TOK_KW_GOTO] = "\"goto\"",
-    [TOK_KW_SWITCH] = "\"switch\"",
-    [TOK_KW_CASE] = "\"case\"",
-    [TOK_KW_DEFAULT] = "\"default\"",
-    [TOK_KW_SIZEOF] = "\"sizeof\"",
-    [TOK_KW_COMPLEX] = "\"_Complex\"",
-    [TOK_KW_ALIGNAS] = "\"alignas\"",
-    [TOK_KW_ALIGNOF] = "\"_Alignof\"",
-    [TOK_LPAREN] = "'('",
-    [TOK_RPAREN] = ")",
-    [TOK_LBRACE] = "'{'",
-    [TOK_RBRACE] = "'}'",
-    [TOK_SEMI] = ";",
-    [TOK_COMMA] = ",",
-    [TOK_PLUS] = "+",
-    [TOK_MINUS] = "-",
-    [TOK_DOT] = ".",
-    [TOK_ARROW] = "'->'",
-    [TOK_AMP] = "&",
-    [TOK_STAR] = "*",
-    [TOK_SLASH] = "/",
-    [TOK_PERCENT] = "%",
-    [TOK_PIPE] = "|",
-    [TOK_CARET] = "^",
-    [TOK_SHL] = "'<<'",
-    [TOK_SHR] = "'>>'",
-    [TOK_PLUSEQ] = "+=",
-    [TOK_MINUSEQ] = "-=",
-    [TOK_STAREQ] = "*=",
-    [TOK_SLASHEQ] = "/=",
-    [TOK_PERCENTEQ] = "%=",
-    [TOK_AMPEQ] = "&=",
-    [TOK_PIPEEQ] = "|=",
-    [TOK_CARETEQ] = "^=",
-    [TOK_SHLEQ] = "<<=",
-    [TOK_SHREQ] = ">>=",
-    [TOK_INC] = "++",
-    [TOK_DEC] = "--",
-    [TOK_ASSIGN] = "=",
-    [TOK_EQ] = "==",
-    [TOK_NEQ] = "!=",
-    [TOK_LOGAND] = "&&",
-    [TOK_LOGOR] = "||",
-    [TOK_NOT] = "!",
-    [TOK_LT] = "<",
-    [TOK_GT] = ">",
-    [TOK_LE] = "<=",
-    [TOK_GE] = ">=",
-    [TOK_LBRACKET] = "[",
-    [TOK_RBRACKET] = "]",
-    [TOK_QMARK] = "?",
-    [TOK_COLON] = ":",
-    [TOK_LABEL] = "label",
-    [TOK_ELLIPSIS] = "'...'",
-    [TOK_UNKNOWN] = "unknown"
-};
 
-/* Map a token type to a human readable name used in error messages */
-static const char *token_name(token_type_t type)
-{
-    size_t n = sizeof(token_names) / sizeof(token_names[0]);
-    if (type >= 0 && (size_t)type < n && token_names[type])
-        return token_names[type];
-    return "unknown";
-}
 
 /* Print a parser error message showing the unexpected token */
 void parser_print_error(parser_t *p, const token_type_t *expected,

--- a/src/token_names.c
+++ b/src/token_names.c
@@ -1,0 +1,117 @@
+/*
+ * Token name lookup table and helper function.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include "token_names.h"
+
+/* Table mapping token_type_t values to the textual names used in diagnostics.
+ * The index of each entry corresponds directly to its token_type_t value.
+ * When adding new tokens, update both the token_type_t enum in token.h and
+ * this table to keep them in sync. */
+static const char *token_names[] = {
+    [TOK_EOF] = "end of file",
+    [TOK_IDENT] = "identifier",
+    [TOK_NUMBER] = "number",
+    [TOK_IMAG_NUMBER] = "imaginary number",
+    [TOK_STRING] = "string",
+    [TOK_CHAR] = "character",
+    [TOK_WIDE_STRING] = "L\"string\"",
+    [TOK_WIDE_CHAR] = "L'char'",
+    [TOK_KW_INT] = "\"int\"",
+    [TOK_KW_CHAR] = "\"char\"",
+    [TOK_KW_FLOAT] = "\"float\"",
+    [TOK_KW_DOUBLE] = "\"double\"",
+    [TOK_KW_SHORT] = "\"short\"",
+    [TOK_KW_LONG] = "\"long\"",
+    [TOK_KW_BOOL] = "\"bool\"",
+    [TOK_KW_UNSIGNED] = "\"unsigned\"",
+    [TOK_KW_VOID] = "\"void\"",
+    [TOK_KW_ENUM] = "\"enum\"",
+    [TOK_KW_STRUCT] = "\"struct\"",
+    [TOK_KW_UNION] = "\"union\"",
+    [TOK_KW_TYPEDEF] = "\"typedef\"",
+    [TOK_KW_STATIC] = "\"static\"",
+    [TOK_KW_EXTERN] = "\"extern\"",
+    [TOK_KW_CONST] = "\"const\"",
+    [TOK_KW_VOLATILE] = "\"volatile\"",
+    [TOK_KW_RESTRICT] = "\"restrict\"",
+    [TOK_KW_REGISTER] = "\"register\"",
+    [TOK_KW_INLINE] = "\"inline\"",
+    [TOK_KW_NORETURN] = "\"_Noreturn\"",
+    [TOK_KW_STATIC_ASSERT] = "\"_Static_assert\"",
+    [TOK_KW_RETURN] = "\"return\"",
+    [TOK_KW_IF] = "\"if\"",
+    [TOK_KW_ELSE] = "\"else\"",
+    [TOK_KW_DO] = "\"do\"",
+    [TOK_KW_WHILE] = "\"while\"",
+    [TOK_KW_FOR] = "\"for\"",
+    [TOK_KW_BREAK] = "\"break\"",
+    [TOK_KW_CONTINUE] = "\"continue\"",
+    [TOK_KW_GOTO] = "\"goto\"",
+    [TOK_KW_SWITCH] = "\"switch\"",
+    [TOK_KW_CASE] = "\"case\"",
+    [TOK_KW_DEFAULT] = "\"default\"",
+    [TOK_KW_SIZEOF] = "\"sizeof\"",
+    [TOK_KW_COMPLEX] = "\"_Complex\"",
+    [TOK_KW_ALIGNAS] = "\"alignas\"",
+    [TOK_KW_ALIGNOF] = "\"_Alignof\"",
+    [TOK_LPAREN] = "'('",
+    [TOK_RPAREN] = ")",
+    [TOK_LBRACE] = "'{'",
+    [TOK_RBRACE] = "'}'",
+    [TOK_SEMI] = ";",
+    [TOK_COMMA] = ",",
+    [TOK_PLUS] = "+",
+    [TOK_MINUS] = "-",
+    [TOK_DOT] = ".",
+    [TOK_ARROW] = "'->'",
+    [TOK_AMP] = "&",
+    [TOK_STAR] = "*",
+    [TOK_SLASH] = "/",
+    [TOK_PERCENT] = "%",
+    [TOK_PIPE] = "|",
+    [TOK_CARET] = "^",
+    [TOK_SHL] = "'<<'",
+    [TOK_SHR] = "'>>'",
+    [TOK_PLUSEQ] = "+=",
+    [TOK_MINUSEQ] = "-=",
+    [TOK_STAREQ] = "*=",
+    [TOK_SLASHEQ] = "/=",
+    [TOK_PERCENTEQ] = "%=",
+    [TOK_AMPEQ] = "&=",
+    [TOK_PIPEEQ] = "|=",
+    [TOK_CARETEQ] = "^=",
+    [TOK_SHLEQ] = "<<=",
+    [TOK_SHREQ] = ">>=",
+    [TOK_INC] = "++",
+    [TOK_DEC] = "--",
+    [TOK_ASSIGN] = "=",
+    [TOK_EQ] = "==",
+    [TOK_NEQ] = "!=",
+    [TOK_LOGAND] = "&&",
+    [TOK_LOGOR] = "||",
+    [TOK_NOT] = "!",
+    [TOK_LT] = "<",
+    [TOK_GT] = ">",
+    [TOK_LE] = "<=",
+    [TOK_GE] = ">=",
+    [TOK_LBRACKET] = "[",
+    [TOK_RBRACKET] = "]",
+    [TOK_QMARK] = "?",
+    [TOK_COLON] = ":",
+    [TOK_LABEL] = "label",
+    [TOK_ELLIPSIS] = "'...'",
+    [TOK_UNKNOWN] = "unknown"
+};
+
+const char *token_name(token_type_t type)
+{
+    size_t n = sizeof(token_names) / sizeof(token_names[0]);
+    if (type >= 0 && (size_t)type < n && token_names[type])
+        return token_names[type];
+    return "unknown";
+}
+


### PR DESCRIPTION
## Summary
- add `token_names.c` implementing lookup table and `token_name()`
- expose API via new header `token_names.h`
- update parser to use the new API
- include new sources in build system

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f3e24c46c83248dcc52aec326225d