### PR TITLE
Add Linux multiarch include path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c99
 OPTFLAGS ?=
+MULTIARCH := $(shell $(CC) -print-multiarch 2>/dev/null || echo x86_64-linux-gnu)
 BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc
 # Core compiler sources
@@ -332,7 +333,7 @@ src/preproc_include.o: src/preproc_include.c $(HDR)
 src/preproc_includes.o: src/preproc_includes.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_includes.c -o src/preproc_includes.o
 src/preproc_path.o: src/preproc_path.c $(HDR)
-	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_path.c -o src/preproc_path.o
+	$(CC) $(CFLAGS) $(OPTFLAGS) -DMULTIARCH=\"$(MULTIARCH)\" -Iinclude -c src/preproc_path.c -o src/preproc_path.o
 
 src/opt.o: src/opt.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt.c -o src/opt.o

--- a/docs/building.md
+++ b/docs/building.md
@@ -30,6 +30,10 @@ make PLATFORM=generic
 
 This disables any NetBSD specific extensions.
 
+On Linux the compiler also searches `/usr/include/<multiarch>` for headers.
+The multiarch directory is determined at build time using `cc -print-multiarch`
+and defaults to `x86_64-linux-gnu` when detection fails.
+
 `vc` can generate either 32-bit or 64-bit x86 assembly. Use the
 `--x86-64` flag when invoking the compiler to enable 64-bit output. The
 default without this flag is 32-bit code.

--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -10,7 +10,16 @@
 #include "preproc_path.h"
 
 /* Default system include search paths */
+#ifdef __linux__
+#ifndef MULTIARCH
+#define MULTIARCH "x86_64-linux-gnu"
+#endif
+#endif
+
 static const char *std_include_dirs[] = {
+#ifdef __linux__
+    "/usr/include/" MULTIARCH,
+#endif
     "/usr/local/include",
     "/usr/include",
     NULL


### PR DESCRIPTION
## Summary
- add MULTIARCH detection in Makefile
- search `/usr/include/<multiarch>` on Linux
- document multiarch include handling

## Testing
- `make PLATFORM=generic`
- `examples/build_examples.sh` *(fails: `stddef.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686fde9ec7e8832488a3126c0744b858