### PR TITLE
Update pragma handling

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -25,9 +25,9 @@ preprocessor directive is handled immediately:
 - Conditional directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else` and
   `#endif`) manipulate a stack of state objects so nested conditions may be
   evaluated correctly.
-- `#pragma` lines are passed through verbatim when active. `#pragma pack(push,n)`
-  updates the current struct packing alignment and `#pragma pack(pop)` restores
-  the previous value.
+- `#pragma` directives are ignored unless recognised. Supported forms are
+  `#pragma pack(push,n)` which updates the current struct packing alignment and
+  `#pragma pack(pop)` which restores the previous value.
 - `#pragma once` marks the current file so subsequent includes of the same
   path are ignored.
 - Any other line has macros expanded and is appended to the output buffer.

--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -123,6 +123,8 @@ int handle_pragma_directive(char *line, const char *dir, vector_t *macros,
             if (!pragma_once_add(ctx, cur))
                 return 0;
         }
+        (void)conds; /* unused when returning early */
+        return 1; /* do not emit pragma line */
     } else if (strncmp(p, "pack", 4) == 0) {
         p += 4;
         p = skip_ws(p);
@@ -157,6 +159,8 @@ int handle_pragma_directive(char *line, const char *dir, vector_t *macros,
         return 1; /* do not emit pragma line */
     }
     (void)stack;
-    return handle_pragma(line, conds, out);
+    (void)conds;
+    (void)out;
+    return 1; /* ignore unrecognised pragmas */
 }
 

--- a/tests/fixtures/include_once.expected
+++ b/tests/fixtures/include_once.expected
@@ -1,3 +1,2 @@
-#pragma once
 int once_var;
 int main() { return 0; }


### PR DESCRIPTION
## Summary
- ignore unrecognised pragmas instead of passing them through
- `#pragma once` no longer appears in preprocessor output
- mention pragma behaviour in docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686fe793624c8324892f4c1a339c6128