### PR TITLE
Raise macro depth limit

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -55,7 +55,7 @@ a macro is invoked `__VA_ARGS__` within its body is replaced by the remaining
 arguments.
 The macro table is cleaned up with [`free_macro_vector`](memory_helpers.md) once preprocessing is complete.
 Macro expansion is recursive so macro bodies may reference other macros. To
-avoid infinite loops a hard limit of 100 nested expansions is enforced.  When
+avoid infinite loops a hard limit of 4096 nested expansions is enforced.  When
 this limit is hit `expand_line` returns zero and the compiler aborts
 preprocessing after printing "Macro expansion limit exceeded".
 

--- a/src/preproc_expand.c
+++ b/src/preproc_expand.c
@@ -23,7 +23,7 @@
 #include "preproc_args.h"
 #include "preproc_builtin.h"
 
-#define MAX_MACRO_DEPTH 100
+#define MAX_MACRO_DEPTH 4096
 
 /*
  * Remove trailing spaces or tabs from a string buffer.


### PR DESCRIPTION
## Summary
- allow deeper macro expansion depth
- document new limit

## Testing
- `make`
- `examples/build_examples.sh` *(fails: Macro expansion limit exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_686ff72a726c8324bd93fcbd071deba5