### PR TITLE
Add GCC and STDC default macros

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -114,6 +114,30 @@ static void define_default_macros(vector_t *macros)
     define_simple_macro(macros, "__GNUC_MINOR__", STR(__GNUC_MINOR__));
     define_simple_macro(macros, "__GNUC_PATCHLEVEL__", STR(__GNUC_PATCHLEVEL__));
 #endif
+#ifdef __STDC_HOSTED__
+    define_simple_macro(macros, "__STDC_HOSTED__", STR(__STDC_HOSTED__));
+#endif
+#ifdef __STDC_UTF_16__
+    define_simple_macro(macros, "__STDC_UTF_16__", STR(__STDC_UTF_16__));
+#endif
+#ifdef __STDC_UTF_32__
+    define_simple_macro(macros, "__STDC_UTF_32__", STR(__STDC_UTF_32__));
+#endif
+#ifdef __STDC_ISO_10646__
+    define_simple_macro(macros, "__STDC_ISO_10646__", STR(__STDC_ISO_10646__));
+#endif
+#ifdef __STDC_IEC_559__
+    define_simple_macro(macros, "__STDC_IEC_559__", STR(__STDC_IEC_559__));
+#endif
+#ifdef __STDC_IEC_559_COMPLEX__
+    define_simple_macro(macros, "__STDC_IEC_559_COMPLEX__", STR(__STDC_IEC_559_COMPLEX__));
+#endif
+#ifdef __STDC_IEC_60559_BFP__
+    define_simple_macro(macros, "__STDC_IEC_60559_BFP__", STR(__STDC_IEC_60559_BFP__));
+#endif
+#ifdef __STDC_IEC_60559_COMPLEX__
+    define_simple_macro(macros, "__STDC_IEC_60559_COMPLEX__", STR(__STDC_IEC_60559_COMPLEX__));
+#endif
 
 #ifdef __SIZE_TYPE__
     define_simple_macro(macros, "__SIZE_TYPE__", STR(__SIZE_TYPE__));

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -145,6 +145,17 @@ rm -f preproc_expand.o preproc_table.o strbuf_variadic.o vector_variadic.o util_
 # build pack pragma layout tests
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/pack_pragma_tests" "$DIR/unit/test_pack_pragma.c"
+# build preprocessing of stdio.h regression test
+MULTIARCH=$(gcc -print-multiarch 2>/dev/null || echo x86_64-linux-gnu)
+GCC_INCLUDE_DIR=$(gcc -print-file-name=include)
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
+    -o "$DIR/preproc_stdio" "$DIR/unit/test_preproc_stdio.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
 # build create_temp_file path length regression test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
@@ -227,6 +238,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/add_macro_fail_tests"
 "$DIR/variadic_macro_tests"
 "$DIR/pack_pragma_tests"
+"$DIR/preproc_stdio"
 "$DIR/invalid_macro_tests"
 # separator for clarity
 echo "======="

--- a/tests/unit/test_preproc_stdio.c
+++ b/tests/unit/test_preproc_stdio.c
@@ -1,0 +1,45 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+/* Stub packing helpers used by the preprocessor */
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *line = "#include <stdio.h>\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, line, strlen(line)) == (ssize_t)strlen(line));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_stdio tests passed\n");
+    else
+        printf("%d preproc_stdio test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- expose gcc/STDC macros to the preprocessor
- add regression test for preprocessing `<stdio.h>`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686ff8b0437c8324a81d9d90508f06f2