### PR TITLE
Ensure clean GCC include path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c99
 OPTFLAGS ?=
 MULTIARCH := $(shell $(CC) -print-multiarch 2>/dev/null || echo x86_64-linux-gnu)
-GCC_INCLUDE_DIR := $(shell $(CC) -print-file-name=include)
+GCC_INCLUDE_DIR := $(shell $(CC) -print-file-name=include | tr -d '\n')
 BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc
 # Core compiler sources

--- a/docs/building.md
+++ b/docs/building.md
@@ -35,7 +35,9 @@ On Linux the compiler also searches `/usr/include/<multiarch>` for headers.
 The multiarch directory is determined at build time using `cc -print-multiarch`
 and defaults to `x86_64-linux-gnu` when detection fails. The GCC internal
 include directory reported by `cc -print-file-name=include` is also added so
-headers like `stddef.h` resolve correctly.
+headers like `stddef.h` resolve correctly. The Makefile removes the trailing
+newline from this path using `tr -d '\n'` to ensure `src/preproc_path.c`
+receives a clean directory string without whitespace.
 
 `vc` can generate either 32-bit or 64-bit x86 assembly. Use the
 `--x86-64` flag when invoking the compiler to enable 64-bit output. The

--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include "util.h"
 #include "preproc_path.h"
@@ -196,6 +197,7 @@ int append_env_paths(const char *env, vector_t *search_dirs)
 int collect_include_dirs(vector_t *search_dirs,
                          const vector_t *include_dirs)
 {
+    assert(strcspn(GCC_INCLUDE_DIR, " \t\n") == strlen(GCC_INCLUDE_DIR));
     vector_init(search_dirs, sizeof(char *));
     for (size_t i = 0; i < include_dirs->count; i++) {
         const char *s = ((const char **)include_dirs->data)[i];


### PR DESCRIPTION
## Summary
- sanitize `-print-file-name=include` output in `Makefile`
- document newline stripping in build instructions
- check for whitespace in `GCC_INCLUDE_DIR`

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68700bdc802c8324b59516a6645f126a