### PR TITLE
Add support for ternary expressions in preprocessor parser

### DIFF
--- a/tests/unit/test_preproc_expr.c
+++ b/tests/unit/test_preproc_expr.c
@@ -37,6 +37,8 @@ static void test_features_expr(void)
     ASSERT(eval_expr("defined FOO", &macros) == 0);
     ASSERT(eval_expr("(11 << 16) + 1 >= (10 << 16) + 1", &macros));
     ASSERT(eval_expr("199309L >= 2 || 0", &macros));
+    ASSERT(eval_expr("1 ? 2 : 3", &macros));
+    ASSERT(eval_expr("0 ? 2 : 3", &macros));
 
     vector_free(&macros);
 }


### PR DESCRIPTION
## Summary
- extend preprocessor expression parser with `parse_conditional`
- call the new level from `parse_expr`
- update `eval_expr` to return boolean result
- add tests covering ternary operator evaluation

## Testing
- `tests/run.sh` *(fails: undefined references when linking unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68703f3475048324996231c71b68dfa7