### PR TITLE
Fix inline hint check for stdin

### DIFF
--- a/src/opt_inline_helpers.c
+++ b/src/opt_inline_helpers.c
@@ -211,7 +211,7 @@ int collect_funcs(ir_builder_t *ir, inline_func_t **out, size_t *count)
 
         int is_inline = 0;
         const char *src_file = ins->next ? ins->next->file : NULL;
-        if (src_file) {
+        if (src_file && strcmp(src_file, "-") != 0) {
             int r = parse_inline_hint(src_file, ins->name);
             if (r > 0) {
                 is_inline = 1;


### PR DESCRIPTION
## Summary
- skip `parse_inline_hint` when the source file is `-`
- ensures stdin compilation doesn't log an optimizer error

## Testing
- `make test` *(fails: Test macro_cycle failed)*

------
https://chatgpt.com/codex/tasks/task_e_68707282e0d48324af7bb7af8094e30f