### PR TITLE
Fix macro recursion error

### DIFF
--- a/src/preproc_expand.c
+++ b/src/preproc_expand.c
@@ -302,8 +302,8 @@ static int expand_user_macro(macro_t *m, const char *line, size_t *pos,
                              vector_t *macros, strbuf_t *out, int depth)
 {
     if (m->expanding) {
-        strbuf_append(out, m->name);
-        return 1;
+        fprintf(stderr, "Macro expansion limit exceeded\n");
+        return -1;
     }
 
     size_t p = *pos;        /* position just after the macro name */


### PR DESCRIPTION
## Summary
- report an error when a macro expansion is recursive
- propagate the failure so preprocessing fails

## Testing
- `make test`
- `./vc -o /tmp/out tests/invalid/macro_cycle.c` (fails with expected message)


------
https://chatgpt.com/codex/tasks/task_e_687074cbb8c88324b45f64bd48ff7460