### PR TITLE
Add mismatched conditional check

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -65,6 +65,11 @@ int process_file(const char *path, vector_t *macros,
     int ok = process_all_lines(lines, path, dir, macros, conds, out, incdirs,
                                stack, ctx);
 
+    if (ok && conds->count) {
+        fprintf(stderr, "Mismatched #if/#endif directives in %s\n", path);
+        ok = 0;
+    }
+
     line_state_pop(prev_file, prev_delta);
 
     include_stack_pop(stack);


### PR DESCRIPTION
## Summary
- detect mismatched `#if`/`#endif` directives
- error when conditional stack is non-empty after preprocessing a file

## Testing
- `make test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687080a6ebd48324aa52f935c9bf7c5d