### PR TITLE
Add header prototype for write_dep_file

### DIFF
--- a/include/compile.h
+++ b/include/compile.h
@@ -30,4 +30,7 @@ int generate_dependencies(const cli_options_t *cli);
 /* Compile multiple sources and link them into an executable. */
 int link_sources(const cli_options_t *cli);
 
+/* Write dependency information to a .d file */
+int write_dep_file(const char *target, const vector_t *deps);
+
 #endif /* VC_COMPILE_H */

--- a/src/compile_stage.c
+++ b/src/compile_stage.c
@@ -47,7 +47,6 @@ static int compile_optimize_impl(ir_builder_t *ir, const opt_config_t *cfg);
 int compile_output_impl(ir_builder_t *ir, const char *output,
                         int dump_ir, int dump_asm, int use_x86_64,
                         int compile, const cli_options_t *cli);
-int write_dep_file(const char *target, const vector_t *deps);
 
 /* Compilation context used by the pipeline */
 typedef struct compile_context {


### PR DESCRIPTION
## Summary
- expose `write_dep_file` in `compile.h`
- drop redundant declaration from `compile_stage.c`

## Testing
- `make -s clean`
- `make -s test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6870836c79648324b15e0223a32c6474