### PR TITLE
Add consteval include in cast module

### DIFF
--- a/src/semantic_expr_cast.c
+++ b/src/semantic_expr_cast.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "semantic_expr.h"
+#include "consteval.h"
 #include "error.h"
 
 /*


### PR DESCRIPTION
## Summary
- include `consteval.h` in `semantic_expr_cast.c` to resolve missing prototypes

## Testing
- `gcc -Wall -Wextra -std=c99 -Iinclude -c /tmp/original_semantic_expr_cast.c -o /tmp/original.o` *(fails: implicit declaration warnings)*
- `gcc -Wall -Wextra -std=c99 -Iinclude -c src/semantic_expr_cast.c -o /tmp/new.o`
- `make test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68708461d92c83249910394d18db5a33