### PR TITLE
Handle missing glibc headers in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ tests/run.sh         # builds vc, compiles unit tests and runs everything
 Both scripts exit with status 0 when all checks pass. The output ends with
 `All tests passed` on success.
 
+The suite includes an optional check using glibc's `<sys/cdefs.h>` to
+exercise `_Pragma` handling. If this header cannot be located or fails to
+preprocess, the check is skipped and the remaining tests still run normally.
+
 ## Documentation
 
 The [documentation index](docs/README.md) provides an overview of all available


### PR DESCRIPTION
## Summary
- avoid running `_Pragma` tests when `<sys/cdefs.h>` is unavailable
- treat failed preprocessing of the header as a skip
- mention the optional check in README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68708351a294832498f711dde0b3e8a7