### PR TITLE
Fix missing regalloc header

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -9,6 +9,7 @@
 #include "codegen_arith_float.h"
 #include "codegen_float.h"
 #include "codegen_x86.h"
+#include "regalloc_x86.h"
 #include "label.h"
 
 #define SCRATCH_REG 0


### PR DESCRIPTION
## Summary
- include `regalloc_x86.h` in integer codegen
- rebuild to ensure warnings are gone

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68708609a034832495f17cf84c670423