### PR TITLE
Remove unused handle_pragma

### DIFF
--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -41,18 +41,6 @@ static int is_active(vector_t *conds)
     return stack_active(conds);
 }
 
-/* Append a #pragma directive to the output when active */
-static int handle_pragma(char *line, vector_t *conds, strbuf_t *out)
-{
-    if (is_active(conds)) {
-        if (strbuf_append(out, line) != 0)
-            return 0;
-        if (strbuf_append(out, "\n") != 0)
-            return 0;
-    }
-    return 1;
-}
-
 int handle_include_directive(char *line, const char *dir, vector_t *macros,
                              vector_t *conds, strbuf_t *out,
                              const vector_t *incdirs, vector_t *stack,


### PR DESCRIPTION
## Summary
- drop `handle_pragma` from `preproc_includes.c`
- confirm build no longer warns about the unused function

## Testing
- `make test`
- `make -j4 > /tmp/make_build.log 2>&1 && grep -n "unused-function" /tmp/make_build.log`

------
https://chatgpt.com/codex/tasks/task_e_68708617f9748324b08ca1b22af789ad