### PR TITLE
Fix include_next delimiter handling

### DIFF
--- a/src/preproc_include.c
+++ b/src/preproc_include.c
@@ -119,7 +119,7 @@ int handle_include_next(char *line, const char *dir, vector_t *macros,
         }
         size_t idx = SIZE_MAX;
         size_t start_idx = (cur == (size_t)-1) ? 0 : cur + 1;
-        char *incpath = find_include_path(fname, '>', NULL, incdirs,
+        char *incpath = find_include_path(fname, endc, NULL, incdirs,
                                           start_idx, &idx);
         if (!process_include_file(fname, incpath, idx, macros, conds, out,
                                   incdirs, stack, ctx))

--- a/tests/fixtures/include_next_quote.c
+++ b/tests/fixtures/include_next_quote.c
@@ -1,0 +1,2 @@
+#include "foo.h"
+int main() { return VALUE; }

--- a/tests/fixtures/include_next_quote.s
+++ b/tests/fixtures/include_next_quote.s
@@ -1,0 +1,9 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $3, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/include_next_quote/dir1/foo.h
+++ b/tests/include_next_quote/dir1/foo.h
@@ -1,0 +1,2 @@
+#define VALUE 1
+#include_next "foo.h"

--- a/tests/include_next_quote/dir2/foo.h
+++ b/tests/include_next_quote/dir2/foo.h
@@ -1,0 +1,3 @@
+#undef VALUE
+#define VALUE 2
+#include_next "foo.h"

--- a/tests/include_next_quote/dir3/foo.h
+++ b/tests/include_next_quote/dir3/foo.h
@@ -1,0 +1,2 @@
+#undef VALUE
+#define VALUE 3

--- a/tests/include_next_quote/miss1/foo.h
+++ b/tests/include_next_quote/miss1/foo.h
@@ -1,0 +1,2 @@
+#define VALUE 1
+#include_next "foo.h"

--- a/tests/include_next_quote/miss2/foo.h
+++ b/tests/include_next_quote/miss2/foo.h
@@ -1,0 +1,3 @@
+#undef VALUE
+#define VALUE 2
+#include_next "foo.h"

--- a/tests/invalid/include_next_quote_missing.c
+++ b/tests/invalid/include_next_quote_missing.c
@@ -1,0 +1,2 @@
+#include "foo.h"
+int main() { return VALUE; }


### PR DESCRIPTION
## Summary
- ensure `#include_next` uses parsed delimiter
- test quoted `#include_next` search paths

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6870886a5a68832489bd13d2162682dc