### PR TITLE
Remove old macro before redefining

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -100,6 +100,7 @@ static int define_simple_macro(vector_t *macros, const char *name,
 {
     vector_t params;
     vector_init(&params, sizeof(char *));
+    remove_macro(macros, name);
     return add_macro(name, val, &params, 0, macros);
 }
 
@@ -263,6 +264,7 @@ static int update_macros_from_cli(vector_t *macros, const vector_t *defines,
             }
             vector_t params;
             vector_init(&params, sizeof(char *));
+            remove_macro(macros, name);
             if (!add_macro(name, val, &params, 0, macros)) {
                 free(name);
                 return 0;

--- a/src/preproc_table.c
+++ b/src/preproc_table.c
@@ -231,6 +231,7 @@ int handle_define(char *line, vector_t *macros, vector_t *conds)
     char *val = *n ? n : "";
     int ok = 1;
     if (is_active(conds)) {
+        remove_macro(macros, name);
         ok = add_macro(name, val, &params, variadic, macros);
     } else {
         free_param_vector(&params);


### PR DESCRIPTION
## Summary
- ensure existing macros are removed before redefining them

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68709149e7088324b4dd4506fe677450