### PR TITLE
Escape backslashes/quotes in stringize

### DIFF
--- a/src/preproc_expand.c
+++ b/src/preproc_expand.c
@@ -82,7 +82,15 @@ static size_t append_stringized_param(const char *value, size_t i,
             strncmp(value + j, "__VA_ARGS__", 11) == 0)
             rep = args[params->count];
         if (rep) {
-            strbuf_appendf(sb, "\"%s\"", rep);
+            strbuf_append(sb, "\"");
+            for (size_t k = 0; rep[k]; k++) {
+                char c = rep[k];
+                if (c == '\\' || c == '"')
+                    strbuf_appendf(sb, "\\%c", c);
+                else
+                    strbuf_appendf(sb, "%c", c);
+            }
+            strbuf_append(sb, "\"");
             return j + len;
         }
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -142,6 +142,15 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_variadic.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_variadic_macro.c" -o "$DIR/test_variadic_macro.o"
 cc -o "$DIR/variadic_macro_tests" preproc_expand.o preproc_table.o strbuf_variadic.o vector_variadic.o util_variadic.o "$DIR/test_variadic_macro.o"
 rm -f preproc_expand.o preproc_table.o strbuf_variadic.o vector_variadic.o util_variadic.o "$DIR/test_variadic_macro.o"
+# build macro stringize escape test
+cc -Iinclude -Wall -Wextra -std=c99 -c src/preproc_expand.c -o preproc_expand.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/preproc_table.c -o preproc_table.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_stringize.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_stringize.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_stringize.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_macro_stringize_escape.c" -o "$DIR/test_macro_stringize_escape.o"
+cc -o "$DIR/macro_stringize_escape" preproc_expand.o preproc_table.o strbuf_stringize.o vector_stringize.o util_stringize.o "$DIR/test_macro_stringize_escape.o"
+rm -f preproc_expand.o preproc_table.o strbuf_stringize.o vector_stringize.o util_stringize.o "$DIR/test_macro_stringize_escape.o"
 # build pack pragma layout tests
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/pack_pragma_tests" "$DIR/unit/test_pack_pragma.c"
@@ -274,6 +283,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_alloc_tests"
 "$DIR/add_macro_fail_tests"
 "$DIR/variadic_macro_tests"
+"$DIR/macro_stringize_escape"
 "$DIR/pack_pragma_tests"
 "$DIR/preproc_stdio"
 "$DIR/preproc_ifmacro"

--- a/tests/unit/test_macro_stringize_escape.c
+++ b/tests/unit/test_macro_stringize_escape.c
@@ -1,0 +1,45 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_macros.h"
+#include "strbuf.h"
+#include "vector.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void add_str_macro(vector_t *macros)
+{
+    vector_t params;
+    vector_init(&params, sizeof(char *));
+    char *p = strdup("x");
+    vector_push(&params, &p);
+    add_macro("STR", "#x", &params, 0, macros);
+}
+
+int main(void)
+{
+    vector_t macros; vector_init(&macros, sizeof(macro_t));
+    add_str_macro(&macros);
+
+    strbuf_t sb; strbuf_init(&sb);
+    preproc_set_location("t.c", 1, 1);
+    ASSERT(expand_line("STR(\"a\\\"b\\\\c\")", &macros, &sb, 0, 0));
+    ASSERT(strcmp(sb.data, "\"\\\"a\\\\\\\"b\\\\\\\\c\\\"\"") == 0);
+    strbuf_free(&sb);
+
+    macro_free(&((macro_t *)macros.data)[0]);
+    vector_free(&macros);
+
+    if (failures == 0)
+        printf("All macro_stringize_escape tests passed\n");
+    else
+        printf("%d macro_stringize_escape test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- correctly escape backslashes and quotes when stringizing macro parameters
- add a regression test covering stringize of a parameter containing escapes
- build the new test in the test runner

## Testing
- `./tests/run.sh` *(fails: undefined references when linking unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_687131f1ad988324b86b1831f6e640f1