### PR TITLE
Fix macro expansion in directives

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -180,6 +180,20 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_line_macro" "$DIR/unit/test_preproc_line_macro.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_pack_macro" "$DIR/unit/test_preproc_pack_macro.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_defined_macro" "$DIR/unit/test_preproc_defined_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -288,6 +302,8 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_stdio"
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"
+"$DIR/preproc_line_macro"
+"$DIR/preproc_pack_macro"
 "$DIR/preproc_defined_macro"
 "$DIR/preproc_pragma"
 "$DIR/preproc_builtin_extra"

--- a/tests/unit/test_preproc_line_macro.c
+++ b/tests/unit/test_preproc_line_macro.c
@@ -1,0 +1,56 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#define NUM 42\n"
+                     "#line NUM \"foo.c\"\n"
+                     "int a = __LINE__;\n"
+                     "const char *f = __FILE__;\n"
+                     "#undef NUM\n"
+                     "#define NUM 100\n"
+                     "#line NUM\n"
+                     "int b = __LINE__;\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int a = 42;") != NULL);
+        ASSERT(strstr(res, "\"foo.c\"") != NULL);
+        ASSERT(strstr(res, "int b = 100;") != NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_line_macro tests passed\n");
+    else
+        printf("%d preproc_line_macro test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}

--- a/tests/unit/test_preproc_pack_macro.c
+++ b/tests/unit/test_preproc_pack_macro.c
@@ -1,0 +1,52 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+static size_t pack_history[4];
+static size_t pack_count = 0;
+void semantic_set_pack(size_t align) { pack_history[pack_count++] = align; semantic_pack_alignment = align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#define P 2\n"
+                     "#pragma pack(push, P)\n"
+                     "#pragma pack(pop)\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    ASSERT(pack_count >= 2);
+    ASSERT(pack_history[0] == 2);
+    ASSERT(pack_history[1] == 0);
+
+    if (failures == 0)
+        printf("All preproc_pack_macro tests passed\n");
+    else
+        printf("%d preproc_pack_macro test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- expand line arguments in `#line` and `#pragma` handlers
- include preprocessor macros header for new helpers
- add regression tests for macro arguments in `#line` and `#pragma pack`
- build and run the new tests

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687139e84754832480a19a3a75bf65ac