### PR TITLE
Handle unterminated block comments

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -65,6 +65,11 @@ int process_file(const char *path, vector_t *macros,
     int ok = process_all_lines(lines, path, dir, macros, conds, out, incdirs,
                                stack, ctx);
 
+    if (ok && ctx->in_comment) {
+        fprintf(stderr, "Unterminated comment\n");
+        ok = 0;
+    }
+
     if (ok && conds->count) {
         fprintf(stderr, "Mismatched #if/#endif directives in %s\n", path);
         ok = 0;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -201,6 +201,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_unterm_comment" "$DIR/unit/test_preproc_unterm_comment.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
     -o "$DIR/preproc_pragma" "$DIR/unit/test_preproc_pragma.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
@@ -305,6 +312,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_line_macro"
 "$DIR/preproc_pack_macro"
 "$DIR/preproc_defined_macro"
+"$DIR/preproc_unterm_comment"
 "$DIR/preproc_pragma"
 "$DIR/preproc_builtin_extra"
 "$DIR/invalid_macro_tests"

--- a/tests/unit/test_preproc_unterm_comment.c
+++ b/tests/unit/test_preproc_unterm_comment.c
@@ -1,0 +1,44 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "/* unterminated comment\n"
+                     "int x = 0;\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res == NULL);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_unterm_comment tests passed\n");
+    else
+        printf("%d preproc_unterm_comment test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- report error on unterminated comments after preprocessing
- add unit test for unterminated comment handling
- run the new unit test from the test harness

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68713d80429483248d50d7cef17091c6