### PR TITLE
Handle malformed includes

### DIFF
--- a/tests/invalid/include_malformed.c
+++ b/tests/invalid/include_malformed.c
@@ -1,0 +1,2 @@
+#include <foo.h
+int main() { return 0; }

--- a/tests/invalid/include_next_malformed.c
+++ b/tests/invalid/include_next_malformed.c
@@ -1,0 +1,2 @@
+#include_next <foo.h
+int main() { return 0; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -349,6 +349,32 @@ if [ $ret -eq 0 ] || ! grep -q "foo.h: No such file or directory" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# negative test for malformed include line
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "${out}" "$DIR/invalid/include_malformed.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Malformed include directive" "${err}"; then
+    echo "Test include_malformed failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
+# negative test for malformed include_next line
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "${out}" "$DIR/invalid/include_next_malformed.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Malformed include directive" "${err}"; then
+    echo "Test include_next_malformed failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 # macro recursion should fail without expansion limit error
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- report malformed include directives in the preprocessor
- test malformed `#include` and `#include_next` lines

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68713f539a4c8324a721e11ac2e2c7b1