### PR TITLE
Add __COUNTER__ and __BASE_FILE__ macros

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -79,6 +79,9 @@ an explicit `#define`:
 - `__STDC__` evaluates to `1` to indicate standard compliance.
 - `__STDC_VERSION__` expands to `199901L` for C99 support.
 - `__func__` yields the enclosing function name as a string literal.
+- `__BASE_FILE__` holds the name of the initial source file being
+  processed.
+- `__COUNTER__` expands to an incrementing integer starting at `0`.
 
 These macros are always available and cannot be undefined. They are useful for
 diagnostics and logging as they convey file names, line numbers and build

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -223,6 +223,14 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
+    -o "$DIR/preproc_counter_base" "$DIR/unit/test_predef_counter_base.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
 # build create_temp_file path length regression test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
@@ -315,6 +323,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_unterm_comment"
 "$DIR/preproc_pragma"
 "$DIR/preproc_builtin_extra"
+"$DIR/preproc_counter_base"
 "$DIR/invalid_macro_tests"
 # separator for clarity
 echo "======="

--- a/tests/unit/test_predef_counter_base.c
+++ b/tests/unit/test_predef_counter_base.c
@@ -1,0 +1,58 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/bmacXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#if defined(__COUNTER__) && defined(__BASE_FILE__)\n"
+                     "int ok;\n"
+                     "#else\n"
+                     "int fail;\n"
+                     "#endif\n"
+                     "int c0 = __COUNTER__;\n"
+                     "const char *b = __BASE_FILE__;\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int ok;") != NULL);
+        ASSERT(strstr(res, "int fail;") == NULL);
+        char cnt0[] = "int c0 = 0;";
+        ASSERT(strstr(res, cnt0) != NULL);
+        char quoted[512]; snprintf(quoted, sizeof(quoted), "\"%s\"", tmpl);
+        ASSERT(strstr(res, quoted) != NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All predef counter/base tests passed\n");
+    else
+        printf("%d predef counter/base test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- define __COUNTER__ and __BASE_FILE__ when initializing macros
- pass source file path to macro init
- document the new builtins
- add unit test exercising the macros

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687140f4b4808324a019d80aff5ee11f