### PR TITLE
Handle standalone hash lines in preprocessor

### DIFF
--- a/src/preproc_directives.c
+++ b/src/preproc_directives.c
@@ -147,6 +147,8 @@ int process_line(char *line, const char *dir, vector_t *macros,
         char *p = line + 1;
         while (*p == ' ' || *p == '\t')
             p++;
+        if (*p == '\0')
+            return 1;
         if (p != line + 1)
             memmove(line + 1, p, strlen(p) + 1);
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -187,6 +187,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_hash_noop" "$DIR/unit/test_preproc_hash_noop.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_pack_macro" "$DIR/unit/test_preproc_pack_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -325,6 +332,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"
 "$DIR/preproc_line_macro"
+"$DIR/preproc_hash_noop"
 "$DIR/preproc_pack_macro"
 "$DIR/preproc_pragma_macro"
 "$DIR/preproc_defined_macro"

--- a/tests/unit/test_preproc_hash_noop.c
+++ b/tests/unit/test_preproc_hash_noop.c
@@ -1,0 +1,48 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#\nint x = 0;\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strchr(res, '#') == NULL);
+        ASSERT(strstr(res, "int x = 0;") != NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_hash_noop tests passed\n");
+    else
+        printf("%d preproc_hash_noop test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- treat lines containing only `#` + whitespace as no‑ops
- add unit test for ignoring standalone `#` lines
- run new test from the test harness

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687149219d1c83248eef4b8f317063bf