### PR TITLE
Handle CR characters when reading source

### DIFF
--- a/src/preproc_file_io.c
+++ b/src/preproc_file_io.c
@@ -108,10 +108,18 @@ static char *read_file_lines_internal(const char *path, char ***out_lines)
 
     size_t w = 0;
     for (size_t r = 0; r < len; r++) {
-        if (text[r] == '\\' && r + 1 < len && text[r + 1] == '\n') {
-            r++;
-            continue;
+        if (text[r] == '\\' && r + 1 < len) {
+            if (text[r + 1] == '\n') {
+                r++;
+                continue;
+            }
+            if (text[r + 1] == '\r' && r + 2 < len && text[r + 2] == '\n') {
+                r += 2;
+                continue;
+            }
         }
+        if (text[r] == '\r')
+            continue;
         text[w++] = text[r];
     }
     text[w] = '\0';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -194,6 +194,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_crlf" "$DIR/unit/test_preproc_crlf.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_pack_macro" "$DIR/unit/test_preproc_pack_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -333,6 +340,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_line"
 "$DIR/preproc_line_macro"
 "$DIR/preproc_hash_noop"
+"$DIR/preproc_crlf"
 "$DIR/preproc_pack_macro"
 "$DIR/preproc_pragma_macro"
 "$DIR/preproc_defined_macro"

--- a/tests/unit/test_preproc_crlf.c
+++ b/tests/unit/test_preproc_crlf.c
@@ -1,0 +1,49 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#define VAL 42\r\n"
+                     "int x = VAL;\r\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int x = 42;") != NULL);
+        ASSERT(strchr(res, '\r') == NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_crlf tests passed\n");
+    else
+        printf("%d preproc_crlf test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- strip CR characters when reading source files
- add regression test for CRLF input
- build/run the new test in the test script

## Testing
- `./tests/run.sh` *(fails: undefined reference to parse_* and other symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68714ca0c840832488949fe7a51c4366