### PR TITLE
Add per-context line tracking for preprocessor

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -100,13 +100,16 @@ vector_t deps;              /* all processed files */
 vector_t pack_stack;        /* active #pragma pack values */
 size_t pack_alignment;      /* current packing alignment */
 int in_comment;             /* multi-line comment state */
+char *current_file;         /* file name for __FILE__ */
+long line_delta;            /* adjustment for __LINE__ */
 ```
 
 `pragma_once_files` tracks headers that issued `#pragma once` so they are not
-processed again. `deps` records every file read during preprocessing, enabling
-dependency generation. Because the entire context is provided by the caller
-rather than stored globally, multiple preprocessing operations can run
-independently. Each call initializes and cleans up the vectors, allowing the
-preprocessor to be used reentrantly by supplying a separate
-`preproc_context_t` instance.
+processed again. `deps` records every file read during preprocessing for
+dependency generation. `current_file` and `line_delta` hold the values used by
+the `__FILE__` and `__LINE__` macros along with `#line` directives. Because the
+entire context is provided by the caller rather than stored globally, multiple
+preprocessing operations can run independently. Each call initializes and
+cleans up the vectors, allowing the preprocessor to be used reentrantly by
+supplying a separate `preproc_context_t` instance.
 

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -30,6 +30,8 @@ typedef struct {
     vector_t pack_stack;        /* vector of size_t pack values */
     size_t pack_alignment;      /* current #pragma pack value */
     int in_comment;             /* tracks multi-line comment state */
+    char *current_file;         /* file name for __FILE__ macro */
+    long line_delta;            /* offset applied to __LINE__ */
 } preproc_context_t;
 
 /* Free the dependency lists stored in the context */

--- a/include/preproc_file_io.h
+++ b/include/preproc_file_io.h
@@ -29,13 +29,13 @@ int process_all_lines(char **lines, const char *path, const char *dir,
                       vector_t *macros, vector_t *conds, strbuf_t *out,
                       const vector_t *incdirs, vector_t *stack,
                       preproc_context_t *ctx);
-
-void preproc_apply_line_directive(const char *file, int line);
+void preproc_apply_line_directive(preproc_context_t *ctx,
+                                  const char *file, int line);
 
 void cleanup_file_resources(char *text, char **lines, char *dir);
 
-void line_state_push(const char *file, long delta,
+void line_state_push(preproc_context_t *ctx, const char *file, long delta,
                      char **prev_file, long *prev_delta);
-void line_state_pop(char *prev_file, long prev_delta);
+void line_state_pop(preproc_context_t *ctx, char *prev_file, long prev_delta);
 
 #endif /* VC_PREPROC_FILE_IO_H */

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -60,7 +60,7 @@ int process_file(const char *path, vector_t *macros,
 
     char *prev_file;
     long prev_delta;
-    line_state_push(path, 0, &prev_file, &prev_delta);
+    line_state_push(ctx, path, 0, &prev_file, &prev_delta);
 
     int ok = process_all_lines(lines, path, dir, macros, conds, out, incdirs,
                                stack, ctx);
@@ -75,7 +75,7 @@ int process_file(const char *path, vector_t *macros,
         ok = 0;
     }
 
-    line_state_pop(prev_file, prev_delta);
+    line_state_pop(ctx, prev_file, prev_delta);
 
     include_stack_pop(stack);
 
@@ -96,6 +96,8 @@ static void init_preproc_vectors(preproc_context_t *ctx, vector_t *macros,
     vector_init(&ctx->pack_stack, sizeof(size_t));
     ctx->pack_alignment = 0;
     ctx->in_comment = 0;
+    ctx->current_file = NULL;
+    ctx->line_delta = 0;
     strbuf_init(out);
 }
 
@@ -259,6 +261,7 @@ void preproc_context_free(preproc_context_t *ctx)
     for (size_t i = 0; i < ctx->deps.count; i++)
         free(((char **)ctx->deps.data)[i]);
     vector_free(&ctx->deps);
+    free(ctx->current_file);
     vector_free(&ctx->pack_stack);
 }
 

--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -103,7 +103,7 @@ int handle_line_directive(char *line, const char *dir, vector_t *macros,
             strbuf_free(&exp);
             return 0;
         }
-        preproc_apply_line_directive(fname ? fname : NULL, lineno);
+        preproc_apply_line_directive(ctx, fname ? fname : NULL, lineno);
     }
     free(fname);
     strbuf_free(&exp);


### PR DESCRIPTION
## Summary
- expand `preproc_context_t` with `current_file` and `line_delta`
- use the new fields in `line_state_push`, `line_state_pop`, `preproc_apply_line_directive`
- initialize and free the new fields
- document updated context structure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68714f124a6c832482423b1673892f9c