### PR TITLE
Handle all whitespace in preprocessor skip functions

### DIFF
--- a/src/preproc_cond.c
+++ b/src/preproc_cond.c
@@ -10,10 +10,10 @@
 #include <string.h>
 #include <stdlib.h>
 
-/* Advance P past spaces and tabs and return the updated pointer */
+/* Advance P past whitespace and return the updated pointer */
 static char *skip_ws(char *p)
 {
-    while (*p == ' ' || *p == '\t')
+    while (isspace((unsigned char)*p))
         p++;
     return p;
 }

--- a/src/preproc_directives.c
+++ b/src/preproc_directives.c
@@ -64,10 +64,10 @@ static void strip_comments(char *s, int *in_comment)
     *out = '\0';
 }
 
-/* Advance P past spaces and tabs and return the updated pointer */
+/* Advance P past whitespace and return the updated pointer */
 static char *skip_ws(char *p)
 {
-    while (*p == ' ' || *p == '\t')
+    while (isspace((unsigned char)*p))
         p++;
     return p;
 }

--- a/src/preproc_expr.c
+++ b/src/preproc_expr.c
@@ -30,10 +30,10 @@ typedef struct {
     int error;
 } expr_ctx_t;
 
-/* Advance the parser position past any spaces or tabs */
+/* Advance the parser position past any whitespace */
 static void skip_ws(expr_ctx_t *ctx)
 {
-    while (*ctx->s == ' ' || *ctx->s == '\t')
+    while (isspace((unsigned char)*ctx->s))
         ctx->s++;
 }
 

--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -18,10 +18,12 @@
 #include "vector.h"
 #include "strbuf.h"
 
-/* Advance P past spaces and tabs and return the updated pointer */
+#include <ctype.h>
+
+/* Advance P past whitespace and return the updated pointer */
 static char *skip_ws(char *p)
 {
-    while (*p == ' ' || *p == '\t')
+    while (isspace((unsigned char)*p))
         p++;
     return p;
 }

--- a/src/preproc_table.c
+++ b/src/preproc_table.c
@@ -81,10 +81,10 @@ void remove_macro(vector_t *macros, const char *name)
     }
 }
 
-/* Advance P past spaces and tabs and return the updated pointer */
+/* Advance P past whitespace and return the updated pointer */
 static char *skip_ws(char *p)
 {
-    while (*p == ' ' || *p == '\t')
+    while (isspace((unsigned char)*p))
         p++;
     return p;
 }


### PR DESCRIPTION
## Summary
- consider every whitespace character when skipping spaces in the preprocessor
- update comments accordingly
- include ctype.h where required

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687165dbfb408324b5def0c0bcdadb2d