### PR TITLE
Support pack push without argument

### DIFF
--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -160,19 +160,25 @@ int handle_pragma_directive(char *line, const char *dir, vector_t *macros,
         p = skip_ws(p);
         if (strncmp(p, "(push", 5) == 0) {
             p += 5; /* after '(push' */
-            if (*p == ',')
-                p++;
             p = skip_ws(p);
-            errno = 0;
-            char *end;
-            long val = strtol(p, &end, 10);
-            if (errno == 0 && end != p) {
-                p = end;
+            if (*p == ')') {
+                /* push current packing without changing it */
+                vector_push(&ctx->pack_stack, &ctx->pack_alignment);
+            } else {
+                if (*p == ',')
+                    p++;
                 p = skip_ws(p);
-                if (*p == ')') {
-                    vector_push(&ctx->pack_stack, &ctx->pack_alignment);
-                    ctx->pack_alignment = (size_t)val;
-                    semantic_set_pack(ctx->pack_alignment);
+                errno = 0;
+                char *end;
+                long val = strtol(p, &end, 10);
+                if (errno == 0 && end != p) {
+                    p = end;
+                    p = skip_ws(p);
+                    if (*p == ')') {
+                        vector_push(&ctx->pack_stack, &ctx->pack_alignment);
+                        ctx->pack_alignment = (size_t)val;
+                        semantic_set_pack(ctx->pack_alignment);
+                    }
                 }
             }
         } else if (strncmp(p, "(pop)", 5) == 0) {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -208,6 +208,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_pack_push" "$DIR/unit/test_preproc_pack_push.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_pragma_macro" "$DIR/unit/test_preproc_pragma_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -349,6 +356,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_hash_noop"
 "$DIR/preproc_crlf"
 "$DIR/preproc_pack_macro"
+"$DIR/preproc_pack_push"
 "$DIR/preproc_pragma_macro"
 "$DIR/preproc_defined_macro"
 "$DIR/preproc_unterm_comment"

--- a/tests/unit/test_preproc_pack_push.c
+++ b/tests/unit/test_preproc_pack_push.c
@@ -1,0 +1,54 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+static size_t pack_history[4];
+static size_t pack_count = 0;
+void semantic_set_pack(size_t align) { pack_history[pack_count++] = align; semantic_pack_alignment = align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#pragma pack(push, 2)\n"
+                     "#pragma pack(push)\n"
+                     "#pragma pack(pop)\n"
+                     "#pragma pack(pop)\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    ASSERT(pack_count >= 3);
+    ASSERT(pack_history[0] == 2); /* push with value */
+    ASSERT(pack_history[1] == 2); /* pop after push() should keep 2 */
+    ASSERT(pack_history[2] == 0); /* final pop restores 0 */
+
+    if (failures == 0)
+        printf("All preproc_pack_push tests passed\n");
+    else
+        printf("%d preproc_pack_push test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- handle `#pragma pack(push)` without parameter
- test pushing current alignment via `pack(push)`

## Testing
- `make`
- `./tests/run.sh` *(fails: undefined references during link)*

------
https://chatgpt.com/codex/tasks/task_e_687168df36108324be87c73f0275759e