### PR TITLE
Add GCC line marker support

### DIFF
--- a/src/preproc_directives.c
+++ b/src/preproc_directives.c
@@ -352,5 +352,9 @@ static int handle_directive(char *line, const char *dir, vector_t *macros,
     if (d)
         return d->handler(line, dir, macros, conds, out, incdirs, stack, ctx);
 
+    if (line[0] == '#' && isdigit((unsigned char)line[1]))
+        return handle_line_directive(line, dir, macros, conds, out,
+                                     incdirs, stack, ctx);
+
     return handle_text_line(line, dir, macros, conds, out, incdirs, stack, ctx);
 }

--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -58,16 +58,29 @@ int handle_line_directive(char *line, const char *dir, vector_t *macros,
                           const vector_t *incdirs, vector_t *stack,
                           preproc_context_t *ctx)
 {
-    (void)dir; (void)incdirs; (void)stack; (void)ctx;
-    char *arg = line + 5;
-    arg = skip_ws(arg);
+    (void)dir; (void)incdirs; (void)stack;
+    char *p = line;
+    int gcc_style = 0;
     strbuf_t exp;
     strbuf_init(&exp);
-    if (!expand_line(arg, macros, &exp, 0, 0)) {
+
+    if (strncmp(line, "#line", 5) == 0 &&
+        (line[5] == '\0' || isspace((unsigned char)line[5]))) {
+        p = line + 5;
+        p = skip_ws(p);
+        if (!expand_line(p, macros, &exp, 0, 0)) {
+            strbuf_free(&exp);
+            return 0;
+        }
+        p = exp.data ? exp.data : "";
+    } else if (line[0] == '#' && isdigit((unsigned char)line[1])) {
+        gcc_style = 1;
+        p = line + 1;
+    } else {
         strbuf_free(&exp);
-        return 0;
+        return 1;
     }
-    char *p = exp.data;
+
     p = skip_ws(p);
     errno = 0;
     char *end;
@@ -86,28 +99,45 @@ int handle_line_directive(char *line, const char *dir, vector_t *macros,
         char *fstart = p;
         while (*p && *p != '"')
             p++;
-        if (*p == '"')
+        if (*p == '"') {
             fname = vc_strndup(fstart, (size_t)(p - fstart));
+            p++;
+        }
     }
+    p = skip_ws(p);
+    char *flags = NULL;
+    if (gcc_style && *p)
+        flags = vc_strdup(p);
+
     if (is_active(conds)) {
         if (strbuf_appendf(out, "# %d", lineno) < 0) {
             free(fname);
+            free(flags);
             strbuf_free(&exp);
             return 0;
         }
         if (fname && strbuf_appendf(out, " \"%s\"", fname) < 0) {
             free(fname);
+            free(flags);
+            strbuf_free(&exp);
+            return 0;
+        }
+        if (flags && strbuf_appendf(out, " %s", flags) < 0) {
+            free(fname);
+            free(flags);
             strbuf_free(&exp);
             return 0;
         }
         if (strbuf_append(out, "\n") < 0) {
             free(fname);
+            free(flags);
             strbuf_free(&exp);
             return 0;
         }
         preproc_apply_line_directive(ctx, fname ? fname : NULL, lineno);
     }
     free(fname);
+    free(flags);
     strbuf_free(&exp);
     return 1;
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -187,6 +187,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/gcc_line_marker" "$DIR/unit/test_gcc_line_marker.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_hash_noop" "$DIR/unit/test_preproc_hash_noop.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -360,6 +367,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"
 "$DIR/preproc_line_macro"
+"$DIR/gcc_line_marker"
 "$DIR/preproc_hash_noop"
 "$DIR/preproc_crlf"
 "$DIR/preproc_pack_macro"

--- a/tests/unit/test_gcc_line_marker.c
+++ b/tests/unit/test_gcc_line_marker.c
@@ -1,0 +1,54 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "# 42 \"foo.c\" 1\n"
+                     "int a = __LINE__;\n"
+                     "const char *f = __FILE__;\n"
+                     "# 100 \"bar.c\" 2\n"
+                     "int b = __LINE__;\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int a = 42;") != NULL);
+        ASSERT(strstr(res, "\"foo.c\"") != NULL);
+        ASSERT(strstr(res, "int b = 100;") != NULL);
+        ASSERT(strstr(res, "\"bar.c\"") != NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All gcc_line_marker tests passed\n");
+    else
+        printf("%d gcc_line_marker test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- extend `handle_line_directive` to understand GCC line markers
- treat lines starting with `# <num>` as line directives
- add a regression test exercising GCC markers
- hook the new test into the build script

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68716e84d4388324ae502470b5bd94d7