### PR TITLE
Improve unterminated conditional reporting

### DIFF
--- a/include/preproc_cond.h
+++ b/include/preproc_cond.h
@@ -15,6 +15,7 @@ typedef struct {
     int parent_active;
     int taking;
     int taken;
+    size_t line;          /* line where the conditional began */
 } cond_state_t;
 
 /* Push a new state for #ifdef/#ifndef directives */

--- a/src/preproc_cond.c
+++ b/src/preproc_cond.c
@@ -4,6 +4,7 @@
 #include "preproc_cond.h"
 #include "preproc_macros.h"
 #include "preproc_expr.h"
+#include "preproc_builtin.h"
 #include "util.h"
 #include "vector.h"
 #include "strbuf.h"
@@ -50,6 +51,7 @@ int cond_push_ifdef_common(char *line, vector_t *macros,
     cond_state_t st;
     st.parent_active = is_active(conds);
     st.taken = 0;
+    st.line = preproc_get_line();
     int defined = is_macro_defined(macros, id);
     if (st.parent_active && (neg ? !defined : defined)) {
         st.taking = 1;
@@ -170,6 +172,7 @@ int cond_push_ifexpr(char *line, vector_t *macros, vector_t *conds)
     cond_state_t st;
     st.parent_active = is_active(conds);
     st.taken = 0;
+    st.line = preproc_get_line();
     if (st.parent_active && eval_expr(expr, macros) != 0) {
         st.taking = 1;
         st.taken = 1;

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -71,7 +71,9 @@ int process_file(const char *path, vector_t *macros,
     }
 
     if (ok && conds->count) {
-        fprintf(stderr, "Mismatched #if/#endif directives in %s\n", path);
+        cond_state_t *st = &((cond_state_t *)conds->data)[conds->count - 1];
+        fprintf(stderr, "%s:%zu: unterminated conditional started here\n",
+                path, st->line);
         ok = 0;
     }
 


### PR DESCRIPTION
## Summary
- extend `cond_state_t` to track the line where a conditional block begins
- record the current line in `cond_push_if*` helpers
- when a file ends with unmatched `#if`, include the start line in the error

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68716eb1db748324b21d5b383e5a6879