### PR TITLE
Add __has_include evaluation in preprocessor expressions

### DIFF
--- a/include/preproc_cond.h
+++ b/include/preproc_cond.h
@@ -25,14 +25,18 @@ int cond_push_ifdef(char *line, vector_t *macros, vector_t *conds);
 int cond_push_ifndef(char *line, vector_t *macros, vector_t *conds);
 
 /* Push a new state for a generic #if expression */
-int cond_push_ifexpr(char *line, vector_t *macros, vector_t *conds);
+int cond_push_ifexpr(char *line, const char *dir, vector_t *macros,
+                     vector_t *conds, const vector_t *incdirs, vector_t *stack);
 
 /* Handle conditional branches */
-void cond_handle_elif(char *line, vector_t *macros, vector_t *conds);
+void cond_handle_elif(char *line, const char *dir, vector_t *macros,
+                      vector_t *conds, const vector_t *incdirs, vector_t *stack);
 void cond_handle_else(vector_t *conds);
 void cond_handle_endif(vector_t *conds);
 
 /* Dispatch a conditional directive */
-int handle_conditional(char *line, vector_t *macros, vector_t *conds);
+int handle_conditional(char *line, const char *dir, vector_t *macros,
+                       vector_t *conds, const vector_t *incdirs,
+                       vector_t *stack);
 
 #endif /* VC_PREPROC_COND_H */

--- a/include/preproc_expr.h
+++ b/include/preproc_expr.h
@@ -18,4 +18,9 @@
 /* Evaluate a conditional expression */
 long long eval_expr(const char *s, vector_t *macros);
 
+/* Evaluate an expression with include lookup support */
+long long eval_expr_full(const char *s, vector_t *macros,
+                         const char *dir, const vector_t *incdirs,
+                         vector_t *stack);
+
 #endif /* VC_PREPROC_EXPR_H */

--- a/src/preproc_directives.c
+++ b/src/preproc_directives.c
@@ -235,8 +235,8 @@ static int handle_conditional_directive(char *line, const char *dir,
                                         vector_t *stack,
                                         preproc_context_t *ctx)
 {
-    (void)dir; (void)out; (void)incdirs; (void)stack; (void)ctx;
-    return handle_conditional(line, macros, conds);
+    (void)out; (void)ctx;
+    return handle_conditional(line, dir, macros, conds, incdirs, stack);
 }
 
 /*

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -166,6 +166,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_has_include" "$DIR/unit/test_preproc_has_include.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_ifmacro" "$DIR/unit/test_preproc_ifmacro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -364,6 +371,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/macro_stringize_escape"
 "$DIR/pack_pragma_tests"
 "$DIR/preproc_stdio"
+"$DIR/preproc_has_include"
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"
 "$DIR/preproc_line_macro"

--- a/tests/unit/test_preproc_has_include.c
+++ b/tests/unit/test_preproc_has_include.c
@@ -1,0 +1,86 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char dir1[] = "/tmp/hi1XXXXXX";
+    char dir2[] = "/tmp/hi2XXXXXX";
+    ASSERT(mkdtemp(dir1) != NULL);
+    ASSERT(mkdtemp(dir2) != NULL);
+
+    char bar[256];
+    snprintf(bar, sizeof(bar), "%s/bar.h", dir2);
+    FILE *f = fopen(bar, "w");
+    ASSERT(f != NULL);
+    if (f) {
+        fputs("/*bar*/\n", f);
+        fclose(f);
+    }
+
+    char hdr[256];
+    snprintf(hdr, sizeof(hdr), "%s/has.h", dir1);
+    f = fopen(hdr, "w");
+    ASSERT(f != NULL);
+    if (f) {
+        fputs("#if __has_include(\"stdio.h\")\nint ok1;\n#endif\n", f);
+        fputs("#if __has_include(\"nosuch.h\")\nint fail1;\n#endif\n", f);
+        fputs("#if __has_include_next(\"bar.h\")\nint ok2;\n#endif\n", f);
+        fputs("#if __has_include_next(\"missing.h\")\nint fail2;\n#endif\n", f);
+        fclose(f);
+    }
+
+    char src[] = "/tmp/hsXXXXXX";
+    int fd = mkstemp(src);
+    ASSERT(fd >= 0);
+    if (fd >= 0) {
+        dprintf(fd, "#include \"has.h\"\n");
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    char *d1 = strdup(dir1);
+    char *d2 = strdup(dir2);
+    vector_push(&dirs, &d1);
+    vector_push(&dirs, &d2);
+
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, src, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int ok1;") != NULL);
+        ASSERT(strstr(res, "int ok2;") != NULL);
+        ASSERT(strstr(res, "fail1") == NULL);
+        ASSERT(strstr(res, "fail2") == NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    free(d1);
+    free(d2);
+    vector_free(&dirs);
+    unlink(src);
+    unlink(hdr);
+    unlink(bar);
+    rmdir(dir1);
+    rmdir(dir2);
+
+    if (failures == 0)
+        printf("All preproc_has_include tests passed\n");
+    else
+        printf("%d preproc_has_include test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- extend preprocessor expression parser to evaluate `__has_include` and `__has_include_next`
- pass include context to expression evaluation
- update conditional handling to use extended expression evaluator
- add unit test covering success and failure cases

## Testing
- `make -j2`
- `gcc -Iinclude -Wall -Wextra -std=c99 -o /tmp/test_has_include tests/unit/test_preproc_has_include.c src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c src/preproc_args.c src/preproc_cond.c src/preproc_expr.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c src/vector.c src/strbuf.c src/util.c src/error.c`
- `/tmp/test_has_include >/tmp/test_has_include.out && cat /tmp/test_has_include.out`

------
https://chatgpt.com/codex/tasks/task_e_687173b9bfa4832498761011c7a8279f