### PR TITLE
Fix VCFLAGS allocation with size_t

### DIFF
--- a/src/cli_env.c
+++ b/src/cli_env.c
@@ -28,7 +28,7 @@ int load_vcflags(int *argc, char ***argv, char ***out_argv,
             vcargc++;
         free(tmp);
 
-        vcargv = malloc(sizeof(char *) * (*argc + vcargc));
+        vcargv = malloc(sizeof(char *) * (size_t)(*argc + vcargc));
         if (!vcargv) {
             fprintf(stderr, "Out of memory while processing VCFLAGS.\n");
             free(vcbuf);


### PR DESCRIPTION
## Summary
- ensure `malloc` uses `size_t` when allocating CLI env arg buffer

## Testing
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_6871aae8bd6883249d34131849c47657