### PR TITLE
Fix sign conversion warning in lexer

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -84,7 +84,7 @@ static int consume_line_marker(const char *src, size_t *i,
         return 0;
     size_t num = 0;
     while (isdigit((unsigned char)src[j])) {
-        num = num * 10 + (src[j] - '0');
+        num = num * 10 + (size_t)(src[j] - '0');
         j++;
     }
     while (src[j] == ' ' || src[j] == '\t')


### PR DESCRIPTION
## Summary
- fix sign-conversion in `consume_line_marker`

## Testing
- `make src/lexer.o`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6871aaf0b22c8324bef6d1d1d089083a