### PR TITLE
Fix Wconversion warnings in pointer arithmetic

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -21,7 +21,7 @@ void emit_ptr_add(strbuf_t *sb, ir_instr_t *ins,
     char b1[32];
     char b2[32];
     const char *sfx = x64 ? "q" : "l";
-    int scale = ins->imm;
+    int scale = (int)ins->imm;
     x86_emit_mov(sb, sfx,
                  x86_loc_str(b1, ra, ins->src2, x64, syntax),
                  x86_loc_str(b2, ra, ins->dest, x64, syntax),
@@ -45,7 +45,7 @@ void emit_ptr_diff(strbuf_t *sb, ir_instr_t *ins,
     char b1[32];
     char b2[32];
     const char *sfx = x64 ? "q" : "l";
-    int esz = ins->imm;
+    int esz = (int)ins->imm;
     int shift = 0;
     while ((esz >>= 1) > 0) shift++;
     x86_emit_mov(sb, sfx,


### PR DESCRIPTION
## Summary
- avoid implicit long long to int conversions in pointer arithmetic helpers

## Testing
- `make src/codegen_arith_int.o`

------
https://chatgpt.com/codex/tasks/task_e_6871ac4e55f083248d260d10fa4e5170