### PR TITLE
Fix stack offset calc for function params

### DIFF
--- a/src/codegen_mem.c
+++ b/src/codegen_mem.c
@@ -210,7 +210,7 @@ static void emit_load_param(strbuf_t *sb, ir_instr_t *ins,
     const char *dest = spill ? reg_str(SCRATCH_REG, syntax)
                              : loc_str(destb, ra, ins->dest, x64, syntax);
     const char *slot = loc_str(mem, ra, ins->dest, x64, syntax);
-    int off = 8 + ins->imm * (x64 ? 8 : 4);
+    int off = 8 + (int)ins->imm * (x64 ? 8 : 4);
     char srcbuf[32];
     if (syntax == ASM_INTEL)
         snprintf(srcbuf, sizeof(srcbuf), "[%s+%d]", bp, off);
@@ -236,7 +236,7 @@ static void emit_store_param(strbuf_t *sb, ir_instr_t *ins,
                      ? (x64 ? "rbp" : "ebp")
                      : (x64 ? "%rbp" : "%ebp");
     const char *sfx = x64 ? "q" : "l";
-    int off = 8 + ins->imm * (x64 ? 8 : 4);
+    int off = 8 + (int)ins->imm * (x64 ? 8 : 4);
     if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    mov%s %d(%s), %s\n", sfx,
                        off, bp, loc_str(b1, ra, ins->src1, x64, syntax));


### PR DESCRIPTION
## Summary
- fix `emit_load_param` and `emit_store_param` offset calculation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6871ac464d2083249e3cb2b4440b2fdb