### PR TITLE
Move alias_ent struct into ir_core

### DIFF
--- a/include/ir_builder.h
+++ b/include/ir_builder.h
@@ -3,12 +3,6 @@
 
 #include "ir_core.h"
 
-typedef struct alias_ent {
-    const char *name;
-    int set;
-    struct alias_ent *next;
-} alias_ent_t;
-
 /* Append a new blank instruction to the builder's list */
 ir_instr_t *append_instr(ir_builder_t *b);
 

--- a/include/ir_core.h
+++ b/include/ir_core.h
@@ -103,7 +103,12 @@ typedef struct ir_instr {
     size_t column;
 } ir_instr_t;
 
-typedef struct alias_ent alias_ent_t;
+
+typedef struct alias_ent {
+    const char *name;
+    int set;
+    struct alias_ent *next;
+} alias_ent_t;
 
 typedef struct {
     ir_instr_t *head;

--- a/src/opt_alias.c
+++ b/src/opt_alias.c
@@ -8,12 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "opt.h"
-
-typedef struct alias_ent {
-    const char *name;
-    int set;
-    struct alias_ent *next;
-} alias_ent_t;
+#include "ir_core.h"
 
 static int lookup_alias(alias_ent_t **list, const char *name, int *next_id)
 {


### PR DESCRIPTION
## Summary
- centralize alias_ent struct definition
- clean up ir_builder.h and opt_alias.c

## Testing
- `make -j4`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6871ac402e8c8324902045611e94fbfe