### PR TITLE
Fix sign conversions in string literal decoding

### DIFF
--- a/src/opt_constprop.c
+++ b/src/opt_constprop.c
@@ -146,7 +146,7 @@ static void propagate_through_instruction(const_track_t *ct, ir_instr_t *ins)
     case IR_CONST:
         if (ins->dest >= 0 && (size_t)ins->dest < max_id) {
             ct->is_const[ins->dest] = 1;
-            ct->values[ins->dest] = ins->imm;
+            ct->values[ins->dest] = (int)ins->imm;
         }
         break;
     case IR_STORE:

--- a/src/opt_fold.c
+++ b/src/opt_fold.c
@@ -113,7 +113,7 @@ static void fold_int_instr(ir_instr_t *ins, size_t max_id,
         int b = values[ins->src2];
         int result = eval_int_op(ins->op, a, b);
         ins->op = IR_CONST;
-        ins->imm = result;
+        ins->imm = (long long)result;
         ins->src1 = ins->src2 = 0;
         update_const(ins, result, 1, max_id, is_const, values);
     } else {
@@ -131,7 +131,7 @@ static void fold_float_instr(ir_instr_t *ins, size_t max_id,
         int b = values[ins->src2];
         int result = eval_float_op(ins->op, a, b);
         ins->op = IR_CONST;
-        ins->imm = result;
+        ins->imm = (long long)result;
         ins->src1 = ins->src2 = 0;
         update_const(ins, result, 1, max_id, is_const, values);
     } else {
@@ -157,7 +157,7 @@ static void fold_long_float_instr(ir_instr_t *ins, size_t max_id,
         memcpy(&b, &ib, sizeof(b));
         uint64_t result = eval_long_float_op(ins->op, a, b);
         ins->op = IR_CONST;
-        ins->imm = result;
+        ins->imm = (long long)result;
         ins->src1 = ins->src2 = 0;
         update_const(ins, (int)result, 1, max_id, is_const, values);
     } else {

--- a/src/preproc_expand.c
+++ b/src/preproc_expand.c
@@ -452,7 +452,7 @@ static char *decode_string_literal(const char *s, size_t len)
                     int hex = (d >= '0' && d <= '9') ? d - '0' :
                                (d >= 'a' && d <= 'f') ? d - 'a' + 10 :
                                (d >= 'A' && d <= 'F') ? d - 'A' + 10 : 0;
-                    value = value * 16 + hex;
+                    value = value * 16 + (unsigned)hex;
                     i++; digits++;
                 }
                 strbuf_appendf(&sb, "%c", (char)value);
@@ -460,10 +460,10 @@ static char *decode_string_literal(const char *s, size_t len)
             }
             default:
                 if (c >= '0' && c <= '7') {
-                    unsigned value = c - '0';
+                    unsigned value = (unsigned)(c - '0');
                     int digits = 1;
                     while (digits < 3 && i < len && s[i] >= '0' && s[i] <= '7') {
-                        value = value * 8 + (s[i] - '0');
+                        value = value * 8 + (unsigned)(s[i] - '0');
                         i++; digits++;
                     }
                     strbuf_appendf(&sb, "%c", (char)value);


### PR DESCRIPTION
## Summary
- cast hex and digit accumulations to `unsigned` in `decode_string_literal`
- cast constant folding results to silence sign conversion warnings

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6871ac550b788324945826dbae6eeb63