### PR TITLE
Refactor expr union

### DIFF
--- a/include/ast_expr.h
+++ b/include/ast_expr.h
@@ -15,11 +15,7 @@
 
 #include "ast.h"
 
-struct expr {
-    expr_kind_t kind;
-    size_t line;
-    size_t column;
-    union {
+union expr_data {
         struct {
             char *value;
             int is_unsigned;
@@ -117,7 +113,13 @@ struct expr {
             init_entry_t *init_list;
             size_t init_count;
         } compound;
-    };
+};
+
+struct expr {
+    expr_kind_t kind;
+    size_t line;
+    size_t column;
+    union expr_data data;
 };
 
 /* Create a numeric literal expression. */

--- a/src/ast_clone.c
+++ b/src/ast_clone.c
@@ -28,74 +28,74 @@ static expr_t *clone_number(const expr_t *expr)
     n->kind = EXPR_NUMBER;
     n->line = expr->line;
     n->column = expr->column;
-    n->number.value = vc_strdup(expr->number.value);
-    if (!n->number.value) {
+    n->data.number.value = vc_strdup(expr->data.number.value);
+    if (!n->data.number.value) {
         free(n);
         return NULL;
     }
-    n->number.is_unsigned = expr->number.is_unsigned;
-    n->number.long_count = expr->number.long_count;
+    n->data.number.is_unsigned = expr->data.number.is_unsigned;
+    n->data.number.long_count = expr->data.number.long_count;
     return n;
 }
 
 /* Duplicate an identifier expression node. */
 static expr_t *clone_ident(const expr_t *expr)
 {
-    return ast_make_ident(expr->ident.name, expr->line, expr->column);
+    return ast_make_ident(expr->data.ident.name, expr->line, expr->column);
 }
 
 /* Duplicate a string literal expression node. */
 static expr_t *clone_string(const expr_t *expr)
 {
-    if (expr->string.is_wide)
-        return ast_make_wstring(expr->string.value, expr->line, expr->column);
-    return ast_make_string(expr->string.value, expr->line, expr->column);
+    if (expr->data.string.is_wide)
+        return ast_make_wstring(expr->data.string.value, expr->line, expr->column);
+    return ast_make_string(expr->data.string.value, expr->line, expr->column);
 }
 
 /* Duplicate a character literal expression node. */
 static expr_t *clone_char(const expr_t *expr)
 {
-    if (expr->ch.is_wide)
-        return ast_make_wchar(expr->ch.value, expr->line, expr->column);
-    return ast_make_char(expr->ch.value, expr->line, expr->column);
+    if (expr->data.ch.is_wide)
+        return ast_make_wchar(expr->data.ch.value, expr->line, expr->column);
+    return ast_make_char(expr->data.ch.value, expr->line, expr->column);
 }
 
 /* Duplicate a complex literal expression node. */
 static expr_t *clone_complex_literal(const expr_t *expr)
 {
-    return ast_make_complex_literal(expr->complex_lit.real,
-                                    expr->complex_lit.imag,
+    return ast_make_complex_literal(expr->data.complex_lit.real,
+                                    expr->data.complex_lit.imag,
                                     expr->line, expr->column);
 }
 
 /* Clone a unary operation and its operand. */
 static expr_t *clone_unary(const expr_t *expr)
 {
-    expr_t *op = clone_expr(expr->unary.operand);
+    expr_t *op = clone_expr(expr->data.unary.operand);
     if (!op)
         return NULL;
-    return ast_make_unary(expr->unary.op, op, expr->line, expr->column);
+    return ast_make_unary(expr->data.unary.op, op, expr->line, expr->column);
 }
 
 /* Clone a binary operation and its operands. */
 static expr_t *clone_binary(const expr_t *expr)
 {
-    expr_t *l = clone_expr(expr->binary.left);
-    expr_t *r = clone_expr(expr->binary.right);
+    expr_t *l = clone_expr(expr->data.binary.left);
+    expr_t *r = clone_expr(expr->data.binary.right);
     if (!l || !r) {
         ast_free_expr(l);
         ast_free_expr(r);
         return NULL;
     }
-    return ast_make_binary(expr->binary.op, l, r, expr->line, expr->column);
+    return ast_make_binary(expr->data.binary.op, l, r, expr->line, expr->column);
 }
 
 /* Clone a conditional expression and its branches. */
 static expr_t *clone_cond(const expr_t *expr)
 {
-    expr_t *c = clone_expr(expr->cond.cond);
-    expr_t *t = clone_expr(expr->cond.then_expr);
-    expr_t *e = clone_expr(expr->cond.else_expr);
+    expr_t *c = clone_expr(expr->data.cond.cond);
+    expr_t *t = clone_expr(expr->data.cond.then_expr);
+    expr_t *e = clone_expr(expr->data.cond.else_expr);
     if (!c || !t || !e) {
         ast_free_expr(c);
         ast_free_expr(t);
@@ -108,17 +108,17 @@ static expr_t *clone_cond(const expr_t *expr)
 /* Clone an assignment expression. */
 static expr_t *clone_assign(const expr_t *expr)
 {
-    expr_t *v = clone_expr(expr->assign.value);
+    expr_t *v = clone_expr(expr->data.assign.value);
     if (!v)
         return NULL;
-    return ast_make_assign(expr->assign.name, v, expr->line, expr->column);
+    return ast_make_assign(expr->data.assign.name, v, expr->line, expr->column);
 }
 
 /* Clone an array indexing expression. */
 static expr_t *clone_index(const expr_t *expr)
 {
-    expr_t *a = clone_expr(expr->index.array);
-    expr_t *i = clone_expr(expr->index.index);
+    expr_t *a = clone_expr(expr->data.index.array);
+    expr_t *i = clone_expr(expr->data.index.index);
     if (!a || !i) {
         ast_free_expr(a);
         ast_free_expr(i);
@@ -130,9 +130,9 @@ static expr_t *clone_index(const expr_t *expr)
 /* Clone an array element assignment. */
 static expr_t *clone_assign_index(const expr_t *expr)
 {
-    expr_t *a = clone_expr(expr->assign_index.array);
-    expr_t *i = clone_expr(expr->assign_index.index);
-    expr_t *v = clone_expr(expr->assign_index.value);
+    expr_t *a = clone_expr(expr->data.assign_index.array);
+    expr_t *i = clone_expr(expr->data.assign_index.index);
+    expr_t *v = clone_expr(expr->data.assign_index.value);
     if (!a || !i || !v) {
         ast_free_expr(a);
         ast_free_expr(i);
@@ -145,37 +145,37 @@ static expr_t *clone_assign_index(const expr_t *expr)
 /* Clone a struct or union member assignment. */
 static expr_t *clone_assign_member(const expr_t *expr)
 {
-    expr_t *obj = clone_expr(expr->assign_member.object);
-    expr_t *val = clone_expr(expr->assign_member.value);
+    expr_t *obj = clone_expr(expr->data.assign_member.object);
+    expr_t *val = clone_expr(expr->data.assign_member.value);
     if (!obj || !val) {
         ast_free_expr(obj);
         ast_free_expr(val);
         return NULL;
     }
-    return ast_make_assign_member(obj, expr->assign_member.member, val,
-                                  expr->assign_member.via_ptr, expr->line,
+    return ast_make_assign_member(obj, expr->data.assign_member.member, val,
+                                  expr->data.assign_member.via_ptr, expr->line,
                                   expr->column);
 }
 
 /* Clone a member access expression. */
 static expr_t *clone_member(const expr_t *expr)
 {
-    expr_t *obj = clone_expr(expr->member.object);
+    expr_t *obj = clone_expr(expr->data.member.object);
     if (!obj)
         return NULL;
-    return ast_make_member(obj, expr->member.member, expr->member.via_ptr,
+    return ast_make_member(obj, expr->data.member.member, expr->data.member.via_ptr,
                            expr->line, expr->column);
 }
 
 /* Clone a sizeof expression. */
 static expr_t *clone_sizeof(const expr_t *expr)
 {
-    if (expr->sizeof_expr.is_type)
-        return ast_make_sizeof_type(expr->sizeof_expr.type,
-                                    expr->sizeof_expr.array_size,
-                                    expr->sizeof_expr.elem_size, expr->line,
+    if (expr->data.sizeof_expr.is_type)
+        return ast_make_sizeof_type(expr->data.sizeof_expr.type,
+                                    expr->data.sizeof_expr.array_size,
+                                    expr->data.sizeof_expr.elem_size, expr->line,
                                     expr->column);
-    expr_t *e = clone_expr(expr->sizeof_expr.expr);
+    expr_t *e = clone_expr(expr->data.sizeof_expr.expr);
     if (!e)
         return NULL;
     return ast_make_sizeof_expr(e, expr->line, expr->column);
@@ -184,14 +184,14 @@ static expr_t *clone_sizeof(const expr_t *expr)
 /* Clone an offsetof expression. */
 static expr_t *clone_offsetof(const expr_t *expr)
 {
-    size_t n = expr->offsetof_expr.member_count;
+    size_t n = expr->data.offsetof_expr.member_count;
     char **members = NULL;
     if (n) {
         members = malloc(n * sizeof(char *));
         if (!members)
             return NULL;
         for (size_t i = 0; i < n; i++) {
-            members[i] = vc_strdup(expr->offsetof_expr.members[i]);
+            members[i] = vc_strdup(expr->data.offsetof_expr.members[i]);
             if (!members[i]) {
                 for (size_t j = 0; j < i; j++)
                     free(members[j]);
@@ -200,26 +200,26 @@ static expr_t *clone_offsetof(const expr_t *expr)
             }
         }
     }
-    char *tag = vc_strdup(expr->offsetof_expr.tag);
+    char *tag = vc_strdup(expr->data.offsetof_expr.tag);
     if (!tag) {
         for (size_t i = 0; i < n; i++)
             free(members[i]);
         free(members);
         return NULL;
     }
-    return ast_make_offsetof(expr->offsetof_expr.type, tag,
+    return ast_make_offsetof(expr->data.offsetof_expr.type, tag,
                              members, n, expr->line, expr->column);
 }
 
 /* Clone an alignof expression. */
 static expr_t *clone_alignof(const expr_t *expr)
 {
-    if (expr->alignof_expr.is_type)
-        return ast_make_alignof_type(expr->alignof_expr.type,
-                                     expr->alignof_expr.array_size,
-                                     expr->alignof_expr.elem_size,
+    if (expr->data.alignof_expr.is_type)
+        return ast_make_alignof_type(expr->data.alignof_expr.type,
+                                     expr->data.alignof_expr.array_size,
+                                     expr->data.alignof_expr.elem_size,
                                      expr->line, expr->column);
-    expr_t *e = clone_expr(expr->alignof_expr.expr);
+    expr_t *e = clone_expr(expr->data.alignof_expr.expr);
     if (!e)
         return NULL;
     return ast_make_alignof_expr(e, expr->line, expr->column);
@@ -228,25 +228,25 @@ static expr_t *clone_alignof(const expr_t *expr)
 /* Clone a cast expression. */
 static expr_t *clone_cast(const expr_t *expr)
 {
-    expr_t *inner = clone_expr(expr->cast.expr);
+    expr_t *inner = clone_expr(expr->data.cast.expr);
     if (!inner)
         return NULL;
-    return ast_make_cast(expr->cast.type, expr->cast.array_size,
-                         expr->cast.elem_size, inner,
+    return ast_make_cast(expr->data.cast.type, expr->data.cast.array_size,
+                         expr->data.cast.elem_size, inner,
                          expr->line, expr->column);
 }
 
 /* Clone a function call expression and its arguments. */
 static expr_t *clone_call(const expr_t *expr)
 {
-    size_t n = expr->call.arg_count;
+    size_t n = expr->data.call.arg_count;
     expr_t **args = NULL;
     if (n) {
         args = malloc(n * sizeof(*args));
         if (!args)
             return NULL;
         for (size_t i = 0; i < n; i++) {
-            args[i] = clone_expr(expr->call.args[i]);
+            args[i] = clone_expr(expr->data.call.args[i]);
             if (!args[i]) {
                 for (size_t j = 0; j < i; j++)
                     ast_free_expr(args[j]);
@@ -255,29 +255,29 @@ static expr_t *clone_call(const expr_t *expr)
             }
         }
     }
-    return ast_make_call(expr->call.name, args, n, expr->line, expr->column);
+    return ast_make_call(expr->data.call.name, args, n, expr->line, expr->column);
 }
 
 /* Clone a compound literal expression and its initializer list. */
 static expr_t *clone_complit(const expr_t *expr)
 {
-    expr_t *init = clone_expr(expr->compound.init);
+    expr_t *init = clone_expr(expr->data.compound.init);
     init_entry_t *list = NULL;
-    if (expr->compound.init_count) {
-        list = malloc(expr->compound.init_count * sizeof(*list));
+    if (expr->data.compound.init_count) {
+        list = malloc(expr->data.compound.init_count * sizeof(*list));
         if (!list) {
             ast_free_expr(init);
             return NULL;
         }
-        for (size_t i = 0; i < expr->compound.init_count; i++) {
-            list[i].kind = expr->compound.init_list[i].kind;
-            list[i].field = expr->compound.init_list[i].field ?
-                            vc_strdup(expr->compound.init_list[i].field) : NULL;
-            list[i].index = clone_expr(expr->compound.init_list[i].index);
-            list[i].value = clone_expr(expr->compound.init_list[i].value);
-            if ((expr->compound.init_list[i].field && !list[i].field) ||
-                (expr->compound.init_list[i].index && !list[i].index) ||
-                (expr->compound.init_list[i].value && !list[i].value)) {
+        for (size_t i = 0; i < expr->data.compound.init_count; i++) {
+            list[i].kind = expr->data.compound.init_list[i].kind;
+            list[i].field = expr->data.compound.init_list[i].field ?
+                            vc_strdup(expr->data.compound.init_list[i].field) : NULL;
+            list[i].index = clone_expr(expr->data.compound.init_list[i].index);
+            list[i].value = clone_expr(expr->data.compound.init_list[i].value);
+            if ((expr->data.compound.init_list[i].field && !list[i].field) ||
+                (expr->data.compound.init_list[i].index && !list[i].index) ||
+                (expr->data.compound.init_list[i].value && !list[i].value)) {
                 for (size_t j = 0; j <= i; j++) {
                     free(list[j].field);
                     ast_free_expr(list[j].index);
@@ -289,9 +289,9 @@ static expr_t *clone_complit(const expr_t *expr)
             }
         }
     }
-    return ast_make_compound(expr->compound.type, expr->compound.array_size,
-                             expr->compound.elem_size, init, list,
-                             expr->compound.init_count, expr->line,
+    return ast_make_compound(expr->data.compound.type, expr->data.compound.array_size,
+                             expr->data.compound.elem_size, init, list,
+                             expr->data.compound.init_count, expr->line,
                              expr->column);
 }
 

--- a/src/ast_dump.c
+++ b/src/ast_dump.c
@@ -69,71 +69,71 @@ static void dump_expr(strbuf_t *sb, const expr_t *e, int lvl)
     indent(sb, lvl);
     strbuf_appendf(sb, "%s", expr_name(e->kind));
     if (e->kind == EXPR_NUMBER)
-        strbuf_appendf(sb, " %s", e->number.value);
+        strbuf_appendf(sb, " %s", e->data.number.value);
     else if (e->kind == EXPR_IDENT)
-        strbuf_appendf(sb, " %s", e->ident.name);
+        strbuf_appendf(sb, " %s", e->data.ident.name);
     else if (e->kind == EXPR_STRING)
-        strbuf_appendf(sb, " \"%s\"", e->string.value);
+        strbuf_appendf(sb, " \"%s\"", e->data.string.value);
     else if (e->kind == EXPR_CHAR)
-        strbuf_appendf(sb, " '%c'", e->ch.value);
+        strbuf_appendf(sb, " '%c'", e->data.ch.value);
     else if (e->kind == EXPR_COMPLEX_LITERAL)
-        strbuf_appendf(sb, " %f%+fi", e->complex_lit.real, e->complex_lit.imag);
+        strbuf_appendf(sb, " %f%+fi", e->data.complex_lit.real, e->data.complex_lit.imag);
     strbuf_append(sb, "\n");
 
     switch (e->kind) {
     case EXPR_UNARY:
-        dump_expr(sb, e->unary.operand, lvl + 1);
+        dump_expr(sb, e->data.unary.operand, lvl + 1);
         break;
     case EXPR_BINARY:
-        dump_expr(sb, e->binary.left, lvl + 1);
-        dump_expr(sb, e->binary.right, lvl + 1);
+        dump_expr(sb, e->data.binary.left, lvl + 1);
+        dump_expr(sb, e->data.binary.right, lvl + 1);
         break;
     case EXPR_COND:
-        dump_expr(sb, e->cond.cond, lvl + 1);
-        dump_expr(sb, e->cond.then_expr, lvl + 1);
-        dump_expr(sb, e->cond.else_expr, lvl + 1);
+        dump_expr(sb, e->data.cond.cond, lvl + 1);
+        dump_expr(sb, e->data.cond.then_expr, lvl + 1);
+        dump_expr(sb, e->data.cond.else_expr, lvl + 1);
         break;
     case EXPR_ASSIGN:
-        dump_expr(sb, e->assign.value, lvl + 1);
+        dump_expr(sb, e->data.assign.value, lvl + 1);
         break;
     case EXPR_CALL:
-        for (size_t i = 0; i < e->call.arg_count; i++)
-            dump_expr(sb, e->call.args[i], lvl + 1);
+        for (size_t i = 0; i < e->data.call.arg_count; i++)
+            dump_expr(sb, e->data.call.args[i], lvl + 1);
         break;
     case EXPR_INDEX:
-        dump_expr(sb, e->index.array, lvl + 1);
-        dump_expr(sb, e->index.index, lvl + 1);
+        dump_expr(sb, e->data.index.array, lvl + 1);
+        dump_expr(sb, e->data.index.index, lvl + 1);
         break;
     case EXPR_ASSIGN_INDEX:
-        dump_expr(sb, e->assign_index.array, lvl + 1);
-        dump_expr(sb, e->assign_index.index, lvl + 1);
-        dump_expr(sb, e->assign_index.value, lvl + 1);
+        dump_expr(sb, e->data.assign_index.array, lvl + 1);
+        dump_expr(sb, e->data.assign_index.index, lvl + 1);
+        dump_expr(sb, e->data.assign_index.value, lvl + 1);
         break;
     case EXPR_ASSIGN_MEMBER:
-        dump_expr(sb, e->assign_member.object, lvl + 1);
-        dump_expr(sb, e->assign_member.value, lvl + 1);
+        dump_expr(sb, e->data.assign_member.object, lvl + 1);
+        dump_expr(sb, e->data.assign_member.value, lvl + 1);
         break;
     case EXPR_MEMBER:
-        dump_expr(sb, e->member.object, lvl + 1);
+        dump_expr(sb, e->data.member.object, lvl + 1);
         break;
     case EXPR_SIZEOF:
-        if (!e->sizeof_expr.is_type)
-            dump_expr(sb, e->sizeof_expr.expr, lvl + 1);
+        if (!e->data.sizeof_expr.is_type)
+            dump_expr(sb, e->data.sizeof_expr.expr, lvl + 1);
         break;
     case EXPR_ALIGNOF:
-        if (!e->alignof_expr.is_type)
-            dump_expr(sb, e->alignof_expr.expr, lvl + 1);
+        if (!e->data.alignof_expr.is_type)
+            dump_expr(sb, e->data.alignof_expr.expr, lvl + 1);
         break;
     case EXPR_OFFSETOF:
         break;
     case EXPR_CAST:
-        dump_expr(sb, e->cast.expr, lvl + 1);
+        dump_expr(sb, e->data.cast.expr, lvl + 1);
         break;
     case EXPR_COMPLIT:
-        if (e->compound.init)
-            dump_expr(sb, e->compound.init, lvl + 1);
-        for (size_t i = 0; i < e->compound.init_count; i++)
-            dump_expr(sb, e->compound.init_list[i].value, lvl + 1);
+        if (e->data.compound.init)
+            dump_expr(sb, e->data.compound.init, lvl + 1);
+        for (size_t i = 0; i < e->data.compound.init_count; i++)
+            dump_expr(sb, e->data.compound.init_list[i].value, lvl + 1);
         break;
     default:
         break;

--- a/src/ast_expr.c
+++ b/src/ast_expr.c
@@ -64,9 +64,9 @@ expr_t *ast_make_number(const char *value, size_t line, size_t column)
         free(val);
         return NULL;
     }
-    expr->number.value = val;
-    expr->number.is_unsigned = is_unsigned;
-    expr->number.long_count = long_count;
+    expr->data.number.value = val;
+    expr->data.number.is_unsigned = is_unsigned;
+    expr->data.number.long_count = long_count;
     return expr;
 }
 
@@ -76,8 +76,8 @@ expr_t *ast_make_ident(const char *name, size_t line, size_t column)
     expr_t *expr = new_expr(EXPR_IDENT, line, column);
     if (!expr)
         return NULL;
-    expr->ident.name = vc_strdup(name ? name : "");
-    if (!expr->ident.name) {
+    expr->data.ident.name = vc_strdup(name ? name : "");
+    if (!expr->data.ident.name) {
         free(expr);
         return NULL;
     }
@@ -90,12 +90,12 @@ static expr_t *make_string(const char *value, size_t line, size_t column, int is
     expr_t *expr = new_expr(EXPR_STRING, line, column);
     if (!expr)
         return NULL;
-    expr->string.value = vc_strdup(value ? value : "");
-    if (!expr->string.value) {
+    expr->data.string.value = vc_strdup(value ? value : "");
+    if (!expr->data.string.value) {
         free(expr);
         return NULL;
     }
-    expr->string.is_wide = is_wide;
+    expr->data.string.is_wide = is_wide;
     return expr;
 }
 
@@ -115,8 +115,8 @@ static expr_t *make_char(char value, size_t line, size_t column, int is_wide)
     expr_t *expr = new_expr(EXPR_CHAR, line, column);
     if (!expr)
         return NULL;
-    expr->ch.value = value;
-    expr->ch.is_wide = is_wide;
+    expr->data.ch.value = value;
+    expr->data.ch.is_wide = is_wide;
     return expr;
 }
 
@@ -137,8 +137,8 @@ expr_t *ast_make_complex_literal(double real, double imag,
     expr_t *expr = new_expr(EXPR_COMPLEX_LITERAL, line, column);
     if (!expr)
         return NULL;
-    expr->complex_lit.real = real;
-    expr->complex_lit.imag = imag;
+    expr->data.complex_lit.real = real;
+    expr->data.complex_lit.imag = imag;
     return expr;
 }
 
@@ -149,9 +149,9 @@ expr_t *ast_make_binary(binop_t op, expr_t *left, expr_t *right,
     expr_t *expr = new_expr(EXPR_BINARY, line, column);
     if (!expr)
         return NULL;
-    expr->binary.op = op;
-    expr->binary.left = left;
-    expr->binary.right = right;
+    expr->data.binary.op = op;
+    expr->data.binary.left = left;
+    expr->data.binary.right = right;
     return expr;
 }
 
@@ -162,8 +162,8 @@ expr_t *ast_make_unary(unop_t op, expr_t *operand,
     expr_t *expr = new_expr(EXPR_UNARY, line, column);
     if (!expr)
         return NULL;
-    expr->unary.op = op;
-    expr->unary.operand = operand;
+    expr->data.unary.op = op;
+    expr->data.unary.operand = operand;
     return expr;
 }
 
@@ -174,9 +174,9 @@ expr_t *ast_make_cond(expr_t *cond, expr_t *then_expr, expr_t *else_expr,
     expr_t *expr = new_expr(EXPR_COND, line, column);
     if (!expr)
         return NULL;
-    expr->cond.cond = cond;
-    expr->cond.then_expr = then_expr;
-    expr->cond.else_expr = else_expr;
+    expr->data.cond.cond = cond;
+    expr->data.cond.then_expr = then_expr;
+    expr->data.cond.else_expr = else_expr;
     return expr;
 }
 
@@ -187,12 +187,12 @@ expr_t *ast_make_assign(const char *name, expr_t *value,
     expr_t *expr = new_expr(EXPR_ASSIGN, line, column);
     if (!expr)
         return NULL;
-    expr->assign.name = vc_strdup(name ? name : "");
-    if (!expr->assign.name) {
+    expr->data.assign.name = vc_strdup(name ? name : "");
+    if (!expr->data.assign.name) {
         free(expr);
         return NULL;
     }
-    expr->assign.value = value;
+    expr->data.assign.value = value;
     return expr;
 }
 
@@ -203,8 +203,8 @@ expr_t *ast_make_index(expr_t *array, expr_t *index,
     expr_t *expr = new_expr(EXPR_INDEX, line, column);
     if (!expr)
         return NULL;
-    expr->index.array = array;
-    expr->index.index = index;
+    expr->data.index.array = array;
+    expr->data.index.index = index;
     return expr;
 }
 
@@ -215,9 +215,9 @@ expr_t *ast_make_assign_index(expr_t *array, expr_t *index, expr_t *value,
     expr_t *expr = new_expr(EXPR_ASSIGN_INDEX, line, column);
     if (!expr)
         return NULL;
-    expr->assign_index.array = array;
-    expr->assign_index.index = index;
-    expr->assign_index.value = value;
+    expr->data.assign_index.array = array;
+    expr->data.assign_index.index = index;
+    expr->data.assign_index.value = value;
     return expr;
 }
 
@@ -228,14 +228,14 @@ expr_t *ast_make_assign_member(expr_t *object, const char *member, expr_t *value
     expr_t *expr = new_expr(EXPR_ASSIGN_MEMBER, line, column);
     if (!expr)
         return NULL;
-    expr->assign_member.object = object;
-    expr->assign_member.member = vc_strdup(member ? member : "");
-    if (!expr->assign_member.member) {
+    expr->data.assign_member.object = object;
+    expr->data.assign_member.member = vc_strdup(member ? member : "");
+    if (!expr->data.assign_member.member) {
         free(expr);
         return NULL;
     }
-    expr->assign_member.value = value;
-    expr->assign_member.via_ptr = via_ptr;
+    expr->data.assign_member.value = value;
+    expr->data.assign_member.via_ptr = via_ptr;
     return expr;
 }
 
@@ -246,13 +246,13 @@ expr_t *ast_make_member(expr_t *object, const char *member, int via_ptr,
     expr_t *expr = new_expr(EXPR_MEMBER, line, column);
     if (!expr)
         return NULL;
-    expr->member.object = object;
-    expr->member.member = vc_strdup(member ? member : "");
-    if (!expr->member.member) {
+    expr->data.member.object = object;
+    expr->data.member.member = vc_strdup(member ? member : "");
+    if (!expr->data.member.member) {
         free(expr);
         return NULL;
     }
-    expr->member.via_ptr = via_ptr;
+    expr->data.member.via_ptr = via_ptr;
     return expr;
 }
 
@@ -263,11 +263,11 @@ expr_t *ast_make_sizeof_type(type_kind_t type, size_t array_size,
     expr_t *expr = new_expr(EXPR_SIZEOF, line, column);
     if (!expr)
         return NULL;
-    expr->sizeof_expr.is_type = 1;
-    expr->sizeof_expr.type = type;
-    expr->sizeof_expr.array_size = array_size;
-    expr->sizeof_expr.elem_size = elem_size;
-    expr->sizeof_expr.expr = NULL;
+    expr->data.sizeof_expr.is_type = 1;
+    expr->data.sizeof_expr.type = type;
+    expr->data.sizeof_expr.array_size = array_size;
+    expr->data.sizeof_expr.elem_size = elem_size;
+    expr->data.sizeof_expr.expr = NULL;
     return expr;
 }
 
@@ -277,11 +277,11 @@ expr_t *ast_make_sizeof_expr(expr_t *e, size_t line, size_t column)
     expr_t *expr = new_expr(EXPR_SIZEOF, line, column);
     if (!expr)
         return NULL;
-    expr->sizeof_expr.is_type = 0;
-    expr->sizeof_expr.type = TYPE_UNKNOWN;
-    expr->sizeof_expr.array_size = 0;
-    expr->sizeof_expr.elem_size = 0;
-    expr->sizeof_expr.expr = e;
+    expr->data.sizeof_expr.is_type = 0;
+    expr->data.sizeof_expr.type = TYPE_UNKNOWN;
+    expr->data.sizeof_expr.array_size = 0;
+    expr->data.sizeof_expr.elem_size = 0;
+    expr->data.sizeof_expr.expr = e;
     return expr;
 }
 
@@ -293,14 +293,14 @@ expr_t *ast_make_offsetof(type_kind_t type, const char *tag,
     expr_t *expr = new_expr(EXPR_OFFSETOF, line, column);
     if (!expr)
         return NULL;
-    expr->offsetof_expr.type = type;
-    expr->offsetof_expr.tag = vc_strdup(tag ? tag : "");
-    if (!expr->offsetof_expr.tag) {
+    expr->data.offsetof_expr.type = type;
+    expr->data.offsetof_expr.tag = vc_strdup(tag ? tag : "");
+    if (!expr->data.offsetof_expr.tag) {
         free(expr);
         return NULL;
     }
-    expr->offsetof_expr.members = members;
-    expr->offsetof_expr.member_count = member_count;
+    expr->data.offsetof_expr.members = members;
+    expr->data.offsetof_expr.member_count = member_count;
     return expr;
 }
 
@@ -311,11 +311,11 @@ expr_t *ast_make_alignof_type(type_kind_t type, size_t array_size,
     expr_t *expr = new_expr(EXPR_ALIGNOF, line, column);
     if (!expr)
         return NULL;
-    expr->alignof_expr.is_type = 1;
-    expr->alignof_expr.type = type;
-    expr->alignof_expr.array_size = array_size;
-    expr->alignof_expr.elem_size = elem_size;
-    expr->alignof_expr.expr = NULL;
+    expr->data.alignof_expr.is_type = 1;
+    expr->data.alignof_expr.type = type;
+    expr->data.alignof_expr.array_size = array_size;
+    expr->data.alignof_expr.elem_size = elem_size;
+    expr->data.alignof_expr.expr = NULL;
     return expr;
 }
 
@@ -325,11 +325,11 @@ expr_t *ast_make_alignof_expr(expr_t *e, size_t line, size_t column)
     expr_t *expr = new_expr(EXPR_ALIGNOF, line, column);
     if (!expr)
         return NULL;
-    expr->alignof_expr.is_type = 0;
-    expr->alignof_expr.type = TYPE_UNKNOWN;
-    expr->alignof_expr.array_size = 0;
-    expr->alignof_expr.elem_size = 0;
-    expr->alignof_expr.expr = e;
+    expr->data.alignof_expr.is_type = 0;
+    expr->data.alignof_expr.type = TYPE_UNKNOWN;
+    expr->data.alignof_expr.array_size = 0;
+    expr->data.alignof_expr.elem_size = 0;
+    expr->data.alignof_expr.expr = e;
     return expr;
 }
 
@@ -340,10 +340,10 @@ expr_t *ast_make_cast(type_kind_t type, size_t array_size, size_t elem_size,
     expr_t *expr = new_expr(EXPR_CAST, line, column);
     if (!expr)
         return NULL;
-    expr->cast.type = type;
-    expr->cast.array_size = array_size;
-    expr->cast.elem_size = elem_size;
-    expr->cast.expr = e;
+    expr->data.cast.type = type;
+    expr->data.cast.array_size = array_size;
+    expr->data.cast.elem_size = elem_size;
+    expr->data.cast.expr = e;
     return expr;
 }
 
@@ -354,13 +354,13 @@ expr_t *ast_make_call(const char *name, expr_t **args, size_t arg_count,
     expr_t *expr = new_expr(EXPR_CALL, line, column);
     if (!expr)
         return NULL;
-    expr->call.name = vc_strdup(name ? name : "");
-    if (!expr->call.name) {
+    expr->data.call.name = vc_strdup(name ? name : "");
+    if (!expr->data.call.name) {
         free(expr);
         return NULL;
     }
-    expr->call.args = args;
-    expr->call.arg_count = arg_count;
+    expr->data.call.args = args;
+    expr->data.call.arg_count = arg_count;
     return expr;
 }
 
@@ -373,12 +373,12 @@ expr_t *ast_make_compound(type_kind_t type, size_t array_size,
     expr_t *expr = new_expr(EXPR_COMPLIT, line, column);
     if (!expr)
         return NULL;
-    expr->compound.type = type;
-    expr->compound.array_size = array_size;
-    expr->compound.elem_size = elem_size;
-    expr->compound.init = init;
-    expr->compound.init_list = init_list;
-    expr->compound.init_count = init_count;
+    expr->data.compound.type = type;
+    expr->data.compound.array_size = array_size;
+    expr->data.compound.elem_size = elem_size;
+    expr->data.compound.init = init;
+    expr->data.compound.init_list = init_list;
+    expr->data.compound.init_count = init_count;
     return expr;
 }
 
@@ -390,83 +390,83 @@ void ast_free_expr(expr_t *expr)
         return;
     switch (expr->kind) {
     case EXPR_NUMBER:
-        free(expr->number.value);
+        free(expr->data.number.value);
         break;
     case EXPR_IDENT:
-        free(expr->ident.name);
+        free(expr->data.ident.name);
         break;
     case EXPR_STRING:
-        free(expr->string.value);
+        free(expr->data.string.value);
         break;
     case EXPR_CHAR:
         break;
     case EXPR_COMPLEX_LITERAL:
         break;
     case EXPR_UNARY:
-        ast_free_expr(expr->unary.operand);
+        ast_free_expr(expr->data.unary.operand);
         break;
     case EXPR_BINARY:
-        ast_free_expr(expr->binary.left);
-        ast_free_expr(expr->binary.right);
+        ast_free_expr(expr->data.binary.left);
+        ast_free_expr(expr->data.binary.right);
         break;
     case EXPR_COND:
-        ast_free_expr(expr->cond.cond);
-        ast_free_expr(expr->cond.then_expr);
-        ast_free_expr(expr->cond.else_expr);
+        ast_free_expr(expr->data.cond.cond);
+        ast_free_expr(expr->data.cond.then_expr);
+        ast_free_expr(expr->data.cond.else_expr);
         break;
     case EXPR_ASSIGN:
-        free(expr->assign.name);
-        ast_free_expr(expr->assign.value);
+        free(expr->data.assign.name);
+        ast_free_expr(expr->data.assign.value);
         break;
     case EXPR_INDEX:
-        ast_free_expr(expr->index.array);
-        ast_free_expr(expr->index.index);
+        ast_free_expr(expr->data.index.array);
+        ast_free_expr(expr->data.index.index);
         break;
     case EXPR_ASSIGN_INDEX:
-        ast_free_expr(expr->assign_index.array);
-        ast_free_expr(expr->assign_index.index);
-        ast_free_expr(expr->assign_index.value);
+        ast_free_expr(expr->data.assign_index.array);
+        ast_free_expr(expr->data.assign_index.index);
+        ast_free_expr(expr->data.assign_index.value);
         break;
     case EXPR_ASSIGN_MEMBER:
-        ast_free_expr(expr->assign_member.object);
-        free(expr->assign_member.member);
-        ast_free_expr(expr->assign_member.value);
+        ast_free_expr(expr->data.assign_member.object);
+        free(expr->data.assign_member.member);
+        ast_free_expr(expr->data.assign_member.value);
         break;
     case EXPR_MEMBER:
-        ast_free_expr(expr->member.object);
-        free(expr->member.member);
+        ast_free_expr(expr->data.member.object);
+        free(expr->data.member.member);
         break;
     case EXPR_SIZEOF:
-        if (!expr->sizeof_expr.is_type)
-            ast_free_expr(expr->sizeof_expr.expr);
+        if (!expr->data.sizeof_expr.is_type)
+            ast_free_expr(expr->data.sizeof_expr.expr);
         break;
     case EXPR_OFFSETOF:
-        for (size_t i = 0; i < expr->offsetof_expr.member_count; i++)
-            free(expr->offsetof_expr.members[i]);
-        free(expr->offsetof_expr.members);
-        free(expr->offsetof_expr.tag);
+        for (size_t i = 0; i < expr->data.offsetof_expr.member_count; i++)
+            free(expr->data.offsetof_expr.members[i]);
+        free(expr->data.offsetof_expr.members);
+        free(expr->data.offsetof_expr.tag);
         break;
     case EXPR_ALIGNOF:
-        if (!expr->alignof_expr.is_type)
-            ast_free_expr(expr->alignof_expr.expr);
+        if (!expr->data.alignof_expr.is_type)
+            ast_free_expr(expr->data.alignof_expr.expr);
         break;
     case EXPR_CALL:
-        for (size_t i = 0; i < expr->call.arg_count; i++)
-            ast_free_expr(expr->call.args[i]);
-        free(expr->call.args);
-        free(expr->call.name);
+        for (size_t i = 0; i < expr->data.call.arg_count; i++)
+            ast_free_expr(expr->data.call.args[i]);
+        free(expr->data.call.args);
+        free(expr->data.call.name);
         break;
     case EXPR_CAST:
-        ast_free_expr(expr->cast.expr);
+        ast_free_expr(expr->data.cast.expr);
         break;
     case EXPR_COMPLIT:
-        ast_free_expr(expr->compound.init);
-        for (size_t i = 0; i < expr->compound.init_count; i++) {
-            ast_free_expr(expr->compound.init_list[i].index);
-            ast_free_expr(expr->compound.init_list[i].value);
-            free(expr->compound.init_list[i].field);
+        ast_free_expr(expr->data.compound.init);
+        for (size_t i = 0; i < expr->data.compound.init_count; i++) {
+            ast_free_expr(expr->data.compound.init_list[i].index);
+            ast_free_expr(expr->data.compound.init_list[i].value);
+            free(expr->data.compound.init_list[i].field);
         }
-        free(expr->compound.init_list);
+        free(expr->data.compound.init_list);
         break;
     }
     free(expr);

--- a/src/parser_decl_var.c
+++ b/src/parser_decl_var.c
@@ -130,7 +130,7 @@ static int parse_array_suffix(parser_t *p, type_kind_t *type, char **name,
                 return 0;
             }
             if ((*size_expr)->kind == EXPR_NUMBER) {
-                if (!vc_strtoul_size((*size_expr)->number.value, arr_size)) {
+                if (!vc_strtoul_size((*size_expr)->data.number.value, arr_size)) {
                     error_set((*size_expr)->line, (*size_expr)->column,
                               error_current_file, error_current_function);
                     error_print("Integer constant out of range");

--- a/src/parser_expr.c
+++ b/src/parser_expr.c
@@ -125,19 +125,19 @@ static expr_t *create_assignment_node(expr_t *left, expr_t *right,
 {
     expr_t *res = NULL;
     if (left->kind == EXPR_IDENT) {
-        char *name = left->ident.name;
+        char *name = left->data.ident.name;
         free(left);
         res = ast_make_assign(name, right, line, column);
         free(name);
     } else if (left->kind == EXPR_INDEX) {
-        expr_t *arr = left->index.array;
-        expr_t *idx = left->index.index;
+        expr_t *arr = left->data.index.array;
+        expr_t *idx = left->data.index.index;
         free(left);
         res = ast_make_assign_index(arr, idx, right, line, column);
     } else {
-        expr_t *obj = left->member.object;
-        char *mem = left->member.member;
-        int via_ptr = left->member.via_ptr;
+        expr_t *obj = left->data.member.object;
+        char *mem = left->data.member.member;
+        int via_ptr = left->data.member.via_ptr;
         free(left);
         res = ast_make_assign_member(obj, mem, right, via_ptr,
                                      line, column);

--- a/src/parser_toplevel_var.c
+++ b/src/parser_toplevel_var.c
@@ -31,7 +31,7 @@ static int parse_array_size(parser_t *p, type_kind_t *type, size_t *arr_size,
                 return 0;
             }
             if ((*size_expr)->kind == EXPR_NUMBER) {
-                if (!vc_strtoul_size((*size_expr)->number.value, arr_size)) {
+                if (!vc_strtoul_size((*size_expr)->data.number.value, arr_size)) {
                     error_set((*size_expr)->line, (*size_expr)->column,
                               error_current_file, error_current_function);
                     error_print("Integer constant out of range");

--- a/src/semantic_expr_cast.c
+++ b/src/semantic_expr_cast.c
@@ -24,8 +24,8 @@ type_kind_t check_cast_expr(expr_t *expr, symtable_t *vars,
                             ir_value_t *out)
 {
     ir_value_t val;
-    type_kind_t src = check_expr(expr->cast.expr, vars, funcs, ir, &val);
-    type_kind_t dst = expr->cast.type;
+    type_kind_t src = check_expr(expr->data.cast.expr, vars, funcs, ir, &val);
+    type_kind_t dst = expr->data.cast.type;
 
     if (src == TYPE_UNKNOWN)
         return TYPE_UNKNOWN;

--- a/src/semantic_expr_const.c
+++ b/src/semantic_expr_const.c
@@ -26,7 +26,7 @@ type_kind_t check_number_expr(expr_t *expr, symtable_t *vars,
 {
     (void)vars; (void)funcs;
     errno = 0;
-    long long val = strtoll(expr->number.value, NULL, 0);
+    long long val = strtoll(expr->data.number.value, NULL, 0);
     if (errno != 0) {
         error_set(expr->line, expr->column, error_current_file,
                   error_current_function);
@@ -36,11 +36,11 @@ type_kind_t check_number_expr(expr_t *expr, symtable_t *vars,
     }
     if (out)
         *out = ir_build_const(ir, val);
-    if (expr->number.long_count == 2)
-        return expr->number.is_unsigned ? TYPE_ULLONG : TYPE_LLONG;
-    if (expr->number.long_count == 1)
-        return expr->number.is_unsigned ? TYPE_ULONG : TYPE_LONG;
-    if (expr->number.is_unsigned)
+    if (expr->data.number.long_count == 2)
+        return expr->data.number.is_unsigned ? TYPE_ULLONG : TYPE_LLONG;
+    if (expr->data.number.long_count == 1)
+        return expr->data.number.is_unsigned ? TYPE_ULONG : TYPE_LONG;
+    if (expr->data.number.is_unsigned)
         return TYPE_UINT;
     if (val > INT_MAX || val < INT_MIN)
         return TYPE_LLONG;
@@ -56,9 +56,9 @@ type_kind_t check_string_expr(expr_t *expr, symtable_t *vars,
                               ir_value_t *out)
 {
     (void)vars; (void)funcs;
-    const char *text = expr->string.value;
+    const char *text = expr->data.string.value;
     if (out) {
-        if (expr->string.is_wide)
+        if (expr->data.string.is_wide)
             *out = ir_build_wstring(ir, text);
         else
             *out = ir_build_string(ir, text);
@@ -75,8 +75,8 @@ type_kind_t check_char_expr(expr_t *expr, symtable_t *vars,
 {
     (void)vars; (void)funcs;
     if (out)
-        *out = ir_build_const(ir, (int)expr->ch.value);
-    return expr->ch.is_wide ? TYPE_INT : TYPE_CHAR;
+        *out = ir_build_const(ir, (int)expr->data.ch.value);
+    return expr->data.ch.is_wide ? TYPE_INT : TYPE_CHAR;
 }
 
 /*
@@ -88,8 +88,8 @@ type_kind_t check_complex_literal(expr_t *expr, symtable_t *vars,
 {
     (void)vars; (void)funcs;
     if (out)
-        *out = ir_build_cplx_const(ir, expr->complex_lit.real,
-                                   expr->complex_lit.imag);
+        *out = ir_build_cplx_const(ir, expr->data.complex_lit.real,
+                                   expr->data.complex_lit.imag);
     return TYPE_DOUBLE_COMPLEX;
 }
 

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -322,10 +322,10 @@ static int emit_global_initializer(stmt_t *decl, symbol_t *sym,
 
     if (decl->var_decl.init &&
         decl->var_decl.init->kind == EXPR_UNARY &&
-        decl->var_decl.init->unary.op == UNOP_ADDR &&
-        decl->var_decl.init->unary.operand->kind == EXPR_IDENT) {
+        decl->var_decl.init->data.unary.op == UNOP_ADDR &&
+        decl->var_decl.init->data.unary.operand->kind == EXPR_IDENT) {
         ir_build_glob_addr(ir, decl->var_decl.name,
-                           decl->var_decl.init->unary.operand->ident.name,
+                           decl->var_decl.init->data.unary.operand->data.ident.name,
                            decl->var_decl.is_static);
         return 1;
     }

--- a/src/semantic_mem.c
+++ b/src/semantic_mem.c
@@ -72,25 +72,25 @@ type_kind_t check_index_expr(expr_t *expr, symtable_t *vars,
                              ir_value_t *out)
 {
     (void)funcs;
-    if (expr->index.array->kind != EXPR_IDENT) {
+    if (expr->data.index.array->kind != EXPR_IDENT) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
-    symbol_t *sym = symtable_lookup(vars, expr->index.array->ident.name);
+    symbol_t *sym = symtable_lookup(vars, expr->data.index.array->data.ident.name);
     if (!sym || sym->type != TYPE_ARRAY) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
     ir_value_t idx_val;
-    if (check_expr(expr->index.index, vars, funcs, ir, &idx_val) != TYPE_INT) {
-        error_set(expr->index.index->line, expr->index.index->column, error_current_file, error_current_function);
+    if (check_expr(expr->data.index.index, vars, funcs, ir, &idx_val) != TYPE_INT) {
+        error_set(expr->data.index.index->line, expr->data.index.index->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
     long long cval;
     if (sym->array_size &&
-        eval_const_expr(expr->index.index, vars, 0, &cval)) {
+        eval_const_expr(expr->data.index.index, vars, 0, &cval)) {
         if (cval < 0 || (size_t)cval >= sym->array_size) {
-            error_set(expr->index.index->line, expr->index.index->column, error_current_file, error_current_function);
+            error_set(expr->data.index.index->line, expr->data.index.index->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
     }
@@ -117,11 +117,11 @@ type_kind_t check_assign_index_expr(expr_t *expr, symtable_t *vars,
                                     ir_value_t *out)
 {
     (void)funcs;
-    if (expr->assign_index.array->kind != EXPR_IDENT) {
+    if (expr->data.assign_index.array->kind != EXPR_IDENT) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
-    symbol_t *sym = symtable_lookup(vars, expr->assign_index.array->ident.name);
+    symbol_t *sym = symtable_lookup(vars, expr->data.assign_index.array->data.ident.name);
     if (!sym || sym->type != TYPE_ARRAY) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
@@ -132,19 +132,19 @@ type_kind_t check_assign_index_expr(expr_t *expr, symtable_t *vars,
     }
 
     ir_value_t idx_val, val;
-    if (check_expr(expr->assign_index.index, vars, funcs, ir, &idx_val) != TYPE_INT) {
-        error_set(expr->assign_index.index->line, expr->assign_index.index->column, error_current_file, error_current_function);
+    if (check_expr(expr->data.assign_index.index, vars, funcs, ir, &idx_val) != TYPE_INT) {
+        error_set(expr->data.assign_index.index->line, expr->data.assign_index.index->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
-    if (check_expr(expr->assign_index.value, vars, funcs, ir, &val) != TYPE_INT) {
-        error_set(expr->assign_index.value->line, expr->assign_index.value->column, error_current_file, error_current_function);
+    if (check_expr(expr->data.assign_index.value, vars, funcs, ir, &val) != TYPE_INT) {
+        error_set(expr->data.assign_index.value->line, expr->data.assign_index.value->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
     long long cval;
     if (sym->array_size &&
-        eval_const_expr(expr->assign_index.index, vars, 0, &cval)) {
+        eval_const_expr(expr->data.assign_index.index, vars, 0, &cval)) {
         if (cval < 0 || (size_t)cval >= sym->array_size) {
-            error_set(expr->assign_index.index->line, expr->assign_index.index->column, error_current_file, error_current_function);
+            error_set(expr->data.assign_index.index->line, expr->data.assign_index.index->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
     }
@@ -172,23 +172,23 @@ type_kind_t check_assign_member_expr(expr_t *expr, symtable_t *vars,
 {
     symbol_t *obj_sym = NULL;
     ir_value_t base_addr;
-    if (expr->assign_member.via_ptr) {
-        if (check_expr(expr->assign_member.object, vars, funcs, ir,
+    if (expr->data.assign_member.via_ptr) {
+        if (check_expr(expr->data.assign_member.object, vars, funcs, ir,
                        &base_addr) != TYPE_PTR) {
-            error_set(expr->assign_member.object->line, expr->assign_member.object->column, error_current_file, error_current_function);
+            error_set(expr->data.assign_member.object->line, expr->data.assign_member.object->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
-        if (expr->assign_member.object->kind == EXPR_IDENT)
+        if (expr->data.assign_member.object->kind == EXPR_IDENT)
             obj_sym = symtable_lookup(vars,
-                                      expr->assign_member.object->ident.name);
+                                      expr->data.assign_member.object->data.ident.name);
     } else {
-        if (expr->assign_member.object->kind != EXPR_IDENT) {
-            error_set(expr->assign_member.object->line, expr->assign_member.object->column, error_current_file, error_current_function);
+        if (expr->data.assign_member.object->kind != EXPR_IDENT) {
+            error_set(expr->data.assign_member.object->line, expr->data.assign_member.object->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
-        obj_sym = symtable_lookup(vars, expr->assign_member.object->ident.name);
+        obj_sym = symtable_lookup(vars, expr->data.assign_member.object->data.ident.name);
         if (!obj_sym || (obj_sym->type != TYPE_UNION && obj_sym->type != TYPE_STRUCT)) {
-            error_set(expr->assign_member.object->line, expr->assign_member.object->column, error_current_file, error_current_function);
+            error_set(expr->data.assign_member.object->line, expr->data.assign_member.object->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
         base_addr = ir_build_addr(ir, obj_sym->ir_name);
@@ -204,34 +204,34 @@ type_kind_t check_assign_member_expr(expr_t *expr, symtable_t *vars,
     type_kind_t mtype = TYPE_UNKNOWN;
     size_t moff = 0;
     unsigned mbw = 0, mbo = 0;
-    if (!find_member(obj_sym, expr->assign_member.member, &mtype, &moff,
+    if (!find_member(obj_sym, expr->data.assign_member.member, &mtype, &moff,
                      &mbw, &mbo)) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
 
     ir_value_t val;
-    type_kind_t vt = check_expr(expr->assign_member.value, vars, funcs, ir, &val);
+    type_kind_t vt = check_expr(expr->data.assign_member.value, vars, funcs, ir, &val);
     if (mbw > 0) {
         if (!is_intlike(vt)) {
-            error_set(expr->assign_member.value->line, expr->assign_member.value->column,
+            error_set(expr->data.assign_member.value->line, expr->data.assign_member.value->column,
                       error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
     } else if (!(((is_intlike(mtype) && is_intlike(vt)) ||
                   (is_floatlike(mtype) && (is_floatlike(vt) || is_intlike(vt)))) ||
                  vt == mtype)) {
-        error_set(expr->assign_member.value->line, expr->assign_member.value->column, error_current_file, error_current_function);
+        error_set(expr->data.assign_member.value->line, expr->data.assign_member.value->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
 
     ir_value_t idx = ir_build_const(ir, (int)moff);
     ir_value_t addr = ir_build_ptr_add(ir, base_addr, idx, 1);
     int restr = 0;
-    if (expr->assign_member.via_ptr &&
-        expr->assign_member.object->kind == EXPR_IDENT) {
+    if (expr->data.assign_member.via_ptr &&
+        expr->data.assign_member.object->kind == EXPR_IDENT) {
         symbol_t *rsym = symtable_lookup(vars,
-                                         expr->assign_member.object->ident.name);
+                                         expr->data.assign_member.object->data.ident.name);
         restr = rsym ? rsym->is_restrict : 0;
     }
     if (mbw > 0) {
@@ -251,9 +251,9 @@ type_kind_t check_assign_member_expr(expr_t *expr, symtable_t *vars,
             ir_build_store_ptr(ir, addr, word);
         if (out)
             *out = val;
-        if (!expr->assign_member.via_ptr && obj_sym && obj_sym->type == TYPE_UNION) {
+        if (!expr->data.assign_member.via_ptr && obj_sym && obj_sym->type == TYPE_UNION) {
             free(obj_sym->active_member);
-            obj_sym->active_member = vc_strdup(expr->assign_member.member);
+            obj_sym->active_member = vc_strdup(expr->data.assign_member.member);
         }
         return TYPE_INT;
     } else {
@@ -263,9 +263,9 @@ type_kind_t check_assign_member_expr(expr_t *expr, symtable_t *vars,
             ir_build_store_ptr(ir, addr, val);
         if (out)
             *out = val;
-        if (!expr->assign_member.via_ptr && obj_sym && obj_sym->type == TYPE_UNION) {
+        if (!expr->data.assign_member.via_ptr && obj_sym && obj_sym->type == TYPE_UNION) {
             free(obj_sym->active_member);
-            obj_sym->active_member = vc_strdup(expr->assign_member.member);
+            obj_sym->active_member = vc_strdup(expr->data.assign_member.member);
         }
         return mtype;
     }
@@ -279,27 +279,27 @@ type_kind_t check_member_expr(expr_t *expr, symtable_t *vars,
                                symtable_t *funcs, ir_builder_t *ir,
                                ir_value_t *out)
 {
-    if (!expr->member.object)
+    if (!expr->data.member.object)
         return TYPE_UNKNOWN;
     symbol_t *obj_sym = NULL;
     ir_value_t base_addr;
-    if (expr->member.via_ptr) {
-        if (check_expr(expr->member.object, vars, funcs, ir,
+    if (expr->data.member.via_ptr) {
+        if (check_expr(expr->data.member.object, vars, funcs, ir,
                        &base_addr) != TYPE_PTR) {
-            error_set(expr->member.object->line, expr->member.object->column, error_current_file, error_current_function);
+            error_set(expr->data.member.object->line, expr->data.member.object->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
-        if (expr->member.object->kind == EXPR_IDENT)
+        if (expr->data.member.object->kind == EXPR_IDENT)
             obj_sym = symtable_lookup(vars,
-                                      expr->member.object->ident.name);
+                                      expr->data.member.object->data.ident.name);
     } else {
-        if (expr->member.object->kind != EXPR_IDENT) {
-            error_set(expr->member.object->line, expr->member.object->column, error_current_file, error_current_function);
+        if (expr->data.member.object->kind != EXPR_IDENT) {
+            error_set(expr->data.member.object->line, expr->data.member.object->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
-        obj_sym = symtable_lookup(vars, expr->member.object->ident.name);
+        obj_sym = symtable_lookup(vars, expr->data.member.object->data.ident.name);
         if (!obj_sym || (obj_sym->type != TYPE_UNION && obj_sym->type != TYPE_STRUCT)) {
-            error_set(expr->member.object->line, expr->member.object->column, error_current_file, error_current_function);
+            error_set(expr->data.member.object->line, expr->data.member.object->column, error_current_file, error_current_function);
             return TYPE_UNKNOWN;
         }
         base_addr = ir_build_addr(ir, obj_sym->ir_name);
@@ -315,14 +315,14 @@ type_kind_t check_member_expr(expr_t *expr, symtable_t *vars,
     type_kind_t mtype = TYPE_UNKNOWN;
     size_t moff = 0;
     unsigned mbw = 0, mbo = 0;
-    if (!find_member(obj_sym, expr->member.member, &mtype, &moff,
+    if (!find_member(obj_sym, expr->data.member.member, &mtype, &moff,
                      &mbw, &mbo)) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
 
-    if (!expr->member.via_ptr && obj_sym && obj_sym->type == TYPE_UNION &&
-        obj_sym->active_member && strcmp(obj_sym->active_member, expr->member.member) != 0) {
+    if (!expr->data.member.via_ptr && obj_sym && obj_sym->type == TYPE_UNION &&
+        obj_sym->active_member && strcmp(obj_sym->active_member, expr->data.member.member) != 0) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
         return TYPE_UNKNOWN;
     }
@@ -331,9 +331,9 @@ type_kind_t check_member_expr(expr_t *expr, symtable_t *vars,
         ir_value_t idx = ir_build_const(ir, (int)moff);
         ir_value_t addr = ir_build_ptr_add(ir, base_addr, idx, 1);
         int restr = 0;
-        if (expr->member.via_ptr && expr->member.object->kind == EXPR_IDENT) {
+        if (expr->data.member.via_ptr && expr->data.member.object->kind == EXPR_IDENT) {
             symbol_t *rsym = symtable_lookup(vars,
-                                            expr->member.object->ident.name);
+                                            expr->data.member.object->data.ident.name);
             restr = rsym ? rsym->is_restrict : 0;
         }
         ir_value_t word = restr ? ir_build_load_ptr_res(ir, addr)
@@ -361,16 +361,16 @@ type_kind_t check_complit_expr(expr_t *expr, symtable_t *vars,
                                symtable_t *funcs, ir_builder_t *ir,
                                ir_value_t *out)
 {
-    size_t count = expr->compound.init_count;
-    size_t arr_sz = expr->compound.array_size;
-    if (expr->compound.type == TYPE_ARRAY && arr_sz == 0)
+    size_t count = expr->data.compound.init_count;
+    size_t arr_sz = expr->data.compound.array_size;
+    if (expr->data.compound.type == TYPE_ARRAY && arr_sz == 0)
         arr_sz = count;
-    size_t total = (arr_sz ? arr_sz : 1) * expr->compound.elem_size;
+    size_t total = (arr_sz ? arr_sz : 1) * expr->data.compound.elem_size;
     ir_value_t sizev = ir_build_const(ir, (int)total);
     ir_value_t addr = ir_build_alloca(ir, sizev);
-    if (expr->compound.init_list) {
+    if (expr->data.compound.init_list) {
         for (size_t i = 0; i < count; i++) {
-            init_entry_t *e = &expr->compound.init_list[i];
+            init_entry_t *e = &expr->data.compound.init_list[i];
             if (e->kind != INIT_SIMPLE)
                 return TYPE_UNKNOWN;
             ir_value_t val;
@@ -378,24 +378,24 @@ type_kind_t check_complit_expr(expr_t *expr, symtable_t *vars,
                 return TYPE_UNKNOWN;
             ir_value_t idxv = ir_build_const(ir, (int)i);
             ir_value_t ptr = ir_build_ptr_add(ir, addr, idxv,
-                                             (int)expr->compound.elem_size);
+                                             (int)expr->data.compound.elem_size);
             ir_build_store_ptr(ir, ptr, val);
         }
-    } else if (expr->compound.init) {
+    } else if (expr->data.compound.init) {
         ir_value_t val;
-        if (check_expr(expr->compound.init, vars, funcs, ir, &val) == TYPE_UNKNOWN)
+        if (check_expr(expr->data.compound.init, vars, funcs, ir, &val) == TYPE_UNKNOWN)
             return TYPE_UNKNOWN;
         ir_build_store_ptr(ir, addr, val);
     }
     if (out) {
-        if (expr->compound.type == TYPE_ARRAY || expr->compound.type == TYPE_STRUCT || expr->compound.type == TYPE_UNION)
+        if (expr->data.compound.type == TYPE_ARRAY || expr->data.compound.type == TYPE_STRUCT || expr->data.compound.type == TYPE_UNION)
             *out = addr;
         else
             *out = ir_build_load_ptr(ir, addr);
     }
-    if (expr->compound.type == TYPE_ARRAY || expr->compound.type == TYPE_STRUCT || expr->compound.type == TYPE_UNION)
+    if (expr->data.compound.type == TYPE_ARRAY || expr->data.compound.type == TYPE_STRUCT || expr->data.compound.type == TYPE_UNION)
         return TYPE_PTR;
     else
-        return expr->compound.type;
+        return expr->data.compound.type;
 }
 

--- a/src/semantic_return.c
+++ b/src/semantic_return.c
@@ -22,18 +22,18 @@ static int validate_struct_return(stmt_t *stmt, symtable_t *vars,
     size_t actual = 0;
 
     if (stmt->ret.expr->kind == EXPR_IDENT) {
-        symbol_t *vsym = symtable_lookup(vars, stmt->ret.expr->ident.name);
+        symbol_t *vsym = symtable_lookup(vars, stmt->ret.expr->data.ident.name);
         if (vsym)
             actual = (expr_type == TYPE_STRUCT)
                 ? vsym->struct_total_size : vsym->total_size;
     } else if (stmt->ret.expr->kind == EXPR_CALL) {
-        symbol_t *fsym = symtable_lookup(funcs, stmt->ret.expr->call.name);
+        symbol_t *fsym = symtable_lookup(funcs, stmt->ret.expr->data.call.name);
         if (!fsym)
-            fsym = symtable_lookup(vars, stmt->ret.expr->call.name);
+            fsym = symtable_lookup(vars, stmt->ret.expr->data.call.name);
         if (fsym)
             actual = fsym->ret_struct_size;
     } else if (stmt->ret.expr->kind == EXPR_COMPLIT) {
-        actual = stmt->ret.expr->compound.elem_size;
+        actual = stmt->ret.expr->data.compound.elem_size;
     }
 
     if (expected && actual && expected != actual) {

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -170,7 +170,7 @@ void warn_unreachable_function(func_t *func, symtable_t *funcs)
             reachable = 1;
         else if (s->kind == STMT_EXPR && s->expr.expr &&
                  s->expr.expr->kind == EXPR_CALL) {
-            symbol_t *fs = symtable_lookup(funcs, s->expr.expr->call.name);
+            symbol_t *fs = symtable_lookup(funcs, s->expr.expr->data.call.name);
             if (fs && fs->is_noreturn) {
                 if (i + 1 < func->body_count &&
                     !(func->body[i+1]->kind == STMT_LABEL && end_label &&

--- a/tests/unit/test_cast_expr.c
+++ b/tests/unit/test_cast_expr.c
@@ -26,8 +26,8 @@ static void test_parser_cast_expr(void)
     expr_t *e = parser_parse_expr(&p);
     ASSERT(e);
     ASSERT(e->kind == EXPR_CAST);
-    ASSERT(e->cast.type == TYPE_INT);
-    ASSERT(e->cast.expr && e->cast.expr->kind == EXPR_NUMBER);
+    ASSERT(e->data.cast.type == TYPE_INT);
+    ASSERT(e->data.cast.expr && e->data.cast.expr->kind == EXPR_NUMBER);
     ast_free_expr(e);
     lexer_free_tokens(toks, count);
 }

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -133,8 +133,8 @@ static void test_parser_imag_literal(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_COMPLEX_LITERAL);
-    ASSERT(expr->complex_lit.real == 0.0);
-    ASSERT(expr->complex_lit.imag == 2.0);
+    ASSERT(expr->data.complex_lit.real == 0.0);
+    ASSERT(expr->data.complex_lit.imag == 2.0);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -148,8 +148,8 @@ static void test_parser_complex_literal(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_COMPLEX_LITERAL);
-    ASSERT(expr->complex_lit.real == 1.0);
-    ASSERT(expr->complex_lit.imag == 2.0);
+    ASSERT(expr->data.complex_lit.real == 1.0);
+    ASSERT(expr->data.complex_lit.imag == 2.0);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -164,14 +164,14 @@ static void test_parser_expr(void)
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr);
     ASSERT(expr->kind == EXPR_BINARY);
-    ASSERT(expr->binary.op == BINOP_ADD);
-    expr_t *left = expr->binary.left;
-    expr_t *right = expr->binary.right;
-    ASSERT(left && left->kind == EXPR_NUMBER && strcmp(left->number.value, "1") == 0);
+    ASSERT(expr->data.binary.op == BINOP_ADD);
+    expr_t *left = expr->data.binary.left;
+    expr_t *right = expr->data.binary.right;
+    ASSERT(left && left->kind == EXPR_NUMBER && strcmp(left->data.number.value, "1") == 0);
     ASSERT(right && right->kind == EXPR_BINARY);
-    ASSERT(right->binary.op == BINOP_MUL);
-    ASSERT(right->binary.left->kind == EXPR_NUMBER && strcmp(right->binary.left->number.value, "2") == 0);
-    ASSERT(right->binary.right->kind == EXPR_NUMBER && strcmp(right->binary.right->number.value, "3") == 0);
+    ASSERT(right->data.binary.op == BINOP_MUL);
+    ASSERT(right->data.binary.left->kind == EXPR_NUMBER && strcmp(right->data.binary.left->data.number.value, "2") == 0);
+    ASSERT(right->data.binary.right->kind == EXPR_NUMBER && strcmp(right->data.binary.right->data.number.value, "3") == 0);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -186,7 +186,7 @@ static void test_parser_stmt_return(void)
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_RETURN);
-    ASSERT(stmt->ret.expr->kind == EXPR_NUMBER && strcmp(stmt->ret.expr->number.value, "5") == 0);
+    ASSERT(stmt->ret.expr->kind == EXPR_NUMBER && strcmp(stmt->ret.expr->data.number.value, "5") == 0);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -219,7 +219,7 @@ static void test_parser_var_decl_init(void)
     ASSERT(strcmp(stmt->var_decl.name, "x") == 0);
     ASSERT(stmt->var_decl.type == TYPE_INT);
     ASSERT(stmt->var_decl.init && stmt->var_decl.init->kind == EXPR_NUMBER &&
-           strcmp(stmt->var_decl.init->number.value, "5") == 0);
+           strcmp(stmt->var_decl.init->data.number.value, "5") == 0);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -357,10 +357,10 @@ static void test_parser_index_expr(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_INDEX);
-    ASSERT(expr->index.array->kind == EXPR_IDENT);
-    ASSERT(strcmp(expr->index.array->ident.name, "a") == 0);
-    ASSERT(expr->index.index->kind == EXPR_NUMBER &&
-           strcmp(expr->index.index->number.value, "1") == 0);
+    ASSERT(expr->data.index.array->kind == EXPR_IDENT);
+    ASSERT(strcmp(expr->data.index.array->data.ident.name, "a") == 0);
+    ASSERT(expr->data.index.index->kind == EXPR_NUMBER &&
+           strcmp(expr->data.index.index->data.number.value, "1") == 0);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -375,9 +375,9 @@ static void test_parser_unary_neg(void)
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr);
     ASSERT(expr->kind == EXPR_UNARY);
-    ASSERT(expr->unary.op == UNOP_NEG);
-    ASSERT(expr->unary.operand->kind == EXPR_NUMBER &&
-           strcmp(expr->unary.operand->number.value, "5") == 0);
+    ASSERT(expr->data.unary.op == UNOP_NEG);
+    ASSERT(expr->data.unary.operand->kind == EXPR_NUMBER &&
+           strcmp(expr->data.unary.operand->data.number.value, "5") == 0);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -391,11 +391,11 @@ static void test_parser_pointer_arith(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_BINARY);
-    ASSERT(expr->binary.op == BINOP_ADD);
-    ASSERT(expr->binary.left->kind == EXPR_IDENT &&
-           strcmp(expr->binary.left->ident.name, "p") == 0);
-    ASSERT(expr->binary.right->kind == EXPR_NUMBER &&
-           strcmp(expr->binary.right->number.value, "1") == 0);
+    ASSERT(expr->data.binary.op == BINOP_ADD);
+    ASSERT(expr->data.binary.left->kind == EXPR_IDENT &&
+           strcmp(expr->data.binary.left->data.ident.name, "p") == 0);
+    ASSERT(expr->data.binary.right->kind == EXPR_NUMBER &&
+           strcmp(expr->data.binary.right->data.number.value, "1") == 0);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -409,7 +409,7 @@ static void test_parser_mod(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_BINARY);
-    ASSERT(expr->binary.op == BINOP_MOD);
+    ASSERT(expr->data.binary.op == BINOP_MOD);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -442,8 +442,8 @@ static void test_parser_unary_expr(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_UNARY);
-    ASSERT(expr->unary.op == UNOP_NEG);
-    ASSERT(expr->unary.operand->kind == EXPR_BINARY);
+    ASSERT(expr->data.unary.op == UNOP_NEG);
+    ASSERT(expr->data.unary.operand->kind == EXPR_BINARY);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -457,11 +457,11 @@ static void test_parser_logical(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_BINARY);
-    ASSERT(expr->binary.op == BINOP_LOGOR);
-    ASSERT(expr->binary.left->kind == EXPR_BINARY &&
-           expr->binary.left->binary.op == BINOP_LOGAND);
-    ASSERT(expr->binary.right->kind == EXPR_UNARY &&
-           expr->binary.right->unary.op == UNOP_NOT);
+    ASSERT(expr->data.binary.op == BINOP_LOGOR);
+    ASSERT(expr->data.binary.left->kind == EXPR_BINARY &&
+           expr->data.binary.left->data.binary.op == BINOP_LOGAND);
+    ASSERT(expr->data.binary.right->kind == EXPR_UNARY &&
+           expr->data.binary.right->data.unary.op == UNOP_NOT);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -475,9 +475,9 @@ static void test_parser_conditional(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_COND);
-    ASSERT(expr->cond.cond->kind == EXPR_IDENT);
-    ASSERT(expr->cond.then_expr->kind == EXPR_IDENT);
-    ASSERT(expr->cond.else_expr->kind == EXPR_IDENT);
+    ASSERT(expr->data.cond.cond->kind == EXPR_IDENT);
+    ASSERT(expr->data.cond.then_expr->kind == EXPR_IDENT);
+    ASSERT(expr->data.cond.else_expr->kind == EXPR_IDENT);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -501,8 +501,8 @@ static void test_parser_sizeof(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_SIZEOF);
-    ASSERT(expr->sizeof_expr.is_type);
-    ASSERT(expr->sizeof_expr.type == TYPE_INT);
+    ASSERT(expr->data.sizeof_expr.is_type);
+    ASSERT(expr->data.sizeof_expr.type == TYPE_INT);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }
@@ -518,7 +518,7 @@ static void test_parser_variadic_call(void)
     parser_t p; parser_init(&p, toks, count);
     expr_t *expr = parser_parse_expr(&p);
     ASSERT(expr && expr->kind == EXPR_CALL);
-    ASSERT(expr->call.arg_count == 2);
+    ASSERT(expr->data.call.arg_count == 2);
     ast_free_expr(expr);
     lexer_free_tokens(toks, count);
 }

--- a/tests/unit/test_number_suffix.c
+++ b/tests/unit/test_number_suffix.c
@@ -17,8 +17,8 @@ static void check_flags(const char *lit, int u, int lcnt, type_kind_t expect)
 {
     expr_t *e = ast_make_number(lit, 1, 1);
     ASSERT(e);
-    ASSERT(e->number.is_unsigned == u);
-    ASSERT(e->number.long_count == lcnt);
+    ASSERT(e->data.number.is_unsigned == u);
+    ASSERT(e->data.number.long_count == lcnt);
     ir_builder_t ir; ir_builder_init(&ir);
     symtable_t vars, funcs; symtable_init(&vars); symtable_init(&funcs);
     type_kind_t t = check_expr(e, &vars, &funcs, &ir, NULL);


### PR DESCRIPTION
## Summary
- introduce `union expr_data`
- wrap expression fields in `struct expr` with new union
- update all code and tests to use `expr->data.*`

## Testing
- `make -j8`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6871bdccaddc8324a7b58d9c03b011c3