### PR TITLE
Extract stmt union

### DIFF
--- a/include/ast_stmt.h
+++ b/include/ast_stmt.h
@@ -47,108 +47,111 @@ struct struct_member {
     int is_flexible;
 };
 
+/* Data for specific statement kinds */
+union stmt_data {
+    struct {
+        expr_t *expr;
+    } expr;
+    struct {
+        /* expression may be NULL for 'return;' in void functions */
+        expr_t *expr;
+    } ret;
+    struct {
+        char *name;
+        type_kind_t type;
+        size_t array_size;
+        expr_t *size_expr;
+        expr_t *align_expr;
+        size_t alignment;
+        size_t elem_size;
+        char *tag; /* NULL for basic types */
+        int is_static;
+        int is_register;
+        int is_extern;
+        int is_const;
+        int is_volatile;
+        int is_restrict;
+        /* optional initializer expression */
+        expr_t *init;
+        /* optional initializer list for arrays */
+        init_entry_t *init_list;
+        size_t init_count;
+        union_member_t *members;
+        size_t member_count;
+        /* function pointer metadata */
+        type_kind_t func_ret_type;
+        type_kind_t *func_param_types;
+        size_t func_param_count;
+        int func_variadic;
+    } var_decl;
+    struct {
+        expr_t *cond;
+        stmt_t *then_branch;
+        stmt_t *else_branch; /* may be NULL */
+    } if_stmt;
+    struct {
+        expr_t *cond;
+        stmt_t *body;
+    } while_stmt;
+    struct {
+        expr_t *cond;
+        stmt_t *body;
+    } do_while_stmt;
+    struct {
+        stmt_t *init_decl; /* optional variable declaration */
+        expr_t *init;       /* optional init expression */
+        expr_t *cond;
+        expr_t *incr;
+        stmt_t *body;
+    } for_stmt;
+    struct {
+        expr_t *expr;
+        switch_case_t *cases;
+        size_t case_count;
+        stmt_t *default_body; /* may be NULL */
+    } switch_stmt;
+    struct {
+        char *name;
+    } label;
+    struct {
+        char *name;
+    } goto_stmt;
+    struct {
+        expr_t *expr;
+        char *message;
+    } static_assert;
+    struct {
+        char *name;
+        type_kind_t type;
+        size_t array_size;
+        size_t elem_size;
+    } typedef_decl;
+    struct {
+        char *tag;
+        enumerator_t *items;
+        size_t count;
+    } enum_decl;
+    struct {
+        char *tag;
+        struct_member_t *members;
+        size_t count;
+    } struct_decl;
+    struct {
+        char *tag;
+        union_member_t *members;
+        size_t count;
+    } union_decl;
+    struct {
+        stmt_t **stmts;
+        size_t count;
+    } block;
+};
+
 struct stmt {
     stmt_kind_t kind;
     size_t line;
     size_t column;
-    union {
-        struct {
-            expr_t *expr;
-        } expr;
-        struct {
-            /* expression may be NULL for 'return;' in void functions */
-            expr_t *expr;
-        } ret;
-        struct {
-            char *name;
-            type_kind_t type;
-            size_t array_size;
-            expr_t *size_expr;
-            expr_t *align_expr;
-            size_t alignment;
-            size_t elem_size;
-            char *tag; /* NULL for basic types */
-            int is_static;
-            int is_register;
-            int is_extern;
-            int is_const;
-            int is_volatile;
-            int is_restrict;
-            /* optional initializer expression */
-            expr_t *init;
-            /* optional initializer list for arrays */
-            init_entry_t *init_list;
-            size_t init_count;
-            union_member_t *members;
-            size_t member_count;
-            /* function pointer metadata */
-            type_kind_t func_ret_type;
-            type_kind_t *func_param_types;
-            size_t func_param_count;
-            int func_variadic;
-        } var_decl;
-        struct {
-            expr_t *cond;
-            stmt_t *then_branch;
-            stmt_t *else_branch; /* may be NULL */
-        } if_stmt;
-        struct {
-            expr_t *cond;
-            stmt_t *body;
-        } while_stmt;
-        struct {
-            expr_t *cond;
-            stmt_t *body;
-        } do_while_stmt;
-        struct {
-            stmt_t *init_decl; /* optional variable declaration */
-            expr_t *init;       /* optional init expression */
-            expr_t *cond;
-            expr_t *incr;
-            stmt_t *body;
-        } for_stmt;
-        struct {
-            expr_t *expr;
-            switch_case_t *cases;
-            size_t case_count;
-            stmt_t *default_body; /* may be NULL */
-        } switch_stmt;
-        struct {
-            char *name;
-        } label;
-        struct {
-            char *name;
-        } goto_stmt;
-        struct {
-            expr_t *expr;
-            char *message;
-        } static_assert;
-        struct {
-            char *name;
-            type_kind_t type;
-            size_t array_size;
-            size_t elem_size;
-        } typedef_decl;
-        struct {
-            char *tag;
-            enumerator_t *items;
-            size_t count;
-        } enum_decl;
-        struct {
-            char *tag;
-            struct_member_t *members;
-            size_t count;
-        } struct_decl;
-        struct {
-            char *tag;
-            union_member_t *members;
-            size_t count;
-        } union_decl;
-        struct {
-            stmt_t **stmts;
-            size_t count;
-        } block;
-    };
+    union stmt_data data;
 };
 
 /* Function definition structure */

--- a/src/ast_dump.c
+++ b/src/ast_dump.c
@@ -154,49 +154,49 @@ static void dump_stmt(strbuf_t *sb, const stmt_t *s, int lvl)
     strbuf_appendf(sb, "%s\n", stmt_name(s->kind));
     switch (s->kind) {
     case STMT_EXPR:
-        dump_expr(sb, s->expr.expr, lvl + 1);
+        dump_expr(sb, s->data.expr.expr, lvl + 1);
         break;
     case STMT_RETURN:
-        dump_expr(sb, s->ret.expr, lvl + 1);
+        dump_expr(sb, s->data.ret.expr, lvl + 1);
         break;
     case STMT_VAR_DECL:
-        if (s->var_decl.init)
-            dump_expr(sb, s->var_decl.init, lvl + 1);
+        if (s->data.var_decl.init)
+            dump_expr(sb, s->data.var_decl.init, lvl + 1);
         break;
     case STMT_IF:
-        dump_expr(sb, s->if_stmt.cond, lvl + 1);
-        dump_stmt(sb, s->if_stmt.then_branch, lvl + 1);
-        dump_stmt(sb, s->if_stmt.else_branch, lvl + 1);
+        dump_expr(sb, s->data.if_stmt.cond, lvl + 1);
+        dump_stmt(sb, s->data.if_stmt.then_branch, lvl + 1);
+        dump_stmt(sb, s->data.if_stmt.else_branch, lvl + 1);
         break;
     case STMT_WHILE:
-        dump_expr(sb, s->while_stmt.cond, lvl + 1);
-        dump_stmt(sb, s->while_stmt.body, lvl + 1);
+        dump_expr(sb, s->data.while_stmt.cond, lvl + 1);
+        dump_stmt(sb, s->data.while_stmt.body, lvl + 1);
         break;
     case STMT_DO_WHILE:
-        dump_stmt(sb, s->do_while_stmt.body, lvl + 1);
-        dump_expr(sb, s->do_while_stmt.cond, lvl + 1);
+        dump_stmt(sb, s->data.do_while_stmt.body, lvl + 1);
+        dump_expr(sb, s->data.do_while_stmt.cond, lvl + 1);
         break;
     case STMT_FOR:
-        if (s->for_stmt.init_decl)
-            dump_stmt(sb, s->for_stmt.init_decl, lvl + 1);
+        if (s->data.for_stmt.init_decl)
+            dump_stmt(sb, s->data.for_stmt.init_decl, lvl + 1);
         else
-            dump_expr(sb, s->for_stmt.init, lvl + 1);
-        dump_expr(sb, s->for_stmt.cond, lvl + 1);
-        dump_expr(sb, s->for_stmt.incr, lvl + 1);
-        dump_stmt(sb, s->for_stmt.body, lvl + 1);
+            dump_expr(sb, s->data.for_stmt.init, lvl + 1);
+        dump_expr(sb, s->data.for_stmt.cond, lvl + 1);
+        dump_expr(sb, s->data.for_stmt.incr, lvl + 1);
+        dump_stmt(sb, s->data.for_stmt.body, lvl + 1);
         break;
     case STMT_SWITCH:
-        dump_expr(sb, s->switch_stmt.expr, lvl + 1);
-        for (size_t i = 0; i < s->switch_stmt.case_count; i++) {
-            dump_expr(sb, s->switch_stmt.cases[i].expr, lvl + 1);
-            dump_stmt(sb, s->switch_stmt.cases[i].body, lvl + 2);
+        dump_expr(sb, s->data.switch_stmt.expr, lvl + 1);
+        for (size_t i = 0; i < s->data.switch_stmt.case_count; i++) {
+            dump_expr(sb, s->data.switch_stmt.cases[i].expr, lvl + 1);
+            dump_stmt(sb, s->data.switch_stmt.cases[i].body, lvl + 2);
         }
-        dump_stmt(sb, s->switch_stmt.default_body, lvl + 1);
+        dump_stmt(sb, s->data.switch_stmt.default_body, lvl + 1);
         break;
     case STMT_LABEL:
         indent(sb, lvl + 1);
-        if (s->label.name)
-            strbuf_appendf(sb, "label: %s\n", s->label.name);
+        if (s->data.label.name)
+            strbuf_appendf(sb, "label: %s\n", s->data.label.name);
         break;
     case STMT_GOTO:
     case STMT_BREAK:
@@ -208,7 +208,7 @@ static void dump_stmt(strbuf_t *sb, const stmt_t *s, int lvl)
     case STMT_UNION_DECL:
         break;
     case STMT_BLOCK:
-        dump_block(sb, s->block.stmts, s->block.count, lvl + 1);
+        dump_block(sb, s->data.block.stmts, s->data.block.count, lvl + 1);
         break;
     }
 }

--- a/src/ast_stmt_create.c
+++ b/src/ast_stmt_create.c
@@ -24,7 +24,7 @@ stmt_t *ast_make_expr_stmt(expr_t *expr, size_t line, size_t column)
     stmt->kind = STMT_EXPR;
     stmt->line = line;
     stmt->column = column;
-    stmt->expr.expr = expr;
+    stmt->data.expr.expr = expr;
     return stmt;
 }
 
@@ -37,7 +37,7 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column)
     stmt->kind = STMT_RETURN;
     stmt->line = line;
     stmt->column = column;
-    stmt->ret.expr = expr;
+    stmt->data.ret.expr = expr;
     return stmt;
 }
 
@@ -56,42 +56,42 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
     stmt->kind = STMT_VAR_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->var_decl.name = vc_strdup(name ? name : "");
-    if (!stmt->var_decl.name) {
+    stmt->data.var_decl.name = vc_strdup(name ? name : "");
+    if (!stmt->data.var_decl.name) {
         free(stmt);
         return NULL;
     }
-    stmt->var_decl.type = type;
-    stmt->var_decl.array_size = array_size;
-    stmt->var_decl.size_expr = size_expr;
-    stmt->var_decl.align_expr = align_expr;
-    stmt->var_decl.alignment = 0;
-    stmt->var_decl.elem_size = elem_size;
+    stmt->data.var_decl.type = type;
+    stmt->data.var_decl.array_size = array_size;
+    stmt->data.var_decl.size_expr = size_expr;
+    stmt->data.var_decl.align_expr = align_expr;
+    stmt->data.var_decl.alignment = 0;
+    stmt->data.var_decl.elem_size = elem_size;
     if (tag) {
-        stmt->var_decl.tag = vc_strdup(tag);
-        if (!stmt->var_decl.tag) {
-            free(stmt->var_decl.name);
+        stmt->data.var_decl.tag = vc_strdup(tag);
+        if (!stmt->data.var_decl.tag) {
+            free(stmt->data.var_decl.name);
             free(stmt);
             return NULL;
         }
     } else {
-        stmt->var_decl.tag = NULL;
+        stmt->data.var_decl.tag = NULL;
     }
-    stmt->var_decl.is_static = is_static;
-    stmt->var_decl.is_register = is_register;
-    stmt->var_decl.is_extern = is_extern;
-    stmt->var_decl.is_const = is_const;
-    stmt->var_decl.is_volatile = is_volatile;
-    stmt->var_decl.is_restrict = is_restrict;
-    stmt->var_decl.init = init;
-    stmt->var_decl.init_list = init_list;
-    stmt->var_decl.init_count = init_count;
-    stmt->var_decl.members = members;
-    stmt->var_decl.member_count = member_count;
-    stmt->var_decl.func_ret_type = TYPE_UNKNOWN;
-    stmt->var_decl.func_param_types = NULL;
-    stmt->var_decl.func_param_count = 0;
-    stmt->var_decl.func_variadic = 0;
+    stmt->data.var_decl.is_static = is_static;
+    stmt->data.var_decl.is_register = is_register;
+    stmt->data.var_decl.is_extern = is_extern;
+    stmt->data.var_decl.is_const = is_const;
+    stmt->data.var_decl.is_volatile = is_volatile;
+    stmt->data.var_decl.is_restrict = is_restrict;
+    stmt->data.var_decl.init = init;
+    stmt->data.var_decl.init_list = init_list;
+    stmt->data.var_decl.init_count = init_count;
+    stmt->data.var_decl.members = members;
+    stmt->data.var_decl.member_count = member_count;
+    stmt->data.var_decl.func_ret_type = TYPE_UNKNOWN;
+    stmt->data.var_decl.func_param_types = NULL;
+    stmt->data.var_decl.func_param_count = 0;
+    stmt->data.var_decl.func_variadic = 0;
     return stmt;
 }
 
@@ -105,9 +105,9 @@ stmt_t *ast_make_if(expr_t *cond, stmt_t *then_branch, stmt_t *else_branch,
     stmt->kind = STMT_IF;
     stmt->line = line;
     stmt->column = column;
-    stmt->if_stmt.cond = cond;
-    stmt->if_stmt.then_branch = then_branch;
-    stmt->if_stmt.else_branch = else_branch;
+    stmt->data.if_stmt.cond = cond;
+    stmt->data.if_stmt.then_branch = then_branch;
+    stmt->data.if_stmt.else_branch = else_branch;
     return stmt;
 }
 
@@ -121,8 +121,8 @@ stmt_t *ast_make_while(expr_t *cond, stmt_t *body,
     stmt->kind = STMT_WHILE;
     stmt->line = line;
     stmt->column = column;
-    stmt->while_stmt.cond = cond;
-    stmt->while_stmt.body = body;
+    stmt->data.while_stmt.cond = cond;
+    stmt->data.while_stmt.body = body;
     return stmt;
 }
 
@@ -136,8 +136,8 @@ stmt_t *ast_make_do_while(expr_t *cond, stmt_t *body,
     stmt->kind = STMT_DO_WHILE;
     stmt->line = line;
     stmt->column = column;
-    stmt->do_while_stmt.cond = cond;
-    stmt->do_while_stmt.body = body;
+    stmt->data.do_while_stmt.cond = cond;
+    stmt->data.do_while_stmt.body = body;
     return stmt;
 }
 
@@ -152,11 +152,11 @@ stmt_t *ast_make_for(stmt_t *init_decl, expr_t *init, expr_t *cond,
     stmt->kind = STMT_FOR;
     stmt->line = line;
     stmt->column = column;
-    stmt->for_stmt.init_decl = init_decl;
-    stmt->for_stmt.init = init;
-    stmt->for_stmt.cond = cond;
-    stmt->for_stmt.incr = incr;
-    stmt->for_stmt.body = body;
+    stmt->data.for_stmt.init_decl = init_decl;
+    stmt->data.for_stmt.init = init;
+    stmt->data.for_stmt.cond = cond;
+    stmt->data.for_stmt.incr = incr;
+    stmt->data.for_stmt.body = body;
     return stmt;
 }
 
@@ -170,10 +170,10 @@ stmt_t *ast_make_switch(expr_t *expr, switch_case_t *cases, size_t case_count,
     stmt->kind = STMT_SWITCH;
     stmt->line = line;
     stmt->column = column;
-    stmt->switch_stmt.expr = expr;
-    stmt->switch_stmt.cases = cases;
-    stmt->switch_stmt.case_count = case_count;
-    stmt->switch_stmt.default_body = default_body;
+    stmt->data.switch_stmt.expr = expr;
+    stmt->data.switch_stmt.cases = cases;
+    stmt->data.switch_stmt.case_count = case_count;
+    stmt->data.switch_stmt.default_body = default_body;
     return stmt;
 }
 
@@ -210,8 +210,8 @@ stmt_t *ast_make_label(const char *name, size_t line, size_t column)
     stmt->kind = STMT_LABEL;
     stmt->line = line;
     stmt->column = column;
-    stmt->label.name = vc_strdup(name ? name : "");
-    if (!stmt->label.name) {
+    stmt->data.label.name = vc_strdup(name ? name : "");
+    if (!stmt->data.label.name) {
         free(stmt);
         return NULL;
     }
@@ -227,8 +227,8 @@ stmt_t *ast_make_goto(const char *name, size_t line, size_t column)
     stmt->kind = STMT_GOTO;
     stmt->line = line;
     stmt->column = column;
-    stmt->goto_stmt.name = vc_strdup(name ? name : "");
-    if (!stmt->goto_stmt.name) {
+    stmt->data.goto_stmt.name = vc_strdup(name ? name : "");
+    if (!stmt->data.goto_stmt.name) {
         free(stmt);
         return NULL;
     }
@@ -245,9 +245,9 @@ stmt_t *ast_make_static_assert(expr_t *expr, const char *msg,
     stmt->kind = STMT_STATIC_ASSERT;
     stmt->line = line;
     stmt->column = column;
-    stmt->static_assert.expr = expr;
-    stmt->static_assert.message = vc_strdup(msg ? msg : "");
-    if (!stmt->static_assert.message) {
+    stmt->data.static_assert.expr = expr;
+    stmt->data.static_assert.message = vc_strdup(msg ? msg : "");
+    if (!stmt->data.static_assert.message) {
         free(stmt);
         return NULL;
     }
@@ -264,14 +264,14 @@ stmt_t *ast_make_typedef(const char *name, type_kind_t type, size_t array_size,
     stmt->kind = STMT_TYPEDEF;
     stmt->line = line;
     stmt->column = column;
-    stmt->typedef_decl.name = vc_strdup(name ? name : "");
-    if (!stmt->typedef_decl.name) {
+    stmt->data.typedef_decl.name = vc_strdup(name ? name : "");
+    if (!stmt->data.typedef_decl.name) {
         free(stmt);
         return NULL;
     }
-    stmt->typedef_decl.type = type;
-    stmt->typedef_decl.array_size = array_size;
-    stmt->typedef_decl.elem_size = elem_size;
+    stmt->data.typedef_decl.type = type;
+    stmt->data.typedef_decl.array_size = array_size;
+    stmt->data.typedef_decl.elem_size = elem_size;
     return stmt;
 }
 
@@ -285,13 +285,13 @@ stmt_t *ast_make_enum_decl(const char *tag, enumerator_t *items, size_t count,
     stmt->kind = STMT_ENUM_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->enum_decl.tag = vc_strdup(tag ? tag : "");
-    if (!stmt->enum_decl.tag) {
+    stmt->data.enum_decl.tag = vc_strdup(tag ? tag : "");
+    if (!stmt->data.enum_decl.tag) {
         free(stmt);
         return NULL;
     }
-    stmt->enum_decl.items = items;
-    stmt->enum_decl.count = count;
+    stmt->data.enum_decl.items = items;
+    stmt->data.enum_decl.count = count;
     return stmt;
 }
 
@@ -305,13 +305,13 @@ stmt_t *ast_make_struct_decl(const char *tag, struct_member_t *members,
     stmt->kind = STMT_STRUCT_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->struct_decl.tag = vc_strdup(tag ? tag : "");
-    if (!stmt->struct_decl.tag) {
+    stmt->data.struct_decl.tag = vc_strdup(tag ? tag : "");
+    if (!stmt->data.struct_decl.tag) {
         free(stmt);
         return NULL;
     }
-    stmt->struct_decl.members = members;
-    stmt->struct_decl.count = count;
+    stmt->data.struct_decl.members = members;
+    stmt->data.struct_decl.count = count;
     return stmt;
 }
 
@@ -325,13 +325,13 @@ stmt_t *ast_make_union_decl(const char *tag, union_member_t *members,
     stmt->kind = STMT_UNION_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->union_decl.tag = vc_strdup(tag ? tag : "");
-    if (!stmt->union_decl.tag) {
+    stmt->data.union_decl.tag = vc_strdup(tag ? tag : "");
+    if (!stmt->data.union_decl.tag) {
         free(stmt);
         return NULL;
     }
-    stmt->union_decl.members = members;
-    stmt->union_decl.count = count;
+    stmt->data.union_decl.members = members;
+    stmt->data.union_decl.count = count;
     return stmt;
 }
 
@@ -345,8 +345,8 @@ stmt_t *ast_make_block(stmt_t **stmts, size_t count,
     stmt->kind = STMT_BLOCK;
     stmt->line = line;
     stmt->column = column;
-    stmt->block.stmts = stmts;
-    stmt->block.count = count;
+    stmt->data.block.stmts = stmts;
+    stmt->data.block.count = count;
     return stmt;
 }
 

--- a/src/ast_stmt_free.c
+++ b/src/ast_stmt_free.c
@@ -15,124 +15,124 @@
 /* Helpers for freeing individual statement types */
 static void free_expr_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->expr.expr);
+    ast_free_expr(stmt->data.expr.expr);
 }
 
 static void free_return_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->ret.expr);
+    ast_free_expr(stmt->data.ret.expr);
 }
 
 static void free_var_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->var_decl.name);
-    ast_free_expr(stmt->var_decl.size_expr);
-    ast_free_expr(stmt->var_decl.align_expr);
-    ast_free_expr(stmt->var_decl.init);
-    for (size_t i = 0; i < stmt->var_decl.init_count; i++) {
-        ast_free_expr(stmt->var_decl.init_list[i].index);
-        ast_free_expr(stmt->var_decl.init_list[i].value);
-        free(stmt->var_decl.init_list[i].field);
+    free(stmt->data.var_decl.name);
+    ast_free_expr(stmt->data.var_decl.size_expr);
+    ast_free_expr(stmt->data.var_decl.align_expr);
+    ast_free_expr(stmt->data.var_decl.init);
+    for (size_t i = 0; i < stmt->data.var_decl.init_count; i++) {
+        ast_free_expr(stmt->data.var_decl.init_list[i].index);
+        ast_free_expr(stmt->data.var_decl.init_list[i].value);
+        free(stmt->data.var_decl.init_list[i].field);
     }
-    free(stmt->var_decl.init_list);
-    free(stmt->var_decl.tag);
-    for (size_t i = 0; i < stmt->var_decl.member_count; i++)
-        free(stmt->var_decl.members[i].name);
-    free(stmt->var_decl.members);
-    free(stmt->var_decl.func_param_types);
+    free(stmt->data.var_decl.init_list);
+    free(stmt->data.var_decl.tag);
+    for (size_t i = 0; i < stmt->data.var_decl.member_count; i++)
+        free(stmt->data.var_decl.members[i].name);
+    free(stmt->data.var_decl.members);
+    free(stmt->data.var_decl.func_param_types);
 }
 
 static void free_if_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->if_stmt.cond);
-    ast_free_stmt(stmt->if_stmt.then_branch);
-    ast_free_stmt(stmt->if_stmt.else_branch);
+    ast_free_expr(stmt->data.if_stmt.cond);
+    ast_free_stmt(stmt->data.if_stmt.then_branch);
+    ast_free_stmt(stmt->data.if_stmt.else_branch);
 }
 
 static void free_while_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->while_stmt.cond);
-    ast_free_stmt(stmt->while_stmt.body);
+    ast_free_expr(stmt->data.while_stmt.cond);
+    ast_free_stmt(stmt->data.while_stmt.body);
 }
 
 static void free_do_while_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->do_while_stmt.cond);
-    ast_free_stmt(stmt->do_while_stmt.body);
+    ast_free_expr(stmt->data.do_while_stmt.cond);
+    ast_free_stmt(stmt->data.do_while_stmt.body);
 }
 
 static void free_for_stmt(stmt_t *stmt)
 {
-    ast_free_stmt(stmt->for_stmt.init_decl);
-    ast_free_expr(stmt->for_stmt.init);
-    ast_free_expr(stmt->for_stmt.cond);
-    ast_free_expr(stmt->for_stmt.incr);
-    ast_free_stmt(stmt->for_stmt.body);
+    ast_free_stmt(stmt->data.for_stmt.init_decl);
+    ast_free_expr(stmt->data.for_stmt.init);
+    ast_free_expr(stmt->data.for_stmt.cond);
+    ast_free_expr(stmt->data.for_stmt.incr);
+    ast_free_stmt(stmt->data.for_stmt.body);
 }
 
 static void free_switch_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->switch_stmt.expr);
-    for (size_t i = 0; i < stmt->switch_stmt.case_count; i++) {
-        ast_free_expr(stmt->switch_stmt.cases[i].expr);
-        ast_free_stmt(stmt->switch_stmt.cases[i].body);
+    ast_free_expr(stmt->data.switch_stmt.expr);
+    for (size_t i = 0; i < stmt->data.switch_stmt.case_count; i++) {
+        ast_free_expr(stmt->data.switch_stmt.cases[i].expr);
+        ast_free_stmt(stmt->data.switch_stmt.cases[i].body);
     }
-    free(stmt->switch_stmt.cases);
-    ast_free_stmt(stmt->switch_stmt.default_body);
+    free(stmt->data.switch_stmt.cases);
+    ast_free_stmt(stmt->data.switch_stmt.default_body);
 }
 
 static void free_label_stmt(stmt_t *stmt)
 {
-    free(stmt->label.name);
+    free(stmt->data.label.name);
 }
 
 static void free_goto_stmt(stmt_t *stmt)
 {
-    free(stmt->goto_stmt.name);
+    free(stmt->data.goto_stmt.name);
 }
 
 static void free_static_assert_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->static_assert.expr);
-    free(stmt->static_assert.message);
+    ast_free_expr(stmt->data.static_assert.expr);
+    free(stmt->data.static_assert.message);
 }
 
 static void free_typedef_stmt(stmt_t *stmt)
 {
-    free(stmt->typedef_decl.name);
+    free(stmt->data.typedef_decl.name);
 }
 
 static void free_enum_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->enum_decl.tag);
-    for (size_t i = 0; i < stmt->enum_decl.count; i++) {
-        free(stmt->enum_decl.items[i].name);
-        ast_free_expr(stmt->enum_decl.items[i].value);
+    free(stmt->data.enum_decl.tag);
+    for (size_t i = 0; i < stmt->data.enum_decl.count; i++) {
+        free(stmt->data.enum_decl.items[i].name);
+        ast_free_expr(stmt->data.enum_decl.items[i].value);
     }
-    free(stmt->enum_decl.items);
+    free(stmt->data.enum_decl.items);
 }
 
 static void free_struct_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->struct_decl.tag);
-    for (size_t i = 0; i < stmt->struct_decl.count; i++)
-        free(stmt->struct_decl.members[i].name);
-    free(stmt->struct_decl.members);
+    free(stmt->data.struct_decl.tag);
+    for (size_t i = 0; i < stmt->data.struct_decl.count; i++)
+        free(stmt->data.struct_decl.members[i].name);
+    free(stmt->data.struct_decl.members);
 }
 
 static void free_union_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->union_decl.tag);
-    for (size_t i = 0; i < stmt->union_decl.count; i++)
-        free(stmt->union_decl.members[i].name);
-    free(stmt->union_decl.members);
+    free(stmt->data.union_decl.tag);
+    for (size_t i = 0; i < stmt->data.union_decl.count; i++)
+        free(stmt->data.union_decl.members[i].name);
+    free(stmt->data.union_decl.members);
 }
 
 static void free_block_stmt(stmt_t *stmt)
 {
-    for (size_t i = 0; i < stmt->block.count; i++)
-        ast_free_stmt(stmt->block.stmts[i]);
-    free(stmt->block.stmts);
+    for (size_t i = 0; i < stmt->data.block.count; i++)
+        ast_free_stmt(stmt->data.block.stmts[i]);
+    free(stmt->data.block.stmts);
 }
 
 static void free_break_stmt(stmt_t *stmt)

--- a/src/parser_decl_var.c
+++ b/src/parser_decl_var.c
@@ -288,10 +288,10 @@ stmt_t *parser_parse_var_decl(parser_t *p)
         free(tag_name);
         free(param_types);
     } else {
-        res->var_decl.func_ret_type = func_ret_type;
-        res->var_decl.func_param_types = param_types;
-        res->var_decl.func_param_count = param_count;
-        res->var_decl.func_variadic = variadic;
+        res->data.var_decl.func_ret_type = func_ret_type;
+        res->data.var_decl.func_param_types = param_types;
+        res->data.var_decl.func_param_count = param_count;
+        res->data.var_decl.func_variadic = variadic;
     }
     return res;
 }

--- a/src/semantic_block.c
+++ b/src/semantic_block.c
@@ -10,8 +10,8 @@ int stmt_block_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                        const char *continue_label)
 {
     symbol_t *old_head = vars->head;
-    for (size_t i = 0; i < stmt->block.count; i++) {
-        if (!check_stmt(stmt->block.stmts[i], vars, funcs, labels, ir,
+    for (size_t i = 0; i < stmt->data.block.count; i++) {
+        if (!check_stmt(stmt->data.block.stmts[i], vars, funcs, labels, ir,
                         func_ret_type, break_label, continue_label)) {
             symtable_pop_scope(vars, old_head);
             return 0;

--- a/src/semantic_decl.c
+++ b/src/semantic_decl.c
@@ -11,10 +11,10 @@
 
 static int check_typedef_stmt(stmt_t *stmt, symtable_t *vars)
 {
-    if (!symtable_add_typedef(vars, stmt->typedef_decl.name,
-                              stmt->typedef_decl.type,
-                              stmt->typedef_decl.array_size,
-                              stmt->typedef_decl.elem_size)) {
+    if (!symtable_add_typedef(vars, stmt->data.typedef_decl.name,
+                              stmt->data.typedef_decl.type,
+                              stmt->data.typedef_decl.array_size,
+                              stmt->data.typedef_decl.elem_size)) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
         return 0;
     }

--- a/src/semantic_decl_stmt.c
+++ b/src/semantic_decl_stmt.c
@@ -12,8 +12,8 @@
 static int check_enum_decl_stmt(stmt_t *stmt, symtable_t *vars)
 {
     int next = 0;
-    for (size_t i = 0; i < stmt->enum_decl.count; i++) {
-        enumerator_t *e = &stmt->enum_decl.items[i];
+    for (size_t i = 0; i < stmt->data.enum_decl.count; i++) {
+        enumerator_t *e = &stmt->data.enum_decl.items[i];
         long long val = next;
         if (e->value) {
             if (!eval_const_expr(e->value, vars, 0, &val)) {
@@ -28,22 +28,22 @@ static int check_enum_decl_stmt(stmt_t *stmt, symtable_t *vars)
         }
         next = (int)val + 1;
     }
-    if (stmt->enum_decl.tag && stmt->enum_decl.tag[0])
-        symtable_add_enum_tag(vars, stmt->enum_decl.tag);
+    if (stmt->data.enum_decl.tag && stmt->data.enum_decl.tag[0])
+        symtable_add_enum_tag(vars, stmt->data.enum_decl.tag);
     return 1;
 }
 
 static int check_struct_decl_stmt(stmt_t *stmt, symtable_t *vars)
 {
-    size_t total = layout_struct_members(stmt->struct_decl.members,
-                                         stmt->struct_decl.count);
-    if (!symtable_add_struct(vars, stmt->struct_decl.tag,
-                             stmt->struct_decl.members,
-                             stmt->struct_decl.count)) {
+    size_t total = layout_struct_members(stmt->data.struct_decl.members,
+                                         stmt->data.struct_decl.count);
+    if (!symtable_add_struct(vars, stmt->data.struct_decl.tag,
+                             stmt->data.struct_decl.members,
+                             stmt->data.struct_decl.count)) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
         return 0;
     }
-    symbol_t *stype = symtable_lookup_struct(vars, stmt->struct_decl.tag);
+    symbol_t *stype = symtable_lookup_struct(vars, stmt->data.struct_decl.tag);
     if (stype)
         stype->struct_total_size = total;
     return 1;
@@ -51,12 +51,12 @@ static int check_struct_decl_stmt(stmt_t *stmt, symtable_t *vars)
 
 static int check_union_decl_stmt(stmt_t *stmt, symtable_t *vars)
 {
-    size_t max = layout_union_members(stmt->union_decl.members,
-                                      stmt->union_decl.count);
+    size_t max = layout_union_members(stmt->data.union_decl.members,
+                                      stmt->data.union_decl.count);
     (void)max;
-    if (!symtable_add_union(vars, stmt->union_decl.tag,
-                            stmt->union_decl.members,
-                            stmt->union_decl.count)) {
+    if (!symtable_add_union(vars, stmt->data.union_decl.tag,
+                            stmt->data.union_decl.members,
+                            stmt->data.union_decl.count)) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
         return 0;
     }
@@ -66,35 +66,35 @@ static int check_union_decl_stmt(stmt_t *stmt, symtable_t *vars)
 static symbol_t *insert_var_symbol(stmt_t *stmt, symtable_t *vars,
                                    const char *ir_name)
 {
-    if (stmt->var_decl.align_expr) {
+    if (stmt->data.var_decl.align_expr) {
         long long aval;
-        if (!eval_const_expr(stmt->var_decl.align_expr, vars, 0, &aval) ||
+        if (!eval_const_expr(stmt->data.var_decl.align_expr, vars, 0, &aval) ||
             aval <= 0 || (aval & (aval - 1))) {
-            error_set(stmt->var_decl.align_expr->line,
-                      stmt->var_decl.align_expr->column,
+            error_set(stmt->data.var_decl.align_expr->line,
+                      stmt->data.var_decl.align_expr->column,
                       error_current_file, error_current_function);
             error_print("Invalid alignment");
             return NULL;
         }
-        stmt->var_decl.alignment = (size_t)aval;
+        stmt->data.var_decl.alignment = (size_t)aval;
     }
-    if (!symtable_add(vars, stmt->var_decl.name, ir_name,
-                      stmt->var_decl.type,
-                      stmt->var_decl.array_size,
-                      stmt->var_decl.elem_size,
-                      stmt->var_decl.alignment,
-                      stmt->var_decl.is_static,
-                      stmt->var_decl.is_register,
-                      stmt->var_decl.is_const,
-                      stmt->var_decl.is_volatile,
-                      stmt->var_decl.is_restrict))
+    if (!symtable_add(vars, stmt->data.var_decl.name, ir_name,
+                      stmt->data.var_decl.type,
+                      stmt->data.var_decl.array_size,
+                      stmt->data.var_decl.elem_size,
+                      stmt->data.var_decl.alignment,
+                      stmt->data.var_decl.is_static,
+                      stmt->data.var_decl.is_register,
+                      stmt->data.var_decl.is_const,
+                      stmt->data.var_decl.is_volatile,
+                      stmt->data.var_decl.is_restrict))
         return NULL;
 
-    symbol_t *sym = symtable_lookup(vars, stmt->var_decl.name);
-    if (stmt->var_decl.init_list && stmt->var_decl.type == TYPE_ARRAY &&
-        stmt->var_decl.array_size == 0) {
-        stmt->var_decl.array_size = stmt->var_decl.init_count;
-        sym->array_size = stmt->var_decl.array_size;
+    symbol_t *sym = symtable_lookup(vars, stmt->data.var_decl.name);
+    if (stmt->data.var_decl.init_list && stmt->data.var_decl.type == TYPE_ARRAY &&
+        stmt->data.var_decl.array_size == 0) {
+        stmt->data.var_decl.array_size = stmt->data.var_decl.init_count;
+        sym->array_size = stmt->data.var_decl.array_size;
     }
 
     return sym;
@@ -103,8 +103,8 @@ static symbol_t *insert_var_symbol(stmt_t *stmt, symtable_t *vars,
 static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
 {
     char ir_name_buf[32];
-    const char *ir_name = stmt->var_decl.name;
-    if (stmt->var_decl.is_static) {
+    const char *ir_name = stmt->data.var_decl.name;
+    if (stmt->data.var_decl.is_static) {
         if (!label_format("__static", label_next_id(), ir_name_buf))
             return NULL;
         ir_name = ir_name_buf;
@@ -112,8 +112,8 @@ static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
 
     if (!compute_var_layout(stmt, vars))
         return NULL;
-    if (stmt->var_decl.is_const && !stmt->var_decl.init &&
-        !stmt->var_decl.init_list) {
+    if (stmt->data.var_decl.is_const && !stmt->data.var_decl.init &&
+        !stmt->data.var_decl.init_list) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
         return NULL;
     }
@@ -123,15 +123,15 @@ static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
         return NULL;
     }
 
-    sym->func_ret_type = stmt->var_decl.func_ret_type;
-    sym->func_param_count = stmt->var_decl.func_param_count;
-    sym->func_variadic = stmt->var_decl.func_variadic;
-    if (stmt->var_decl.func_param_count) {
+    sym->func_ret_type = stmt->data.var_decl.func_ret_type;
+    sym->func_param_count = stmt->data.var_decl.func_param_count;
+    sym->func_variadic = stmt->data.var_decl.func_variadic;
+    if (stmt->data.var_decl.func_param_count) {
         sym->func_param_types = malloc(sym->func_param_count * sizeof(type_kind_t));
         if (!sym->func_param_types)
             return NULL;
         for (size_t i = 0; i < sym->func_param_count; i++)
-            sym->func_param_types[i] = stmt->var_decl.func_param_types[i];
+            sym->func_param_types[i] = stmt->data.var_decl.func_param_types[i];
     }
 
     return sym;
@@ -143,8 +143,8 @@ static int check_var_decl_stmt(stmt_t *stmt, symtable_t *vars,
     symbol_t *sym = register_var_symbol(stmt, vars);
     if (!sym)
         return 0;
-    if (stmt->var_decl.type == TYPE_ARRAY && stmt->var_decl.array_size == 0 &&
-        stmt->var_decl.size_expr) {
+    if (stmt->data.var_decl.type == TYPE_ARRAY && stmt->data.var_decl.array_size == 0 &&
+        stmt->data.var_decl.size_expr) {
         if (!handle_vla_size(stmt, sym, vars, funcs, ir))
             return 0;
     }

--- a/src/semantic_expr_stmt.c
+++ b/src/semantic_expr_stmt.c
@@ -7,7 +7,7 @@ static int check_expr_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                            ir_builder_t *ir)
 {
     ir_value_t tmp;
-    return check_expr(stmt->expr.expr, vars, funcs, ir, &tmp) != TYPE_UNKNOWN;
+    return check_expr(stmt->data.expr.expr, vars, funcs, ir, &tmp) != TYPE_UNKNOWN;
 }
 
 int stmt_expr_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,

--- a/src/semantic_label.c
+++ b/src/semantic_label.c
@@ -6,7 +6,7 @@
 static int handle_label_stmt(stmt_t *stmt, label_table_t *labels,
                              ir_builder_t *ir)
 {
-    const char *ir_name = label_table_get_or_add(labels, stmt->label.name);
+    const char *ir_name = label_table_get_or_add(labels, stmt->data.label.name);
     ir_build_label(ir, ir_name);
     return 1;
 }
@@ -14,7 +14,7 @@ static int handle_label_stmt(stmt_t *stmt, label_table_t *labels,
 static int check_goto_stmt(stmt_t *stmt, label_table_t *labels,
                            ir_builder_t *ir)
 {
-    const char *ir_name = label_table_get_or_add(labels, stmt->goto_stmt.name);
+    const char *ir_name = label_table_get_or_add(labels, stmt->data.goto_stmt.name);
     ir_build_br(ir, ir_name);
     return 1;
 }

--- a/src/semantic_layout.c
+++ b/src/semantic_layout.c
@@ -84,18 +84,18 @@ size_t layout_struct_members(struct_member_t *members, size_t count)
 /* Compute layout for a union variable declaration */
 int compute_union_layout(stmt_t *decl, symtable_t *globals)
 {
-    if (decl->var_decl.member_count) {
-        size_t max = layout_union_members(decl->var_decl.members,
-                                          decl->var_decl.member_count);
-        decl->var_decl.elem_size = max;
-    } else if (decl->var_decl.tag) {
-        symbol_t *utype = symtable_lookup_union(globals, decl->var_decl.tag);
+    if (decl->data.var_decl.member_count) {
+        size_t max = layout_union_members(decl->data.var_decl.members,
+                                          decl->data.var_decl.member_count);
+        decl->data.var_decl.elem_size = max;
+    } else if (decl->data.var_decl.tag) {
+        symbol_t *utype = symtable_lookup_union(globals, decl->data.var_decl.tag);
         if (!utype) {
             error_set(decl->line, decl->column, error_current_file,
                       error_current_function);
             return 0;
         }
-        decl->var_decl.elem_size = utype->total_size;
+        decl->data.var_decl.elem_size = utype->total_size;
     }
     return 1;
 }
@@ -103,18 +103,18 @@ int compute_union_layout(stmt_t *decl, symtable_t *globals)
 /* Compute layout for a struct variable declaration */
 int compute_struct_layout(stmt_t *decl, symtable_t *globals)
 {
-    if (decl->var_decl.member_count) {
-        size_t total = layout_struct_members((struct_member_t *)decl->var_decl.members,
-                                             decl->var_decl.member_count);
-        decl->var_decl.elem_size = total;
-    } else if (decl->var_decl.tag) {
-        symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
+    if (decl->data.var_decl.member_count) {
+        size_t total = layout_struct_members((struct_member_t *)decl->data.var_decl.members,
+                                             decl->data.var_decl.member_count);
+        decl->data.var_decl.elem_size = total;
+    } else if (decl->data.var_decl.tag) {
+        symbol_t *stype = symtable_lookup_struct(globals, decl->data.var_decl.tag);
         if (!stype) {
             error_set(decl->line, decl->column, error_current_file,
                       error_current_function);
             return 0;
         }
-        decl->var_decl.elem_size = stype->struct_total_size;
+        decl->data.var_decl.elem_size = stype->struct_total_size;
     }
     return 1;
 }
@@ -171,14 +171,14 @@ int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
 int copy_aggregate_metadata(stmt_t *decl, symbol_t *sym,
                             symtable_t *globals)
 {
-    if (decl->var_decl.type == TYPE_UNION)
-        return copy_union_metadata(sym, decl->var_decl.members,
-                                   decl->var_decl.member_count,
-                                   decl->var_decl.elem_size);
+    if (decl->data.var_decl.type == TYPE_UNION)
+        return copy_union_metadata(sym, decl->data.var_decl.members,
+                                   decl->data.var_decl.member_count,
+                                   decl->data.var_decl.elem_size);
 
-    if (decl->var_decl.type == TYPE_STRUCT) {
-        if (decl->var_decl.member_count == 0 && decl->var_decl.tag) {
-            symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
+    if (decl->data.var_decl.type == TYPE_STRUCT) {
+        if (decl->data.var_decl.member_count == 0 && decl->data.var_decl.tag) {
+            symbol_t *stype = symtable_lookup_struct(globals, decl->data.var_decl.tag);
             if (!stype)
                 return 0;
             return copy_struct_metadata(sym, stype->struct_members,
@@ -186,9 +186,9 @@ int copy_aggregate_metadata(stmt_t *decl, symbol_t *sym,
                                         stype->struct_total_size);
         }
         return copy_struct_metadata(sym,
-                                    (struct_member_t *)decl->var_decl.members,
-                                    decl->var_decl.member_count,
-                                    decl->var_decl.elem_size);
+                                    (struct_member_t *)decl->data.var_decl.members,
+                                    decl->data.var_decl.member_count,
+                                    decl->data.var_decl.elem_size);
     }
 
     return 1;

--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -36,10 +36,10 @@ int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         !label_format_suffix("L", id, "_end", end_label))
         return 0;
     ir_build_label(ir, start_label);
-    if (check_expr(stmt->while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
+    if (check_expr(stmt->data.while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
     ir_build_bcond(ir, cond_val, end_label);
-    if (!check_stmt(stmt->while_stmt.body, vars, funcs, labels, ir,
+    if (!check_stmt(stmt->data.while_stmt.body, vars, funcs, labels, ir,
                     func_ret_type, end_label, start_label))
         return 0;
     ir_build_br(ir, start_label);
@@ -67,11 +67,11 @@ int check_do_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         !label_format_suffix("L", id, "_end", end_label))
         return 0;
     ir_build_label(ir, start_label);
-    if (!check_stmt(stmt->do_while_stmt.body, vars, funcs, labels, ir,
+    if (!check_stmt(stmt->data.do_while_stmt.body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cond_label))
         return 0;
     ir_build_label(ir, cond_label);
-    if (check_expr(stmt->do_while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
+    if (check_expr(stmt->data.do_while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
     ir_build_bcond(ir, cond_val, end_label);
     ir_build_br(ir, start_label);
@@ -98,20 +98,20 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         !label_format_suffix("L", id, "_end", end_label))
         return 0;
     symbol_t *old_head = vars->head;
-    if (stmt->for_stmt.init_decl) {
-        if (!check_stmt(stmt->for_stmt.init_decl, vars, funcs, labels, ir,
+    if (stmt->data.for_stmt.init_decl) {
+        if (!check_stmt(stmt->data.for_stmt.init_decl, vars, funcs, labels, ir,
                         func_ret_type, NULL, NULL)) {
             symtable_pop_scope(vars, old_head);
             return 0;
         }
     } else {
-        if (check_expr(stmt->for_stmt.init, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+        if (check_expr(stmt->data.for_stmt.init, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
             symtable_pop_scope(vars, old_head);
             return 0; /* reuse cond_val for init but ignore value */
         }
     }
     ir_build_label(ir, start_label);
-    if (check_expr(stmt->for_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+    if (check_expr(stmt->data.for_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
         symtable_pop_scope(vars, old_head);
         return 0;
     }
@@ -121,13 +121,13 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         symtable_pop_scope(vars, old_head);
         return 0;
     }
-    if (!check_stmt(stmt->for_stmt.body, vars, funcs, labels, ir,
+    if (!check_stmt(stmt->data.for_stmt.body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cont_label)) {
         symtable_pop_scope(vars, old_head);
         return 0;
     }
     ir_build_label(ir, cont_label);
-    if (check_expr(stmt->for_stmt.incr, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+    if (check_expr(stmt->data.for_stmt.incr, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
         symtable_pop_scope(vars, old_head);
         return 0;
     }

--- a/src/semantic_return.c
+++ b/src/semantic_return.c
@@ -10,7 +10,7 @@ static int validate_struct_return(stmt_t *stmt, symtable_t *vars,
                                   type_kind_t func_ret_type)
 {
     if (expr_type != func_ret_type) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+        error_set(stmt->data.ret.expr->line, stmt->data.ret.expr->column,
                   error_current_file, error_current_function);
         return 0;
     }
@@ -21,23 +21,23 @@ static int validate_struct_return(stmt_t *stmt, symtable_t *vars,
     size_t expected = func_sym ? func_sym->ret_struct_size : 0;
     size_t actual = 0;
 
-    if (stmt->ret.expr->kind == EXPR_IDENT) {
-        symbol_t *vsym = symtable_lookup(vars, stmt->ret.expr->ident.name);
+    if (stmt->data.ret.expr->kind == EXPR_IDENT) {
+        symbol_t *vsym = symtable_lookup(vars, stmt->data.ret.expr->ident.name);
         if (vsym)
             actual = (expr_type == TYPE_STRUCT)
                 ? vsym->struct_total_size : vsym->total_size;
-    } else if (stmt->ret.expr->kind == EXPR_CALL) {
-        symbol_t *fsym = symtable_lookup(funcs, stmt->ret.expr->call.name);
+    } else if (stmt->data.ret.expr->kind == EXPR_CALL) {
+        symbol_t *fsym = symtable_lookup(funcs, stmt->data.ret.expr->call.name);
         if (!fsym)
-            fsym = symtable_lookup(vars, stmt->ret.expr->call.name);
+            fsym = symtable_lookup(vars, stmt->data.ret.expr->call.name);
         if (fsym)
             actual = fsym->ret_struct_size;
-    } else if (stmt->ret.expr->kind == EXPR_COMPLIT) {
-        actual = stmt->ret.expr->compound.elem_size;
+    } else if (stmt->data.ret.expr->kind == EXPR_COMPLIT) {
+        actual = stmt->data.ret.expr->compound.elem_size;
     }
 
     if (expected && actual && expected != actual) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+        error_set(stmt->data.ret.expr->line, stmt->data.ret.expr->column,
                   error_current_file, error_current_function);
         return 0;
     }
@@ -49,7 +49,7 @@ static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
                               symtable_t *funcs, ir_builder_t *ir,
                               type_kind_t func_ret_type)
 {
-    if (!stmt->ret.expr) {
+    if (!stmt->data.ret.expr) {
         if (func_ret_type != TYPE_VOID) {
             error_set(stmt->line, stmt->column, error_current_file, error_current_function);
             return 0;
@@ -60,9 +60,9 @@ static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
     }
 
     ir_value_t val;
-    type_kind_t vt = check_expr(stmt->ret.expr, vars, funcs, ir, &val);
+    type_kind_t vt = check_expr(stmt->data.ret.expr, vars, funcs, ir, &val);
     if (vt == TYPE_UNKNOWN) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+        error_set(stmt->data.ret.expr->line, stmt->data.ret.expr->column,
                   error_current_file, error_current_function);
         return 0;
     }

--- a/src/semantic_static_assert.c
+++ b/src/semantic_static_assert.c
@@ -7,14 +7,14 @@
 static int check_static_assert_stmt(stmt_t *stmt, symtable_t *vars)
 {
     long long val;
-    if (!eval_const_expr(stmt->static_assert.expr, vars, 0, &val)) {
-        error_set(stmt->static_assert.expr->line, stmt->static_assert.expr->column,
+    if (!eval_const_expr(stmt->data.static_assert.expr, vars, 0, &val)) {
+        error_set(stmt->data.static_assert.expr->line, stmt->data.static_assert.expr->column,
                   error_current_file, error_current_function);
         return 0;
     }
     if (val == 0) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        error_print(stmt->static_assert.message);
+        error_print(stmt->data.static_assert.message);
         return 0;
     }
     return 1;

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -136,7 +136,7 @@ static const char *find_end_label(func_t *func)
     for (size_t i = func->body_count; i-- > 0;) {
         stmt_t *s = func->body[i];
         if (s->kind == STMT_LABEL)
-            return s->label.name;
+            return s->data.label.name;
         if (s->kind != STMT_RETURN)
             break;
     }
@@ -154,7 +154,7 @@ void warn_unreachable_function(func_t *func, symtable_t *funcs)
         stmt_t *s = func->body[i];
         if (!reachable) {
             if (!(s->kind == STMT_LABEL && end_label &&
-                  strcmp(s->label.name, end_label) == 0)) {
+                  strcmp(s->data.label.name, end_label) == 0)) {
                 error_set(s->line, s->column, error_current_file,
                           error_current_function);
                 error_print("warning: unreachable statement");
@@ -163,18 +163,18 @@ void warn_unreachable_function(func_t *func, symtable_t *funcs)
         if (s->kind == STMT_RETURN)
             reachable = 0;
         else if (s->kind == STMT_GOTO && end_label &&
-                 strcmp(s->goto_stmt.name, end_label) == 0)
+                 strcmp(s->data.goto_stmt.name, end_label) == 0)
             reachable = 0;
         else if (s->kind == STMT_LABEL && end_label &&
-                 strcmp(s->label.name, end_label) == 0)
+                 strcmp(s->data.label.name, end_label) == 0)
             reachable = 1;
-        else if (s->kind == STMT_EXPR && s->expr.expr &&
-                 s->expr.expr->kind == EXPR_CALL) {
-            symbol_t *fs = symtable_lookup(funcs, s->expr.expr->call.name);
+        else if (s->kind == STMT_EXPR && s->data.expr.expr &&
+                 s->data.expr.expr->kind == EXPR_CALL) {
+            symbol_t *fs = symtable_lookup(funcs, s->data.expr.expr->call.name);
             if (fs && fs->is_noreturn) {
                 if (i + 1 < func->body_count &&
                     !(func->body[i+1]->kind == STMT_LABEL && end_label &&
-                      strcmp(func->body[i+1]->label.name, end_label) == 0)) {
+                      strcmp(func->body[i+1]->data.label.name, end_label) == 0)) {
                     error_set(s->line, s->column, error_current_file,
                               error_current_function);
                     error_print("warning: non-returning call without terminator");

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -186,7 +186,7 @@ static void test_parser_stmt_return(void)
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_RETURN);
-    ASSERT(stmt->ret.expr->kind == EXPR_NUMBER && strcmp(stmt->ret.expr->number.value, "5") == 0);
+    ASSERT(stmt->data.ret.expr->kind == EXPR_NUMBER && strcmp(stmt->data.ret.expr->number.value, "5") == 0);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -201,7 +201,7 @@ static void test_parser_stmt_return_void(void)
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_RETURN);
-    ASSERT(stmt->ret.expr == NULL);
+    ASSERT(stmt->data.ret.expr == NULL);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -216,10 +216,10 @@ static void test_parser_var_decl_init(void)
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_VAR_DECL);
-    ASSERT(strcmp(stmt->var_decl.name, "x") == 0);
-    ASSERT(stmt->var_decl.type == TYPE_INT);
-    ASSERT(stmt->var_decl.init && stmt->var_decl.init->kind == EXPR_NUMBER &&
-           strcmp(stmt->var_decl.init->number.value, "5") == 0);
+    ASSERT(strcmp(stmt->data.var_decl.name, "x") == 0);
+    ASSERT(stmt->data.var_decl.type == TYPE_INT);
+    ASSERT(stmt->data.var_decl.init && stmt->data.var_decl.init->kind == EXPR_NUMBER &&
+           strcmp(stmt->data.var_decl.init->number.value, "5") == 0);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -233,7 +233,7 @@ static void test_parser_short_decl(void)
     parser_t p; parser_init(&p, toks, count);
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
-    ASSERT(stmt->var_decl.type == TYPE_SHORT);
+    ASSERT(stmt->data.var_decl.type == TYPE_SHORT);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -247,7 +247,7 @@ static void test_parser_bool_decl(void)
     parser_t p; parser_init(&p, toks, count);
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
-    ASSERT(stmt->var_decl.type == TYPE_BOOL);
+    ASSERT(stmt->data.var_decl.type == TYPE_BOOL);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -261,7 +261,7 @@ static void test_parser__Bool_decl(void)
     parser_t p; parser_init(&p, toks, count);
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
-    ASSERT(stmt->var_decl.type == TYPE_BOOL);
+    ASSERT(stmt->data.var_decl.type == TYPE_BOOL);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -275,7 +275,7 @@ static void test_parser_float_complex_decl(void)
     parser_t p; parser_init(&p, toks, count);
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
-    ASSERT(stmt->var_decl.type == TYPE_FLOAT_COMPLEX);
+    ASSERT(stmt->data.var_decl.type == TYPE_FLOAT_COMPLEX);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -289,7 +289,7 @@ static void test_parser_double_complex_decl(void)
     parser_t p; parser_init(&p, toks, count);
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
-    ASSERT(stmt->var_decl.type == TYPE_DOUBLE_COMPLEX);
+    ASSERT(stmt->data.var_decl.type == TYPE_DOUBLE_COMPLEX);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -303,7 +303,7 @@ static void test_parser_long_double_complex_decl(void)
     parser_t p; parser_init(&p, toks, count);
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt && stmt->kind == STMT_VAR_DECL);
-    ASSERT(stmt->var_decl.type == TYPE_LDOUBLE_COMPLEX);
+    ASSERT(stmt->data.var_decl.type == TYPE_LDOUBLE_COMPLEX);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -326,7 +326,7 @@ static void test_parser_static_local(void)
     token_t *toks = lexer_tokenize(src, &count);
     parser_t p; parser_init(&p, toks, count);
     stmt_t *stmt = parser_parse_stmt(&p);
-    ASSERT(stmt && stmt->kind == STMT_VAR_DECL && stmt->var_decl.is_static);
+    ASSERT(stmt && stmt->kind == STMT_VAR_DECL && stmt->data.var_decl.is_static);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -341,9 +341,9 @@ static void test_parser_array_decl(void)
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_VAR_DECL);
-    ASSERT(strcmp(stmt->var_decl.name, "a") == 0);
-    ASSERT(stmt->var_decl.type == TYPE_ARRAY);
-    ASSERT(stmt->var_decl.array_size == 4);
+    ASSERT(strcmp(stmt->data.var_decl.name, "a") == 0);
+    ASSERT(stmt->data.var_decl.type == TYPE_ARRAY);
+    ASSERT(stmt->data.var_decl.array_size == 4);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -426,8 +426,8 @@ static void test_parser_global_init(void)
     ASSERT(parser_parse_toplevel(&p, &funcs, &fn, &global));
     ASSERT(fn == NULL);
     ASSERT(global && global->kind == STMT_VAR_DECL);
-    ASSERT(strcmp(global->var_decl.name, "y") == 0);
-    ASSERT(global->var_decl.init && global->var_decl.init->kind == EXPR_BINARY);
+    ASSERT(strcmp(global->data.var_decl.name, "y") == 0);
+    ASSERT(global->data.var_decl.init && global->data.var_decl.init->kind == EXPR_BINARY);
     symtable_free(&funcs);
     ast_free_stmt(global);
     lexer_free_tokens(toks, count);
@@ -550,11 +550,11 @@ static void test_parser_block(void)
     stmt_t *stmt = parser_parse_stmt(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_BLOCK);
-    ASSERT(stmt->block.count == 2);
-    ASSERT(stmt->block.stmts[0]->kind == STMT_VAR_DECL);
-    ASSERT(stmt->block.stmts[1]->kind == STMT_BLOCK);
-    ASSERT(stmt->block.stmts[1]->block.count == 1);
-    ASSERT(stmt->block.stmts[1]->block.stmts[0]->kind == STMT_VAR_DECL);
+    ASSERT(stmt->data.block.count == 2);
+    ASSERT(stmt->data.block.stmts[0]->kind == STMT_VAR_DECL);
+    ASSERT(stmt->data.block.stmts[1]->kind == STMT_BLOCK);
+    ASSERT(stmt->data.block.stmts[1]->data.block.count == 1);
+    ASSERT(stmt->data.block.stmts[1]->data.block.stmts[0]->kind == STMT_VAR_DECL);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -569,9 +569,9 @@ static void test_parser_bitfield(void)
     stmt_t *stmt = parser_parse_struct_decl(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_STRUCT_DECL);
-    ASSERT(stmt->struct_decl.count == 1);
-    ASSERT(strcmp(stmt->struct_decl.members[0].name, "f") == 0);
-    ASSERT(stmt->struct_decl.members[0].bit_width == 1);
+    ASSERT(stmt->data.struct_decl.count == 1);
+    ASSERT(strcmp(stmt->data.struct_decl.members[0].name, "f") == 0);
+    ASSERT(stmt->data.struct_decl.members[0].bit_width == 1);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -586,10 +586,10 @@ static void test_parser_member_helpers(void)
     stmt_t *stmt = parser_parse_struct_decl(&p);
     ASSERT(stmt);
     ASSERT(stmt->kind == STMT_STRUCT_DECL);
-    ASSERT(stmt->struct_decl.count == 3);
-    ASSERT(strcmp(stmt->struct_decl.members[0].name, "a") == 0);
-    ASSERT(stmt->struct_decl.members[1].type == TYPE_ARRAY);
-    ASSERT(stmt->struct_decl.members[2].bit_width == 3);
+    ASSERT(stmt->data.struct_decl.count == 3);
+    ASSERT(strcmp(stmt->data.struct_decl.members[0].name, "a") == 0);
+    ASSERT(stmt->data.struct_decl.members[1].type == TYPE_ARRAY);
+    ASSERT(stmt->data.struct_decl.members[2].bit_width == 3);
     ast_free_stmt(stmt);
     lexer_free_tokens(toks, count);
 }
@@ -606,8 +606,8 @@ static void test_parser_struct_tag_var(void)
     ASSERT(parser_parse_toplevel(&p, &funcs, &fn, &global));
     ASSERT(fn == NULL);
     ASSERT(global && global->kind == STMT_VAR_DECL);
-    ASSERT(global->var_decl.type == TYPE_STRUCT);
-    ASSERT(strcmp(global->var_decl.tag, "S") == 0);
+    ASSERT(global->data.var_decl.type == TYPE_STRUCT);
+    ASSERT(strcmp(global->data.var_decl.tag, "S") == 0);
     symtable_free(&funcs);
     ast_free_stmt(global);
     lexer_free_tokens(toks, count);


### PR DESCRIPTION
## Summary
- define a reusable `union stmt_data` in `ast_stmt.h`
- update `struct stmt` to hold `union stmt_data data`
- adjust all statement accesses to use the new `data` member
- refresh tests and rebuild

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6871be35966c8324a338dd0a757e07b7