### PR TITLE
Fix vcflags allocation for sign correctness

### DIFF
--- a/src/cli_env.c
+++ b/src/cli_env.c
@@ -9,7 +9,7 @@ int load_vcflags(int *argc, char ***argv, char ***out_argv,
 {
     char **vcargv = NULL;
     char *vcbuf = NULL;
-    int vcargc = 0;
+    size_t vcargc = 0;
     const char *env = getenv("VCFLAGS");
     if (env && *env) {
         vcbuf = vc_strdup(env);
@@ -28,7 +28,8 @@ int load_vcflags(int *argc, char ***argv, char ***out_argv,
             vcargc++;
         free(tmp);
 
-        vcargv = malloc(sizeof(char *) * (size_t)(*argc + vcargc));
+        size_t alloc_sz = sizeof(char *) * ((size_t)*argc + vcargc);
+        vcargv = malloc(alloc_sz);
         if (!vcargv) {
             fprintf(stderr, "Out of memory while processing VCFLAGS.\n");
             free(vcbuf);
@@ -36,14 +37,14 @@ int load_vcflags(int *argc, char ***argv, char ***out_argv,
         }
 
         vcargv[0] = (*argv)[0];
-        int idx = 1;
+        size_t idx = 1;
         for (char *t = strtok(vcbuf, " "); t; t = strtok(NULL, " "))
             vcargv[idx++] = t;
         for (int i = 1; i < *argc; i++)
             vcargv[idx++] = (*argv)[i];
 
         *argv = vcargv;
-        *argc += vcargc;
+        *argc += (int)vcargc;
     }
 
     *out_argv = vcargv;


### PR DESCRIPTION
## Summary
- store VCFLAGS argument count as `size_t`
- compute allocation size using `sizeof(char *) * ((size_t)*argc + vcargc)`
- index the argument array with `size_t`
- cast back to `int` when updating `argc`

## Testing
- `make CFLAGS="-Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -std=c99" src/cli_env.o`
- `make test -s`

------
https://chatgpt.com/codex/tasks/task_e_6871bdf335e88324828e5af8530f0bea