### PR TITLE
Add named union field and macros for stmt

### DIFF
--- a/include/ast_stmt.h
+++ b/include/ast_stmt.h
@@ -47,109 +47,129 @@ struct struct_member {
     int is_flexible;
 };
 
+union stmt_data {
+    struct {
+        expr_t *expr;
+    } expr;
+    struct {
+        /* expression may be NULL for 'return;' in void functions */
+        expr_t *expr;
+    } ret;
+    struct {
+        char *name;
+        type_kind_t type;
+        size_t array_size;
+        expr_t *size_expr;
+        expr_t *align_expr;
+        size_t alignment;
+        size_t elem_size;
+        char *tag; /* NULL for basic types */
+        int is_static;
+        int is_register;
+        int is_extern;
+        int is_const;
+        int is_volatile;
+        int is_restrict;
+        /* optional initializer expression */
+        expr_t *init;
+        /* optional initializer list for arrays */
+        init_entry_t *init_list;
+        size_t init_count;
+        union_member_t *members;
+        size_t member_count;
+        /* function pointer metadata */
+        type_kind_t func_ret_type;
+        type_kind_t *func_param_types;
+        size_t func_param_count;
+        int func_variadic;
+    } var_decl;
+    struct {
+        expr_t *cond;
+        stmt_t *then_branch;
+        stmt_t *else_branch; /* may be NULL */
+    } if_stmt;
+    struct {
+        expr_t *cond;
+        stmt_t *body;
+    } while_stmt;
+    struct {
+        expr_t *cond;
+        stmt_t *body;
+    } do_while_stmt;
+    struct {
+        stmt_t *init_decl; /* optional variable declaration */
+        expr_t *init;       /* optional init expression */
+        expr_t *cond;
+        expr_t *incr;
+        stmt_t *body;
+    } for_stmt;
+    struct {
+        expr_t *expr;
+        switch_case_t *cases;
+        size_t case_count;
+        stmt_t *default_body; /* may be NULL */
+    } switch_stmt;
+    struct {
+        char *name;
+    } label;
+    struct {
+        char *name;
+    } goto_stmt;
+    struct {
+        expr_t *expr;
+        char *message;
+    } static_assert;
+    struct {
+        char *name;
+        type_kind_t type;
+        size_t array_size;
+        size_t elem_size;
+    } typedef_decl;
+    struct {
+        char *tag;
+        enumerator_t *items;
+        size_t count;
+    } enum_decl;
+    struct {
+        char *tag;
+        struct_member_t *members;
+        size_t count;
+    } struct_decl;
+    struct {
+        char *tag;
+        union_member_t *members;
+        size_t count;
+    } union_decl;
+    struct {
+        stmt_t **stmts;
+        size_t count;
+    } block;
+};
+
 struct stmt {
     stmt_kind_t kind;
     size_t line;
     size_t column;
-    union {
-        struct {
-            expr_t *expr;
-        } expr;
-        struct {
-            /* expression may be NULL for 'return;' in void functions */
-            expr_t *expr;
-        } ret;
-        struct {
-            char *name;
-            type_kind_t type;
-            size_t array_size;
-            expr_t *size_expr;
-            expr_t *align_expr;
-            size_t alignment;
-            size_t elem_size;
-            char *tag; /* NULL for basic types */
-            int is_static;
-            int is_register;
-            int is_extern;
-            int is_const;
-            int is_volatile;
-            int is_restrict;
-            /* optional initializer expression */
-            expr_t *init;
-            /* optional initializer list for arrays */
-            init_entry_t *init_list;
-            size_t init_count;
-            union_member_t *members;
-            size_t member_count;
-            /* function pointer metadata */
-            type_kind_t func_ret_type;
-            type_kind_t *func_param_types;
-            size_t func_param_count;
-            int func_variadic;
-        } var_decl;
-        struct {
-            expr_t *cond;
-            stmt_t *then_branch;
-            stmt_t *else_branch; /* may be NULL */
-        } if_stmt;
-        struct {
-            expr_t *cond;
-            stmt_t *body;
-        } while_stmt;
-        struct {
-            expr_t *cond;
-            stmt_t *body;
-        } do_while_stmt;
-        struct {
-            stmt_t *init_decl; /* optional variable declaration */
-            expr_t *init;       /* optional init expression */
-            expr_t *cond;
-            expr_t *incr;
-            stmt_t *body;
-        } for_stmt;
-        struct {
-            expr_t *expr;
-            switch_case_t *cases;
-            size_t case_count;
-            stmt_t *default_body; /* may be NULL */
-        } switch_stmt;
-        struct {
-            char *name;
-        } label;
-        struct {
-            char *name;
-        } goto_stmt;
-        struct {
-            expr_t *expr;
-            char *message;
-        } static_assert;
-        struct {
-            char *name;
-            type_kind_t type;
-            size_t array_size;
-            size_t elem_size;
-        } typedef_decl;
-        struct {
-            char *tag;
-            enumerator_t *items;
-            size_t count;
-        } enum_decl;
-        struct {
-            char *tag;
-            struct_member_t *members;
-            size_t count;
-        } struct_decl;
-        struct {
-            char *tag;
-            union_member_t *members;
-            size_t count;
-        } union_decl;
-        struct {
-            stmt_t **stmts;
-            size_t count;
-        } block;
-    };
+    union stmt_data data;
 };
+
+/* Convenience macros for accessing statement data */
+#define STMT_EXPR(s)        ((s)->data.expr)
+#define STMT_RET(s)         ((s)->data.ret)
+#define STMT_VAR_DECL(s)    ((s)->data.var_decl)
+#define STMT_IF(s)          ((s)->data.if_stmt)
+#define STMT_WHILE(s)       ((s)->data.while_stmt)
+#define STMT_DO_WHILE(s)    ((s)->data.do_while_stmt)
+#define STMT_FOR(s)         ((s)->data.for_stmt)
+#define STMT_SWITCH(s)      ((s)->data.switch_stmt)
+#define STMT_LABEL(s)       ((s)->data.label)
+#define STMT_GOTO(s)        ((s)->data.goto_stmt)
+#define STMT_STATIC_ASSERT(s) ((s)->data.static_assert)
+#define STMT_TYPEDEF(s)     ((s)->data.typedef_decl)
+#define STMT_ENUM_DECL(s)   ((s)->data.enum_decl)
+#define STMT_STRUCT_DECL(s) ((s)->data.struct_decl)
+#define STMT_UNION_DECL(s)  ((s)->data.union_decl)
+#define STMT_BLOCK(s)       ((s)->data.block)
 
 /* Function definition structure */
 struct func {

--- a/src/ast_dump.c
+++ b/src/ast_dump.c
@@ -154,49 +154,49 @@ static void dump_stmt(strbuf_t *sb, const stmt_t *s, int lvl)
     strbuf_appendf(sb, "%s\n", stmt_name(s->kind));
     switch (s->kind) {
     case STMT_EXPR:
-        dump_expr(sb, s->expr.expr, lvl + 1);
+        dump_expr(sb, STMT_EXPR(s).expr, lvl + 1);
         break;
     case STMT_RETURN:
-        dump_expr(sb, s->ret.expr, lvl + 1);
+        dump_expr(sb, STMT_RET(s).expr, lvl + 1);
         break;
     case STMT_VAR_DECL:
-        if (s->var_decl.init)
-            dump_expr(sb, s->var_decl.init, lvl + 1);
+        if (STMT_VAR_DECL(s).init)
+            dump_expr(sb, STMT_VAR_DECL(s).init, lvl + 1);
         break;
     case STMT_IF:
-        dump_expr(sb, s->if_stmt.cond, lvl + 1);
-        dump_stmt(sb, s->if_stmt.then_branch, lvl + 1);
-        dump_stmt(sb, s->if_stmt.else_branch, lvl + 1);
+        dump_expr(sb, STMT_IF(s).cond, lvl + 1);
+        dump_stmt(sb, STMT_IF(s).then_branch, lvl + 1);
+        dump_stmt(sb, STMT_IF(s).else_branch, lvl + 1);
         break;
     case STMT_WHILE:
-        dump_expr(sb, s->while_stmt.cond, lvl + 1);
-        dump_stmt(sb, s->while_stmt.body, lvl + 1);
+        dump_expr(sb, STMT_WHILE(s).cond, lvl + 1);
+        dump_stmt(sb, STMT_WHILE(s).body, lvl + 1);
         break;
     case STMT_DO_WHILE:
-        dump_stmt(sb, s->do_while_stmt.body, lvl + 1);
-        dump_expr(sb, s->do_while_stmt.cond, lvl + 1);
+        dump_stmt(sb, STMT_DO_WHILE(s).body, lvl + 1);
+        dump_expr(sb, STMT_DO_WHILE(s).cond, lvl + 1);
         break;
     case STMT_FOR:
-        if (s->for_stmt.init_decl)
-            dump_stmt(sb, s->for_stmt.init_decl, lvl + 1);
+        if (STMT_FOR(s).init_decl)
+            dump_stmt(sb, STMT_FOR(s).init_decl, lvl + 1);
         else
-            dump_expr(sb, s->for_stmt.init, lvl + 1);
-        dump_expr(sb, s->for_stmt.cond, lvl + 1);
-        dump_expr(sb, s->for_stmt.incr, lvl + 1);
-        dump_stmt(sb, s->for_stmt.body, lvl + 1);
+            dump_expr(sb, STMT_FOR(s).init, lvl + 1);
+        dump_expr(sb, STMT_FOR(s).cond, lvl + 1);
+        dump_expr(sb, STMT_FOR(s).incr, lvl + 1);
+        dump_stmt(sb, STMT_FOR(s).body, lvl + 1);
         break;
     case STMT_SWITCH:
-        dump_expr(sb, s->switch_stmt.expr, lvl + 1);
-        for (size_t i = 0; i < s->switch_stmt.case_count; i++) {
-            dump_expr(sb, s->switch_stmt.cases[i].expr, lvl + 1);
-            dump_stmt(sb, s->switch_stmt.cases[i].body, lvl + 2);
+        dump_expr(sb, STMT_SWITCH(s).expr, lvl + 1);
+        for (size_t i = 0; i < STMT_SWITCH(s).case_count; i++) {
+            dump_expr(sb, STMT_SWITCH(s).cases[i].expr, lvl + 1);
+            dump_stmt(sb, STMT_SWITCH(s).cases[i].body, lvl + 2);
         }
-        dump_stmt(sb, s->switch_stmt.default_body, lvl + 1);
+        dump_stmt(sb, STMT_SWITCH(s).default_body, lvl + 1);
         break;
     case STMT_LABEL:
         indent(sb, lvl + 1);
-        if (s->label.name)
-            strbuf_appendf(sb, "label: %s\n", s->label.name);
+        if (STMT_LABEL(s).name)
+            strbuf_appendf(sb, "label: %s\n", STMT_LABEL(s).name);
         break;
     case STMT_GOTO:
     case STMT_BREAK:
@@ -208,7 +208,7 @@ static void dump_stmt(strbuf_t *sb, const stmt_t *s, int lvl)
     case STMT_UNION_DECL:
         break;
     case STMT_BLOCK:
-        dump_block(sb, s->block.stmts, s->block.count, lvl + 1);
+        dump_block(sb, STMT_BLOCK(s).stmts, STMT_BLOCK(s).count, lvl + 1);
         break;
     }
 }

--- a/src/ast_stmt_create.c
+++ b/src/ast_stmt_create.c
@@ -24,7 +24,7 @@ stmt_t *ast_make_expr_stmt(expr_t *expr, size_t line, size_t column)
     stmt->kind = STMT_EXPR;
     stmt->line = line;
     stmt->column = column;
-    stmt->expr.expr = expr;
+    STMT_EXPR(stmt).expr = expr;
     return stmt;
 }
 
@@ -37,7 +37,7 @@ stmt_t *ast_make_return(expr_t *expr, size_t line, size_t column)
     stmt->kind = STMT_RETURN;
     stmt->line = line;
     stmt->column = column;
-    stmt->ret.expr = expr;
+    STMT_RET(stmt).expr = expr;
     return stmt;
 }
 
@@ -56,42 +56,42 @@ stmt_t *ast_make_var_decl(const char *name, type_kind_t type, size_t array_size,
     stmt->kind = STMT_VAR_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->var_decl.name = vc_strdup(name ? name : "");
-    if (!stmt->var_decl.name) {
+    STMT_VAR_DECL(stmt).name = vc_strdup(name ? name : "");
+    if (!STMT_VAR_DECL(stmt).name) {
         free(stmt);
         return NULL;
     }
-    stmt->var_decl.type = type;
-    stmt->var_decl.array_size = array_size;
-    stmt->var_decl.size_expr = size_expr;
-    stmt->var_decl.align_expr = align_expr;
-    stmt->var_decl.alignment = 0;
-    stmt->var_decl.elem_size = elem_size;
+    STMT_VAR_DECL(stmt).type = type;
+    STMT_VAR_DECL(stmt).array_size = array_size;
+    STMT_VAR_DECL(stmt).size_expr = size_expr;
+    STMT_VAR_DECL(stmt).align_expr = align_expr;
+    STMT_VAR_DECL(stmt).alignment = 0;
+    STMT_VAR_DECL(stmt).elem_size = elem_size;
     if (tag) {
-        stmt->var_decl.tag = vc_strdup(tag);
-        if (!stmt->var_decl.tag) {
-            free(stmt->var_decl.name);
+        STMT_VAR_DECL(stmt).tag = vc_strdup(tag);
+        if (!STMT_VAR_DECL(stmt).tag) {
+            free(STMT_VAR_DECL(stmt).name);
             free(stmt);
             return NULL;
         }
     } else {
-        stmt->var_decl.tag = NULL;
+        STMT_VAR_DECL(stmt).tag = NULL;
     }
-    stmt->var_decl.is_static = is_static;
-    stmt->var_decl.is_register = is_register;
-    stmt->var_decl.is_extern = is_extern;
-    stmt->var_decl.is_const = is_const;
-    stmt->var_decl.is_volatile = is_volatile;
-    stmt->var_decl.is_restrict = is_restrict;
-    stmt->var_decl.init = init;
-    stmt->var_decl.init_list = init_list;
-    stmt->var_decl.init_count = init_count;
-    stmt->var_decl.members = members;
-    stmt->var_decl.member_count = member_count;
-    stmt->var_decl.func_ret_type = TYPE_UNKNOWN;
-    stmt->var_decl.func_param_types = NULL;
-    stmt->var_decl.func_param_count = 0;
-    stmt->var_decl.func_variadic = 0;
+    STMT_VAR_DECL(stmt).is_static = is_static;
+    STMT_VAR_DECL(stmt).is_register = is_register;
+    STMT_VAR_DECL(stmt).is_extern = is_extern;
+    STMT_VAR_DECL(stmt).is_const = is_const;
+    STMT_VAR_DECL(stmt).is_volatile = is_volatile;
+    STMT_VAR_DECL(stmt).is_restrict = is_restrict;
+    STMT_VAR_DECL(stmt).init = init;
+    STMT_VAR_DECL(stmt).init_list = init_list;
+    STMT_VAR_DECL(stmt).init_count = init_count;
+    STMT_VAR_DECL(stmt).members = members;
+    STMT_VAR_DECL(stmt).member_count = member_count;
+    STMT_VAR_DECL(stmt).func_ret_type = TYPE_UNKNOWN;
+    STMT_VAR_DECL(stmt).func_param_types = NULL;
+    STMT_VAR_DECL(stmt).func_param_count = 0;
+    STMT_VAR_DECL(stmt).func_variadic = 0;
     return stmt;
 }
 
@@ -105,9 +105,9 @@ stmt_t *ast_make_if(expr_t *cond, stmt_t *then_branch, stmt_t *else_branch,
     stmt->kind = STMT_IF;
     stmt->line = line;
     stmt->column = column;
-    stmt->if_stmt.cond = cond;
-    stmt->if_stmt.then_branch = then_branch;
-    stmt->if_stmt.else_branch = else_branch;
+    STMT_IF(stmt).cond = cond;
+    STMT_IF(stmt).then_branch = then_branch;
+    STMT_IF(stmt).else_branch = else_branch;
     return stmt;
 }
 
@@ -121,8 +121,8 @@ stmt_t *ast_make_while(expr_t *cond, stmt_t *body,
     stmt->kind = STMT_WHILE;
     stmt->line = line;
     stmt->column = column;
-    stmt->while_stmt.cond = cond;
-    stmt->while_stmt.body = body;
+    STMT_WHILE(stmt).cond = cond;
+    STMT_WHILE(stmt).body = body;
     return stmt;
 }
 
@@ -136,8 +136,8 @@ stmt_t *ast_make_do_while(expr_t *cond, stmt_t *body,
     stmt->kind = STMT_DO_WHILE;
     stmt->line = line;
     stmt->column = column;
-    stmt->do_while_stmt.cond = cond;
-    stmt->do_while_stmt.body = body;
+    STMT_DO_WHILE(stmt).cond = cond;
+    STMT_DO_WHILE(stmt).body = body;
     return stmt;
 }
 
@@ -152,11 +152,11 @@ stmt_t *ast_make_for(stmt_t *init_decl, expr_t *init, expr_t *cond,
     stmt->kind = STMT_FOR;
     stmt->line = line;
     stmt->column = column;
-    stmt->for_stmt.init_decl = init_decl;
-    stmt->for_stmt.init = init;
-    stmt->for_stmt.cond = cond;
-    stmt->for_stmt.incr = incr;
-    stmt->for_stmt.body = body;
+    STMT_FOR(stmt).init_decl = init_decl;
+    STMT_FOR(stmt).init = init;
+    STMT_FOR(stmt).cond = cond;
+    STMT_FOR(stmt).incr = incr;
+    STMT_FOR(stmt).body = body;
     return stmt;
 }
 
@@ -170,10 +170,10 @@ stmt_t *ast_make_switch(expr_t *expr, switch_case_t *cases, size_t case_count,
     stmt->kind = STMT_SWITCH;
     stmt->line = line;
     stmt->column = column;
-    stmt->switch_stmt.expr = expr;
-    stmt->switch_stmt.cases = cases;
-    stmt->switch_stmt.case_count = case_count;
-    stmt->switch_stmt.default_body = default_body;
+    STMT_SWITCH(stmt).expr = expr;
+    STMT_SWITCH(stmt).cases = cases;
+    STMT_SWITCH(stmt).case_count = case_count;
+    STMT_SWITCH(stmt).default_body = default_body;
     return stmt;
 }
 
@@ -210,8 +210,8 @@ stmt_t *ast_make_label(const char *name, size_t line, size_t column)
     stmt->kind = STMT_LABEL;
     stmt->line = line;
     stmt->column = column;
-    stmt->label.name = vc_strdup(name ? name : "");
-    if (!stmt->label.name) {
+    STMT_LABEL(stmt).name = vc_strdup(name ? name : "");
+    if (!STMT_LABEL(stmt).name) {
         free(stmt);
         return NULL;
     }
@@ -227,8 +227,8 @@ stmt_t *ast_make_goto(const char *name, size_t line, size_t column)
     stmt->kind = STMT_GOTO;
     stmt->line = line;
     stmt->column = column;
-    stmt->goto_stmt.name = vc_strdup(name ? name : "");
-    if (!stmt->goto_stmt.name) {
+    STMT_GOTO(stmt).name = vc_strdup(name ? name : "");
+    if (!STMT_GOTO(stmt).name) {
         free(stmt);
         return NULL;
     }
@@ -245,9 +245,9 @@ stmt_t *ast_make_static_assert(expr_t *expr, const char *msg,
     stmt->kind = STMT_STATIC_ASSERT;
     stmt->line = line;
     stmt->column = column;
-    stmt->static_assert.expr = expr;
-    stmt->static_assert.message = vc_strdup(msg ? msg : "");
-    if (!stmt->static_assert.message) {
+    STMT_STATIC_ASSERT(stmt).expr = expr;
+    STMT_STATIC_ASSERT(stmt).message = vc_strdup(msg ? msg : "");
+    if (!STMT_STATIC_ASSERT(stmt).message) {
         free(stmt);
         return NULL;
     }
@@ -264,14 +264,14 @@ stmt_t *ast_make_typedef(const char *name, type_kind_t type, size_t array_size,
     stmt->kind = STMT_TYPEDEF;
     stmt->line = line;
     stmt->column = column;
-    stmt->typedef_decl.name = vc_strdup(name ? name : "");
-    if (!stmt->typedef_decl.name) {
+    STMT_TYPEDEF(stmt).name = vc_strdup(name ? name : "");
+    if (!STMT_TYPEDEF(stmt).name) {
         free(stmt);
         return NULL;
     }
-    stmt->typedef_decl.type = type;
-    stmt->typedef_decl.array_size = array_size;
-    stmt->typedef_decl.elem_size = elem_size;
+    STMT_TYPEDEF(stmt).type = type;
+    STMT_TYPEDEF(stmt).array_size = array_size;
+    STMT_TYPEDEF(stmt).elem_size = elem_size;
     return stmt;
 }
 
@@ -285,13 +285,13 @@ stmt_t *ast_make_enum_decl(const char *tag, enumerator_t *items, size_t count,
     stmt->kind = STMT_ENUM_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->enum_decl.tag = vc_strdup(tag ? tag : "");
-    if (!stmt->enum_decl.tag) {
+    STMT_ENUM_DECL(stmt).tag = vc_strdup(tag ? tag : "");
+    if (!STMT_ENUM_DECL(stmt).tag) {
         free(stmt);
         return NULL;
     }
-    stmt->enum_decl.items = items;
-    stmt->enum_decl.count = count;
+    STMT_ENUM_DECL(stmt).items = items;
+    STMT_ENUM_DECL(stmt).count = count;
     return stmt;
 }
 
@@ -305,13 +305,13 @@ stmt_t *ast_make_struct_decl(const char *tag, struct_member_t *members,
     stmt->kind = STMT_STRUCT_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->struct_decl.tag = vc_strdup(tag ? tag : "");
-    if (!stmt->struct_decl.tag) {
+    STMT_STRUCT_DECL(stmt).tag = vc_strdup(tag ? tag : "");
+    if (!STMT_STRUCT_DECL(stmt).tag) {
         free(stmt);
         return NULL;
     }
-    stmt->struct_decl.members = members;
-    stmt->struct_decl.count = count;
+    STMT_STRUCT_DECL(stmt).members = members;
+    STMT_STRUCT_DECL(stmt).count = count;
     return stmt;
 }
 
@@ -325,13 +325,13 @@ stmt_t *ast_make_union_decl(const char *tag, union_member_t *members,
     stmt->kind = STMT_UNION_DECL;
     stmt->line = line;
     stmt->column = column;
-    stmt->union_decl.tag = vc_strdup(tag ? tag : "");
-    if (!stmt->union_decl.tag) {
+    STMT_UNION_DECL(stmt).tag = vc_strdup(tag ? tag : "");
+    if (!STMT_UNION_DECL(stmt).tag) {
         free(stmt);
         return NULL;
     }
-    stmt->union_decl.members = members;
-    stmt->union_decl.count = count;
+    STMT_UNION_DECL(stmt).members = members;
+    STMT_UNION_DECL(stmt).count = count;
     return stmt;
 }
 
@@ -345,8 +345,8 @@ stmt_t *ast_make_block(stmt_t **stmts, size_t count,
     stmt->kind = STMT_BLOCK;
     stmt->line = line;
     stmt->column = column;
-    stmt->block.stmts = stmts;
-    stmt->block.count = count;
+    STMT_BLOCK(stmt).stmts = stmts;
+    STMT_BLOCK(stmt).count = count;
     return stmt;
 }
 

--- a/src/ast_stmt_free.c
+++ b/src/ast_stmt_free.c
@@ -15,124 +15,124 @@
 /* Helpers for freeing individual statement types */
 static void free_expr_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->expr.expr);
+    ast_free_expr(STMT_EXPR(stmt).expr);
 }
 
 static void free_return_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->ret.expr);
+    ast_free_expr(STMT_RET(stmt).expr);
 }
 
 static void free_var_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->var_decl.name);
-    ast_free_expr(stmt->var_decl.size_expr);
-    ast_free_expr(stmt->var_decl.align_expr);
-    ast_free_expr(stmt->var_decl.init);
-    for (size_t i = 0; i < stmt->var_decl.init_count; i++) {
-        ast_free_expr(stmt->var_decl.init_list[i].index);
-        ast_free_expr(stmt->var_decl.init_list[i].value);
-        free(stmt->var_decl.init_list[i].field);
+    free(STMT_VAR_DECL(stmt).name);
+    ast_free_expr(STMT_VAR_DECL(stmt).size_expr);
+    ast_free_expr(STMT_VAR_DECL(stmt).align_expr);
+    ast_free_expr(STMT_VAR_DECL(stmt).init);
+    for (size_t i = 0; i < STMT_VAR_DECL(stmt).init_count; i++) {
+        ast_free_expr(STMT_VAR_DECL(stmt).init_list[i].index);
+        ast_free_expr(STMT_VAR_DECL(stmt).init_list[i].value);
+        free(STMT_VAR_DECL(stmt).init_list[i].field);
     }
-    free(stmt->var_decl.init_list);
-    free(stmt->var_decl.tag);
-    for (size_t i = 0; i < stmt->var_decl.member_count; i++)
-        free(stmt->var_decl.members[i].name);
-    free(stmt->var_decl.members);
-    free(stmt->var_decl.func_param_types);
+    free(STMT_VAR_DECL(stmt).init_list);
+    free(STMT_VAR_DECL(stmt).tag);
+    for (size_t i = 0; i < STMT_VAR_DECL(stmt).member_count; i++)
+        free(STMT_VAR_DECL(stmt).members[i].name);
+    free(STMT_VAR_DECL(stmt).members);
+    free(STMT_VAR_DECL(stmt).func_param_types);
 }
 
 static void free_if_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->if_stmt.cond);
-    ast_free_stmt(stmt->if_stmt.then_branch);
-    ast_free_stmt(stmt->if_stmt.else_branch);
+    ast_free_expr(STMT_IF(stmt).cond);
+    ast_free_stmt(STMT_IF(stmt).then_branch);
+    ast_free_stmt(STMT_IF(stmt).else_branch);
 }
 
 static void free_while_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->while_stmt.cond);
-    ast_free_stmt(stmt->while_stmt.body);
+    ast_free_expr(STMT_WHILE(stmt).cond);
+    ast_free_stmt(STMT_WHILE(stmt).body);
 }
 
 static void free_do_while_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->do_while_stmt.cond);
-    ast_free_stmt(stmt->do_while_stmt.body);
+    ast_free_expr(STMT_DO_WHILE(stmt).cond);
+    ast_free_stmt(STMT_DO_WHILE(stmt).body);
 }
 
 static void free_for_stmt(stmt_t *stmt)
 {
-    ast_free_stmt(stmt->for_stmt.init_decl);
-    ast_free_expr(stmt->for_stmt.init);
-    ast_free_expr(stmt->for_stmt.cond);
-    ast_free_expr(stmt->for_stmt.incr);
-    ast_free_stmt(stmt->for_stmt.body);
+    ast_free_stmt(STMT_FOR(stmt).init_decl);
+    ast_free_expr(STMT_FOR(stmt).init);
+    ast_free_expr(STMT_FOR(stmt).cond);
+    ast_free_expr(STMT_FOR(stmt).incr);
+    ast_free_stmt(STMT_FOR(stmt).body);
 }
 
 static void free_switch_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->switch_stmt.expr);
-    for (size_t i = 0; i < stmt->switch_stmt.case_count; i++) {
-        ast_free_expr(stmt->switch_stmt.cases[i].expr);
-        ast_free_stmt(stmt->switch_stmt.cases[i].body);
+    ast_free_expr(STMT_SWITCH(stmt).expr);
+    for (size_t i = 0; i < STMT_SWITCH(stmt).case_count; i++) {
+        ast_free_expr(STMT_SWITCH(stmt).cases[i].expr);
+        ast_free_stmt(STMT_SWITCH(stmt).cases[i].body);
     }
-    free(stmt->switch_stmt.cases);
-    ast_free_stmt(stmt->switch_stmt.default_body);
+    free(STMT_SWITCH(stmt).cases);
+    ast_free_stmt(STMT_SWITCH(stmt).default_body);
 }
 
 static void free_label_stmt(stmt_t *stmt)
 {
-    free(stmt->label.name);
+    free(STMT_LABEL(stmt).name);
 }
 
 static void free_goto_stmt(stmt_t *stmt)
 {
-    free(stmt->goto_stmt.name);
+    free(STMT_GOTO(stmt).name);
 }
 
 static void free_static_assert_stmt(stmt_t *stmt)
 {
-    ast_free_expr(stmt->static_assert.expr);
-    free(stmt->static_assert.message);
+    ast_free_expr(STMT_STATIC_ASSERT(stmt).expr);
+    free(STMT_STATIC_ASSERT(stmt).message);
 }
 
 static void free_typedef_stmt(stmt_t *stmt)
 {
-    free(stmt->typedef_decl.name);
+    free(STMT_TYPEDEF(stmt).name);
 }
 
 static void free_enum_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->enum_decl.tag);
-    for (size_t i = 0; i < stmt->enum_decl.count; i++) {
-        free(stmt->enum_decl.items[i].name);
-        ast_free_expr(stmt->enum_decl.items[i].value);
+    free(STMT_ENUM_DECL(stmt).tag);
+    for (size_t i = 0; i < STMT_ENUM_DECL(stmt).count; i++) {
+        free(STMT_ENUM_DECL(stmt).items[i].name);
+        ast_free_expr(STMT_ENUM_DECL(stmt).items[i].value);
     }
-    free(stmt->enum_decl.items);
+    free(STMT_ENUM_DECL(stmt).items);
 }
 
 static void free_struct_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->struct_decl.tag);
-    for (size_t i = 0; i < stmt->struct_decl.count; i++)
-        free(stmt->struct_decl.members[i].name);
-    free(stmt->struct_decl.members);
+    free(STMT_STRUCT_DECL(stmt).tag);
+    for (size_t i = 0; i < STMT_STRUCT_DECL(stmt).count; i++)
+        free(STMT_STRUCT_DECL(stmt).members[i].name);
+    free(STMT_STRUCT_DECL(stmt).members);
 }
 
 static void free_union_decl_stmt(stmt_t *stmt)
 {
-    free(stmt->union_decl.tag);
-    for (size_t i = 0; i < stmt->union_decl.count; i++)
-        free(stmt->union_decl.members[i].name);
-    free(stmt->union_decl.members);
+    free(STMT_UNION_DECL(stmt).tag);
+    for (size_t i = 0; i < STMT_UNION_DECL(stmt).count; i++)
+        free(STMT_UNION_DECL(stmt).members[i].name);
+    free(STMT_UNION_DECL(stmt).members);
 }
 
 static void free_block_stmt(stmt_t *stmt)
 {
-    for (size_t i = 0; i < stmt->block.count; i++)
-        ast_free_stmt(stmt->block.stmts[i]);
-    free(stmt->block.stmts);
+    for (size_t i = 0; i < STMT_BLOCK(stmt).count; i++)
+        ast_free_stmt(STMT_BLOCK(stmt).stmts[i]);
+    free(STMT_BLOCK(stmt).stmts);
 }
 
 static void free_break_stmt(stmt_t *stmt)

--- a/src/parser_decl_var.c
+++ b/src/parser_decl_var.c
@@ -288,10 +288,10 @@ stmt_t *parser_parse_var_decl(parser_t *p)
         free(tag_name);
         free(param_types);
     } else {
-        res->var_decl.func_ret_type = func_ret_type;
-        res->var_decl.func_param_types = param_types;
-        res->var_decl.func_param_count = param_count;
-        res->var_decl.func_variadic = variadic;
+        STMT_VAR_DECL(res).func_ret_type = func_ret_type;
+        STMT_VAR_DECL(res).func_param_types = param_types;
+        STMT_VAR_DECL(res).func_param_count = param_count;
+        STMT_VAR_DECL(res).func_variadic = variadic;
     }
     return res;
 }

--- a/src/semantic_block.c
+++ b/src/semantic_block.c
@@ -10,8 +10,8 @@ int stmt_block_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                        const char *continue_label)
 {
     symbol_t *old_head = vars->head;
-    for (size_t i = 0; i < stmt->block.count; i++) {
-        if (!check_stmt(stmt->block.stmts[i], vars, funcs, labels, ir,
+    for (size_t i = 0; i < STMT_BLOCK(stmt).count; i++) {
+        if (!check_stmt(STMT_BLOCK(stmt).stmts[i], vars, funcs, labels, ir,
                         func_ret_type, break_label, continue_label)) {
             symtable_pop_scope(vars, old_head);
             return 0;

--- a/src/semantic_control.c
+++ b/src/semantic_control.c
@@ -112,7 +112,7 @@ static char **emit_case_branches(stmt_t *stmt, symtable_t *vars,
                                  const char *default_label,
                                  const char *end_label, int id)
 {
-    size_t count = stmt->switch_stmt.case_count;
+    size_t count = STMT_SWITCH(stmt).case_count;
     char **labels = calloc(count, sizeof(char *));
     long long *values = calloc(count, sizeof(long long));
     if (!labels || !values) {
@@ -126,12 +126,12 @@ static char **emit_case_branches(stmt_t *stmt, symtable_t *vars,
         snprintf(buf, sizeof(buf), "L%d_case%zu", id, i);
         labels[i] = vc_strdup(buf);
         long long cval;
-        if (!eval_const_expr(stmt->switch_stmt.cases[i].expr, vars, 0, &cval)) {
+        if (!eval_const_expr(STMT_SWITCH(stmt).cases[i].expr, vars, 0, &cval)) {
             for (size_t j = 0; j <= i; j++)
                 free(labels[j]);
             free(labels);
             free(values);
-            error_set(stmt->switch_stmt.cases[i].expr->line, stmt->switch_stmt.cases[i].expr->column, error_current_file, error_current_function);
+            error_set(STMT_SWITCH(stmt).cases[i].expr->line, STMT_SWITCH(stmt).cases[i].expr->column, error_current_file, error_current_function);
             return NULL;
         }
         for (size_t j = 0; j < i; j++) {
@@ -140,7 +140,7 @@ static char **emit_case_branches(stmt_t *stmt, symtable_t *vars,
                     free(labels[k]);
                 free(labels);
                 free(values);
-                error_set(stmt->switch_stmt.cases[i].expr->line, stmt->switch_stmt.cases[i].expr->column, error_current_file, error_current_function);
+                error_set(STMT_SWITCH(stmt).cases[i].expr->line, STMT_SWITCH(stmt).cases[i].expr->column, error_current_file, error_current_function);
                 return NULL;
             }
         }
@@ -150,7 +150,7 @@ static char **emit_case_branches(stmt_t *stmt, symtable_t *vars,
         ir_build_bcond(ir, cmp, labels[i]);
     }
 
-    if (stmt->switch_stmt.default_body)
+    if (STMT_SWITCH(stmt).default_body)
         ir_build_br(ir, default_label);
     else
         ir_build_br(ir, end_label);
@@ -172,17 +172,17 @@ static int process_switch_body(stmt_t *stmt, symtable_t *vars,
                                const char *default_label,
                                const char *end_label)
 {
-    for (size_t i = 0; i < stmt->switch_stmt.case_count; i++) {
+    for (size_t i = 0; i < STMT_SWITCH(stmt).case_count; i++) {
         ir_build_label(ir, case_labels[i]);
-        if (!check_stmt(stmt->switch_stmt.cases[i].body, vars, funcs, labels,
+        if (!check_stmt(STMT_SWITCH(stmt).cases[i].body, vars, funcs, labels,
                         ir, func_ret_type, end_label, NULL))
             return 0;
         ir_build_br(ir, end_label);
     }
 
-    if (stmt->switch_stmt.default_body) {
+    if (STMT_SWITCH(stmt).default_body) {
         ir_build_label(ir, default_label);
-        if (!check_stmt(stmt->switch_stmt.default_body, vars, funcs, labels, ir,
+        if (!check_stmt(STMT_SWITCH(stmt).default_body, vars, funcs, labels, ir,
                         func_ret_type, end_label, NULL))
             return 0;
     }
@@ -203,7 +203,7 @@ int check_switch_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                       type_kind_t func_ret_type)
 {
     ir_value_t expr_val;
-    if (check_expr(stmt->switch_stmt.expr, vars, funcs, ir, &expr_val) == TYPE_UNKNOWN)
+    if (check_expr(STMT_SWITCH(stmt).expr, vars, funcs, ir, &expr_val) == TYPE_UNKNOWN)
         return 0;
     char end_label[32];
     char default_label[32];
@@ -222,7 +222,7 @@ int check_switch_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     int ok = process_switch_body(stmt, vars, funcs, labels, ir, func_ret_type,
                                  case_labels, default_label, end_label);
 
-    for (size_t j = 0; j < stmt->switch_stmt.case_count; j++)
+    for (size_t j = 0; j < STMT_SWITCH(stmt).case_count; j++)
         free(case_labels[j]);
     free(case_labels);
     return ok;
@@ -257,7 +257,7 @@ int check_if_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                   const char *break_label, const char *continue_label)
 {
     ir_value_t cond_val;
-    if (check_expr(stmt->if_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
+    if (check_expr(STMT_IF(stmt).cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
     char else_label[32];
     char end_label[32];
@@ -265,15 +265,15 @@ int check_if_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     if (!label_format_suffix("L", id, "_else", else_label) ||
         !label_format_suffix("L", id, "_end", end_label))
         return 0;
-    const char *target = stmt->if_stmt.else_branch ? else_label : end_label;
+    const char *target = STMT_IF(stmt).else_branch ? else_label : end_label;
     ir_build_bcond(ir, cond_val, target);
-    if (!check_stmt(stmt->if_stmt.then_branch, vars, funcs, labels, ir,
+    if (!check_stmt(STMT_IF(stmt).then_branch, vars, funcs, labels, ir,
                     func_ret_type, break_label, continue_label))
         return 0;
-    if (stmt->if_stmt.else_branch) {
+    if (STMT_IF(stmt).else_branch) {
         ir_build_br(ir, end_label);
         ir_build_label(ir, else_label);
-        if (!check_stmt(stmt->if_stmt.else_branch, vars, funcs, labels, ir,
+        if (!check_stmt(STMT_IF(stmt).else_branch, vars, funcs, labels, ir,
                         func_ret_type, break_label, continue_label))
             return 0;
     }

--- a/src/semantic_decl.c
+++ b/src/semantic_decl.c
@@ -11,10 +11,10 @@
 
 static int check_typedef_stmt(stmt_t *stmt, symtable_t *vars)
 {
-    if (!symtable_add_typedef(vars, stmt->typedef_decl.name,
-                              stmt->typedef_decl.type,
-                              stmt->typedef_decl.array_size,
-                              stmt->typedef_decl.elem_size)) {
+    if (!symtable_add_typedef(vars, STMT_TYPEDEF(stmt).name,
+                              STMT_TYPEDEF(stmt).type,
+                              STMT_TYPEDEF(stmt).array_size,
+                              STMT_TYPEDEF(stmt).elem_size)) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
         return 0;
     }

--- a/src/semantic_expr_stmt.c
+++ b/src/semantic_expr_stmt.c
@@ -7,7 +7,7 @@ static int check_expr_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
                            ir_builder_t *ir)
 {
     ir_value_t tmp;
-    return check_expr(stmt->expr.expr, vars, funcs, ir, &tmp) != TYPE_UNKNOWN;
+    return check_expr(STMT_EXPR(stmt).expr, vars, funcs, ir, &tmp) != TYPE_UNKNOWN;
 }
 
 int stmt_expr_handler(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,

--- a/src/semantic_label.c
+++ b/src/semantic_label.c
@@ -6,7 +6,7 @@
 static int handle_label_stmt(stmt_t *stmt, label_table_t *labels,
                              ir_builder_t *ir)
 {
-    const char *ir_name = label_table_get_or_add(labels, stmt->label.name);
+    const char *ir_name = label_table_get_or_add(labels, STMT_LABEL(stmt).name);
     ir_build_label(ir, ir_name);
     return 1;
 }
@@ -14,7 +14,7 @@ static int handle_label_stmt(stmt_t *stmt, label_table_t *labels,
 static int check_goto_stmt(stmt_t *stmt, label_table_t *labels,
                            ir_builder_t *ir)
 {
-    const char *ir_name = label_table_get_or_add(labels, stmt->goto_stmt.name);
+    const char *ir_name = label_table_get_or_add(labels, STMT_GOTO(stmt).name);
     ir_build_br(ir, ir_name);
     return 1;
 }

--- a/src/semantic_layout.c
+++ b/src/semantic_layout.c
@@ -84,18 +84,18 @@ size_t layout_struct_members(struct_member_t *members, size_t count)
 /* Compute layout for a union variable declaration */
 int compute_union_layout(stmt_t *decl, symtable_t *globals)
 {
-    if (decl->var_decl.member_count) {
-        size_t max = layout_union_members(decl->var_decl.members,
-                                          decl->var_decl.member_count);
-        decl->var_decl.elem_size = max;
-    } else if (decl->var_decl.tag) {
-        symbol_t *utype = symtable_lookup_union(globals, decl->var_decl.tag);
+    if (STMT_VAR_DECL(decl).member_count) {
+        size_t max = layout_union_members(STMT_VAR_DECL(decl).members,
+                                          STMT_VAR_DECL(decl).member_count);
+        STMT_VAR_DECL(decl).elem_size = max;
+    } else if (STMT_VAR_DECL(decl).tag) {
+        symbol_t *utype = symtable_lookup_union(globals, STMT_VAR_DECL(decl).tag);
         if (!utype) {
             error_set(decl->line, decl->column, error_current_file,
                       error_current_function);
             return 0;
         }
-        decl->var_decl.elem_size = utype->total_size;
+        STMT_VAR_DECL(decl).elem_size = utype->total_size;
     }
     return 1;
 }
@@ -103,18 +103,18 @@ int compute_union_layout(stmt_t *decl, symtable_t *globals)
 /* Compute layout for a struct variable declaration */
 int compute_struct_layout(stmt_t *decl, symtable_t *globals)
 {
-    if (decl->var_decl.member_count) {
-        size_t total = layout_struct_members((struct_member_t *)decl->var_decl.members,
-                                             decl->var_decl.member_count);
-        decl->var_decl.elem_size = total;
-    } else if (decl->var_decl.tag) {
-        symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
+    if (STMT_VAR_DECL(decl).member_count) {
+        size_t total = layout_struct_members((struct_member_t *)STMT_VAR_DECL(decl).members,
+                                             STMT_VAR_DECL(decl).member_count);
+        STMT_VAR_DECL(decl).elem_size = total;
+    } else if (STMT_VAR_DECL(decl).tag) {
+        symbol_t *stype = symtable_lookup_struct(globals, STMT_VAR_DECL(decl).tag);
         if (!stype) {
             error_set(decl->line, decl->column, error_current_file,
                       error_current_function);
             return 0;
         }
-        decl->var_decl.elem_size = stype->struct_total_size;
+        STMT_VAR_DECL(decl).elem_size = stype->struct_total_size;
     }
     return 1;
 }
@@ -171,14 +171,14 @@ int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
 int copy_aggregate_metadata(stmt_t *decl, symbol_t *sym,
                             symtable_t *globals)
 {
-    if (decl->var_decl.type == TYPE_UNION)
-        return copy_union_metadata(sym, decl->var_decl.members,
-                                   decl->var_decl.member_count,
-                                   decl->var_decl.elem_size);
+    if (STMT_VAR_DECL(decl).type == TYPE_UNION)
+        return copy_union_metadata(sym, STMT_VAR_DECL(decl).members,
+                                   STMT_VAR_DECL(decl).member_count,
+                                   STMT_VAR_DECL(decl).elem_size);
 
-    if (decl->var_decl.type == TYPE_STRUCT) {
-        if (decl->var_decl.member_count == 0 && decl->var_decl.tag) {
-            symbol_t *stype = symtable_lookup_struct(globals, decl->var_decl.tag);
+    if (STMT_VAR_DECL(decl).type == TYPE_STRUCT) {
+        if (STMT_VAR_DECL(decl).member_count == 0 && STMT_VAR_DECL(decl).tag) {
+            symbol_t *stype = symtable_lookup_struct(globals, STMT_VAR_DECL(decl).tag);
             if (!stype)
                 return 0;
             return copy_struct_metadata(sym, stype->struct_members,
@@ -186,9 +186,9 @@ int copy_aggregate_metadata(stmt_t *decl, symbol_t *sym,
                                         stype->struct_total_size);
         }
         return copy_struct_metadata(sym,
-                                    (struct_member_t *)decl->var_decl.members,
-                                    decl->var_decl.member_count,
-                                    decl->var_decl.elem_size);
+                                    (struct_member_t *)STMT_VAR_DECL(decl).members,
+                                    STMT_VAR_DECL(decl).member_count,
+                                    STMT_VAR_DECL(decl).elem_size);
     }
 
     return 1;

--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -36,10 +36,10 @@ int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         !label_format_suffix("L", id, "_end", end_label))
         return 0;
     ir_build_label(ir, start_label);
-    if (check_expr(stmt->while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
+    if (check_expr(STMT_WHILE(stmt).cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
     ir_build_bcond(ir, cond_val, end_label);
-    if (!check_stmt(stmt->while_stmt.body, vars, funcs, labels, ir,
+    if (!check_stmt(STMT_WHILE(stmt).body, vars, funcs, labels, ir,
                     func_ret_type, end_label, start_label))
         return 0;
     ir_build_br(ir, start_label);
@@ -67,11 +67,11 @@ int check_do_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         !label_format_suffix("L", id, "_end", end_label))
         return 0;
     ir_build_label(ir, start_label);
-    if (!check_stmt(stmt->do_while_stmt.body, vars, funcs, labels, ir,
+    if (!check_stmt(STMT_DO_WHILE(stmt).body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cond_label))
         return 0;
     ir_build_label(ir, cond_label);
-    if (check_expr(stmt->do_while_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
+    if (check_expr(STMT_DO_WHILE(stmt).cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
     ir_build_bcond(ir, cond_val, end_label);
     ir_build_br(ir, start_label);
@@ -98,20 +98,20 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         !label_format_suffix("L", id, "_end", end_label))
         return 0;
     symbol_t *old_head = vars->head;
-    if (stmt->for_stmt.init_decl) {
-        if (!check_stmt(stmt->for_stmt.init_decl, vars, funcs, labels, ir,
+    if (STMT_FOR(stmt).init_decl) {
+        if (!check_stmt(STMT_FOR(stmt).init_decl, vars, funcs, labels, ir,
                         func_ret_type, NULL, NULL)) {
             symtable_pop_scope(vars, old_head);
             return 0;
         }
     } else {
-        if (check_expr(stmt->for_stmt.init, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+        if (check_expr(STMT_FOR(stmt).init, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
             symtable_pop_scope(vars, old_head);
             return 0; /* reuse cond_val for init but ignore value */
         }
     }
     ir_build_label(ir, start_label);
-    if (check_expr(stmt->for_stmt.cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+    if (check_expr(STMT_FOR(stmt).cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
         symtable_pop_scope(vars, old_head);
         return 0;
     }
@@ -121,13 +121,13 @@ int check_for_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
         symtable_pop_scope(vars, old_head);
         return 0;
     }
-    if (!check_stmt(stmt->for_stmt.body, vars, funcs, labels, ir,
+    if (!check_stmt(STMT_FOR(stmt).body, vars, funcs, labels, ir,
                     func_ret_type, end_label, cont_label)) {
         symtable_pop_scope(vars, old_head);
         return 0;
     }
     ir_build_label(ir, cont_label);
-    if (check_expr(stmt->for_stmt.incr, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
+    if (check_expr(STMT_FOR(stmt).incr, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN) {
         symtable_pop_scope(vars, old_head);
         return 0;
     }

--- a/src/semantic_return.c
+++ b/src/semantic_return.c
@@ -10,7 +10,7 @@ static int validate_struct_return(stmt_t *stmt, symtable_t *vars,
                                   type_kind_t func_ret_type)
 {
     if (expr_type != func_ret_type) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+        error_set(STMT_RET(stmt).expr->line, STMT_RET(stmt).expr->column,
                   error_current_file, error_current_function);
         return 0;
     }
@@ -21,23 +21,23 @@ static int validate_struct_return(stmt_t *stmt, symtable_t *vars,
     size_t expected = func_sym ? func_sym->ret_struct_size : 0;
     size_t actual = 0;
 
-    if (stmt->ret.expr->kind == EXPR_IDENT) {
-        symbol_t *vsym = symtable_lookup(vars, stmt->ret.expr->data.ident.name);
+    if (STMT_RET(stmt).expr->kind == EXPR_IDENT) {
+        symbol_t *vsym = symtable_lookup(vars, STMT_RET(stmt).expr->data.ident.name);
         if (vsym)
             actual = (expr_type == TYPE_STRUCT)
                 ? vsym->struct_total_size : vsym->total_size;
-    } else if (stmt->ret.expr->kind == EXPR_CALL) {
-        symbol_t *fsym = symtable_lookup(funcs, stmt->ret.expr->data.call.name);
+    } else if (STMT_RET(stmt).expr->kind == EXPR_CALL) {
+        symbol_t *fsym = symtable_lookup(funcs, STMT_RET(stmt).expr->data.call.name);
         if (!fsym)
-            fsym = symtable_lookup(vars, stmt->ret.expr->data.call.name);
+            fsym = symtable_lookup(vars, STMT_RET(stmt).expr->data.call.name);
         if (fsym)
             actual = fsym->ret_struct_size;
-    } else if (stmt->ret.expr->kind == EXPR_COMPLIT) {
-        actual = stmt->ret.expr->data.compound.elem_size;
+    } else if (STMT_RET(stmt).expr->kind == EXPR_COMPLIT) {
+        actual = STMT_RET(stmt).expr->data.compound.elem_size;
     }
 
     if (expected && actual && expected != actual) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+        error_set(STMT_RET(stmt).expr->line, STMT_RET(stmt).expr->column,
                   error_current_file, error_current_function);
         return 0;
     }
@@ -49,7 +49,7 @@ static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
                               symtable_t *funcs, ir_builder_t *ir,
                               type_kind_t func_ret_type)
 {
-    if (!stmt->ret.expr) {
+    if (!STMT_RET(stmt).expr) {
         if (func_ret_type != TYPE_VOID) {
             error_set(stmt->line, stmt->column, error_current_file, error_current_function);
             return 0;
@@ -60,9 +60,9 @@ static int handle_return_stmt(stmt_t *stmt, symtable_t *vars,
     }
 
     ir_value_t val;
-    type_kind_t vt = check_expr(stmt->ret.expr, vars, funcs, ir, &val);
+    type_kind_t vt = check_expr(STMT_RET(stmt).expr, vars, funcs, ir, &val);
     if (vt == TYPE_UNKNOWN) {
-        error_set(stmt->ret.expr->line, stmt->ret.expr->column,
+        error_set(STMT_RET(stmt).expr->line, STMT_RET(stmt).expr->column,
                   error_current_file, error_current_function);
         return 0;
     }

--- a/src/semantic_static_assert.c
+++ b/src/semantic_static_assert.c
@@ -7,14 +7,14 @@
 static int check_static_assert_stmt(stmt_t *stmt, symtable_t *vars)
 {
     long long val;
-    if (!eval_const_expr(stmt->static_assert.expr, vars, 0, &val)) {
-        error_set(stmt->static_assert.expr->line, stmt->static_assert.expr->column,
+    if (!eval_const_expr(STMT_STATIC_ASSERT(stmt).expr, vars, 0, &val)) {
+        error_set(STMT_STATIC_ASSERT(stmt).expr->line, STMT_STATIC_ASSERT(stmt).expr->column,
                   error_current_file, error_current_function);
         return 0;
     }
     if (val == 0) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
-        error_print(stmt->static_assert.message);
+        error_print(STMT_STATIC_ASSERT(stmt).message);
         return 0;
     }
     return 1;

--- a/src/semantic_stmt.c
+++ b/src/semantic_stmt.c
@@ -136,7 +136,7 @@ static const char *find_end_label(func_t *func)
     for (size_t i = func->body_count; i-- > 0;) {
         stmt_t *s = func->body[i];
         if (s->kind == STMT_LABEL)
-            return s->label.name;
+            return STMT_LABEL(s).name;
         if (s->kind != STMT_RETURN)
             break;
     }
@@ -154,7 +154,7 @@ void warn_unreachable_function(func_t *func, symtable_t *funcs)
         stmt_t *s = func->body[i];
         if (!reachable) {
             if (!(s->kind == STMT_LABEL && end_label &&
-                  strcmp(s->label.name, end_label) == 0)) {
+                  strcmp(STMT_LABEL(s).name, end_label) == 0)) {
                 error_set(s->line, s->column, error_current_file,
                           error_current_function);
                 error_print("warning: unreachable statement");
@@ -163,18 +163,18 @@ void warn_unreachable_function(func_t *func, symtable_t *funcs)
         if (s->kind == STMT_RETURN)
             reachable = 0;
         else if (s->kind == STMT_GOTO && end_label &&
-                 strcmp(s->goto_stmt.name, end_label) == 0)
+                 strcmp(STMT_GOTO(s).name, end_label) == 0)
             reachable = 0;
         else if (s->kind == STMT_LABEL && end_label &&
-                 strcmp(s->label.name, end_label) == 0)
+                 strcmp(STMT_LABEL(s).name, end_label) == 0)
             reachable = 1;
-        else if (s->kind == STMT_EXPR && s->expr.expr &&
-                 s->expr.expr->kind == EXPR_CALL) {
-            symbol_t *fs = symtable_lookup(funcs, s->expr.expr->data.call.name);
+        else if (s->kind == STMT_EXPR && STMT_EXPR(s).expr &&
+                 STMT_EXPR(s).expr->kind == EXPR_CALL) {
+            symbol_t *fs = symtable_lookup(funcs, STMT_EXPR(s).expr->data.call.name);
             if (fs && fs->is_noreturn) {
                 if (i + 1 < func->body_count &&
                     !(func->body[i+1]->kind == STMT_LABEL && end_label &&
-                      strcmp(func->body[i+1]->label.name, end_label) == 0)) {
+                      strcmp(STMT_LABEL(func->body[i+1]).name, end_label) == 0)) {
                     error_set(s->line, s->column, error_current_file,
                               error_current_function);
                     error_print("warning: non-returning call without terminator");

--- a/src/semantic_var.c
+++ b/src/semantic_var.c
@@ -76,11 +76,11 @@ static int handle_array_init(stmt_t *stmt, symbol_t *sym, symtable_t *vars,
                              ir_builder_t *ir)
 {
     long long *vals;
-    if (!expand_array_initializer(stmt->var_decl.init_list, stmt->var_decl.init_count,
+    if (!expand_array_initializer(STMT_VAR_DECL(stmt).init_list, STMT_VAR_DECL(stmt).init_count,
                                   sym->array_size, vars, stmt->line, stmt->column,
                                   &vals))
         return 0;
-    if (stmt->var_decl.is_static) {
+    if (STMT_VAR_DECL(stmt).is_static) {
         if (!init_static_array(ir, sym->ir_name, vals, sym->array_size)) {
             free(vals);
             return 0;
@@ -88,7 +88,7 @@ static int handle_array_init(stmt_t *stmt, symbol_t *sym, symtable_t *vars,
     }
     else
         init_dynamic_array(ir, sym->ir_name, vals, sym->array_size,
-                           stmt->var_decl.is_volatile);
+                           STMT_VAR_DECL(stmt).is_volatile);
     free(vals);
     return 1;
 }
@@ -103,7 +103,7 @@ static int handle_struct_init(stmt_t *stmt, symbol_t *sym, symtable_t *vars,
                               ir_builder_t *ir)
 {
     long long *vals;
-    if (!expand_struct_initializer(stmt->var_decl.init_list, stmt->var_decl.init_count,
+    if (!expand_struct_initializer(STMT_VAR_DECL(stmt).init_list, STMT_VAR_DECL(stmt).init_count,
                                    sym, vars, stmt->line, stmt->column, &vals))
         return 0;
     ir_value_t base = ir_build_addr(ir, sym->ir_name);
@@ -120,36 +120,36 @@ static int handle_struct_init(stmt_t *stmt, symbol_t *sym, symtable_t *vars,
  */
 int compute_var_layout(stmt_t *stmt, symtable_t *vars)
 {
-    if (stmt->var_decl.type == TYPE_UNION) {
-        if (stmt->var_decl.member_count) {
-            size_t max = layout_union_members(stmt->var_decl.members,
-                                              stmt->var_decl.member_count);
-            stmt->var_decl.elem_size = max;
-        } else if (stmt->var_decl.tag) {
-            symbol_t *utype = symtable_lookup_union(vars, stmt->var_decl.tag);
+    if (STMT_VAR_DECL(stmt).type == TYPE_UNION) {
+        if (STMT_VAR_DECL(stmt).member_count) {
+            size_t max = layout_union_members(STMT_VAR_DECL(stmt).members,
+                                              STMT_VAR_DECL(stmt).member_count);
+            STMT_VAR_DECL(stmt).elem_size = max;
+        } else if (STMT_VAR_DECL(stmt).tag) {
+            symbol_t *utype = symtable_lookup_union(vars, STMT_VAR_DECL(stmt).tag);
             if (!utype) {
                 error_set(stmt->line, stmt->column, error_current_file,
                           error_current_function);
                 return 0;
             }
-            stmt->var_decl.elem_size = utype->total_size;
+            STMT_VAR_DECL(stmt).elem_size = utype->total_size;
         }
     }
 
-    if (stmt->var_decl.type == TYPE_STRUCT) {
-        if (stmt->var_decl.member_count) {
+    if (STMT_VAR_DECL(stmt).type == TYPE_STRUCT) {
+        if (STMT_VAR_DECL(stmt).member_count) {
             size_t total = layout_struct_members(
-                (struct_member_t *)stmt->var_decl.members,
-                stmt->var_decl.member_count);
-            stmt->var_decl.elem_size = total;
-        } else if (stmt->var_decl.tag) {
-            symbol_t *stype = symtable_lookup_struct(vars, stmt->var_decl.tag);
+                (struct_member_t *)STMT_VAR_DECL(stmt).members,
+                STMT_VAR_DECL(stmt).member_count);
+            STMT_VAR_DECL(stmt).elem_size = total;
+        } else if (STMT_VAR_DECL(stmt).tag) {
+            symbol_t *stype = symtable_lookup_struct(vars, STMT_VAR_DECL(stmt).tag);
             if (!stype) {
                 error_set(stmt->line, stmt->column, error_current_file,
                           error_current_function);
                 return 0;
             }
-            stmt->var_decl.elem_size = stype->struct_total_size;
+            STMT_VAR_DECL(stmt).elem_size = stype->struct_total_size;
         }
     }
 
@@ -164,15 +164,15 @@ static int emit_static_initializer(stmt_t *stmt, symbol_t *sym,
                                    symtable_t *vars, ir_builder_t *ir)
 {
     long long cval;
-    if (!eval_const_expr(stmt->var_decl.init, vars, 0, &cval)) {
-        error_set(stmt->var_decl.init->line, stmt->var_decl.init->column,
+    if (!eval_const_expr(STMT_VAR_DECL(stmt).init, vars, 0, &cval)) {
+        error_set(STMT_VAR_DECL(stmt).init->line, STMT_VAR_DECL(stmt).init->column,
                   error_current_file, error_current_function);
         return 0;
     }
-    if (stmt->var_decl.type == TYPE_UNION)
+    if (STMT_VAR_DECL(stmt).type == TYPE_UNION)
         ir_build_glob_union(ir, sym->ir_name, (int)sym->elem_size, 1,
                            sym->alignment);
-    else if (stmt->var_decl.type == TYPE_STRUCT)
+    else if (STMT_VAR_DECL(stmt).type == TYPE_STRUCT)
         ir_build_glob_struct(ir, sym->ir_name, (int)sym->struct_total_size, 1,
                             sym->alignment);
     else
@@ -189,16 +189,16 @@ static int emit_dynamic_initializer(stmt_t *stmt, symbol_t *sym,
                                     ir_builder_t *ir)
 {
     ir_value_t val;
-    type_kind_t vt = check_expr(stmt->var_decl.init, vars, funcs, ir, &val);
-    if (!(((is_intlike(stmt->var_decl.type) && is_intlike(vt)) ||
-           (is_floatlike(stmt->var_decl.type) &&
+    type_kind_t vt = check_expr(STMT_VAR_DECL(stmt).init, vars, funcs, ir, &val);
+    if (!(((is_intlike(STMT_VAR_DECL(stmt).type) && is_intlike(vt)) ||
+           (is_floatlike(STMT_VAR_DECL(stmt).type) &&
             (is_floatlike(vt) || is_intlike(vt)))) ||
-          vt == stmt->var_decl.type)) {
-        error_set(stmt->var_decl.init->line, stmt->var_decl.init->column,
+          vt == STMT_VAR_DECL(stmt).type)) {
+        error_set(STMT_VAR_DECL(stmt).init->line, STMT_VAR_DECL(stmt).init->column,
                   error_current_file, error_current_function);
         return 0;
     }
-    if (stmt->var_decl.is_volatile)
+    if (STMT_VAR_DECL(stmt).is_volatile)
         ir_build_store_vol(ir, sym->ir_name, val);
     else
         ir_build_store(ir, sym->ir_name, val);
@@ -212,9 +212,9 @@ static int emit_dynamic_initializer(stmt_t *stmt, symbol_t *sym,
 static int emit_aggregate_initializer(stmt_t *stmt, symbol_t *sym,
                                       symtable_t *vars, ir_builder_t *ir)
 {
-    if (stmt->var_decl.type == TYPE_ARRAY)
+    if (STMT_VAR_DECL(stmt).type == TYPE_ARRAY)
         return handle_array_init(stmt, sym, vars, ir);
-    if (stmt->var_decl.type == TYPE_STRUCT)
+    if (STMT_VAR_DECL(stmt).type == TYPE_STRUCT)
         return handle_struct_init(stmt, sym, vars, ir);
     error_set(stmt->line, stmt->column, error_current_file, error_current_function);
     return 0;
@@ -228,10 +228,10 @@ int handle_vla_size(stmt_t *stmt, symbol_t *sym, symtable_t *vars,
                     symtable_t *funcs, ir_builder_t *ir)
 {
     ir_value_t lenv;
-    if (check_expr(stmt->var_decl.size_expr, vars, funcs, ir, &lenv) ==
+    if (check_expr(STMT_VAR_DECL(stmt).size_expr, vars, funcs, ir, &lenv) ==
         TYPE_UNKNOWN)
         return 0;
-    ir_value_t eszv = ir_build_const(ir, (int)stmt->var_decl.elem_size);
+    ir_value_t eszv = ir_build_const(ir, (int)STMT_VAR_DECL(stmt).elem_size);
     ir_value_t total = ir_build_binop(ir, IR_MUL, lenv, eszv);
     sym->vla_addr = ir_build_alloca(ir, total);
     sym->vla_size = lenv;
@@ -288,9 +288,9 @@ int emit_var_initializer(stmt_t *stmt, symbol_t *sym,
     if (!copy_aggregate_metadata(stmt, sym, vars))
         return 0;
 
-    if (stmt->var_decl.init)
-        kind = stmt->var_decl.is_static ? INIT_STATIC : INIT_DYNAMIC;
-    else if (stmt->var_decl.init_list)
+    if (STMT_VAR_DECL(stmt).init)
+        kind = STMT_VAR_DECL(stmt).is_static ? INIT_STATIC : INIT_DYNAMIC;
+    else if (STMT_VAR_DECL(stmt).init_list)
         kind = INIT_AGGREGATE;
 
     switch (kind) {


### PR DESCRIPTION
## Summary
- name the `union` inside `struct stmt` and expose it as `stmt_data`
- add accessor macros like `STMT_EXPR` and `STMT_IF`
- update all source files to use the new access macros

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6871d2d30c4083248c8af00efccce0c0