### PR TITLE
Reset counter on each preproc_run

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -85,6 +85,8 @@ an explicit `#define`:
 - `__BASE_FILE__` holds the name of the initial source file being
   processed.
 - `__COUNTER__` expands to an incrementing integer starting at `0`.
+  The counter is reset to zero each time `preproc_run` begins so
+  consecutive preprocessing operations behave independently.
 
 These macros are always available and cannot be undefined. They are useful for
 diagnostics and logging as they convey file names, line numbers and processing

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -342,6 +342,8 @@ char *preproc_run(preproc_context_t *ctx, const char *path,
 
     /* Prepare all vectors used during preprocessing */
     init_preproc_vectors(ctx, &macros, &conds, &stack, &out);
+    /* Reset builtin counter so each run starts from zero */
+    ctx->counter = 0;
     define_default_macros(&macros, path);
     if (!record_dependency(ctx, path)) {
         cleanup_preproc_vectors(ctx, &macros, &conds, &stack, &search_dirs, &out);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -295,6 +295,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_counter_reset" "$DIR/unit/test_preproc_counter_reset.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_errwarn" "$DIR/unit/test_preproc_errwarn.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -402,6 +409,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_builtin_extra"
 "$DIR/preproc_charlit"
 "$DIR/preproc_counter_base"
+"$DIR/preproc_counter_reset"
 "$DIR/preproc_independent"
 "$DIR/preproc_errwarn"
 "$DIR/invalid_macro_tests"

--- a/tests/unit/test_preproc_counter_reset.c
+++ b/tests/unit/test_preproc_counter_reset.c
@@ -1,0 +1,45 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    const char *src = "int v = __COUNTER__;\n";
+    char tmpl[] = "/tmp/cntXXXXXX.c";
+    int fd = mkstemp(tmpl); ASSERT(fd >= 0);
+    if (fd >= 0) { write(fd, src, strlen(src)); close(fd); }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+
+    char *r1 = preproc_run(&ctx, tmpl, &dirs, NULL, NULL); ASSERT(r1);
+    if (r1) { ASSERT(strstr(r1, "int v = 0;") != NULL); free(r1); }
+    preproc_context_free(&ctx);
+
+    char *r2 = preproc_run(&ctx, tmpl, &dirs, NULL, NULL); ASSERT(r2);
+    if (r2) { ASSERT(strstr(r2, "int v = 0;") != NULL); free(r2); }
+    preproc_context_free(&ctx);
+
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc counter reset tests passed\n");
+    else
+        printf("%d preproc counter reset test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- ensure `ctx->counter` is reset when running the preprocessor
- document that `__COUNTER__` restarts at zero for each run
- add unit test proving the counter resets

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687299ba82bc83249a39ca092b56760f