### PR TITLE
Fix parsing of literals in macro arguments

### DIFF
--- a/src/preproc_args.c
+++ b/src/preproc_args.c
@@ -20,10 +20,25 @@ static char *dup_arg_segment(const char *line, size_t start, size_t end)
 static char find_arg_delim(const char *line, size_t *p, int *nest,
                            size_t *out_end)
 {
+    int quote = 0;             /* current quote character or 0 */
     for (;; (*p)++) {
         char c = line[*p];
         if (c == '\0')
             return 0;
+        if (quote) {
+            if (c == '\\' && line[*p + 1]) {
+                (*p)++;
+                continue;
+            }
+            if (c == quote) {
+                quote = 0;
+            }
+            continue;
+        }
+        if (c == '"' || c == '\'') {
+            quote = c;
+            continue;
+        }
         if (c == '(') {
             (*nest)++;
             continue;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -151,6 +151,16 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_stringize.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_macro_stringize_escape.c" -o "$DIR/test_macro_stringize_escape.o"
 cc -o "$DIR/macro_stringize_escape" preproc_expand.o preproc_table.o strbuf_stringize.o vector_stringize.o util_stringize.o "$DIR/test_macro_stringize_escape.o"
 rm -f preproc_expand.o preproc_table.o strbuf_stringize.o vector_stringize.o util_stringize.o "$DIR/test_macro_stringize_escape.o"
+# build literal argument parsing tests
+cc -Iinclude -Wall -Wextra -std=c99 -c src/preproc_expand.c -o preproc_expand.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/preproc_table.c -o preproc_table.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_litargs.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_litargs.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_litargs.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/preproc_builtin.c -o preproc_builtin_litargs.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_preproc_literal_args.c" -o "$DIR/test_preproc_literal_args.o"
+cc -o "$DIR/preproc_literal_args" preproc_expand.o preproc_table.o strbuf_litargs.o vector_litargs.o util_litargs.o preproc_builtin_litargs.o "$DIR/test_preproc_literal_args.o"
+rm -f preproc_expand.o preproc_table.o strbuf_litargs.o vector_litargs.o util_litargs.o preproc_builtin_litargs.o "$DIR/test_preproc_literal_args.o"
 # build pack pragma layout tests
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/pack_pragma_tests" "$DIR/unit/test_pack_pragma.c"
@@ -390,6 +400,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/add_macro_fail_tests"
 "$DIR/variadic_macro_tests"
 "$DIR/macro_stringize_escape"
+"$DIR/preproc_literal_args"
 "$DIR/pack_pragma_tests"
 "$DIR/preproc_stdio"
 "$DIR/preproc_has_include"

--- a/tests/unit/test_preproc_literal_args.c
+++ b/tests/unit/test_preproc_literal_args.c
@@ -1,0 +1,53 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_macros.h"
+#include "strbuf.h"
+#include "vector.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void add_echo_macro(vector_t *macros)
+{
+    vector_t params;
+    vector_init(&params, sizeof(char *));
+    char *p = strdup("x");
+    vector_push(&params, &p);
+    add_macro("ECHO", "x", &params, 0, macros);
+}
+
+static void run_case(const char *call, const char *expect)
+{
+    vector_t macros; vector_init(&macros, sizeof(macro_t));
+    add_echo_macro(&macros);
+
+    strbuf_t sb; strbuf_init(&sb);
+    preproc_context_t ctx = {0};
+    preproc_set_location(&ctx, "t.c", 1, 1);
+    ASSERT(expand_line(call, &macros, &sb, 0, 0, &ctx));
+    ASSERT(strcmp(sb.data, expect) == 0);
+    strbuf_free(&sb);
+
+    macro_free(&((macro_t *)macros.data)[0]);
+    vector_free(&macros);
+}
+
+int main(void)
+{
+    run_case("ECHO(\"a,b\")", "\"a,b\"");
+    run_case("ECHO(')')", "')'");
+    run_case("ECHO(',')", "','");
+    run_case("ECHO(\"a\\\"b,\")", "\"a\\\"b,\"");
+    if (failures == 0)
+        printf("All preproc_literal_args tests passed\n");
+    else
+        printf("%d preproc_literal_args test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- update `find_arg_delim` to skip text inside quoted literals
- test parsing of string and character literals in macro arguments
- wire new test into unit test build script

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68729f8a5258832483d52b6cacd5aeac