### PR TITLE
Remove duplicate pack_stack free

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -93,27 +93,32 @@ int run_preprocessor(const cli_options_t *cli)
                                 &cli->undefines);
         if (!text) {
             perror("preproc_run");
+            preproc_context_free(&ctx);
             return 1;
         }
         size_t len = strlen(text);
         if (fwrite(text, 1, len, stdout) != len) {
             perror("fwrite");
             free(text);
+            preproc_context_free(&ctx);
             return 1;
         }
         if (len == 0 || text[len - 1] != '\n') {
             if (putchar('\n') == EOF) {
                 perror("putchar");
                 free(text);
+                preproc_context_free(&ctx);
                 return 1;
             }
         }
         if (fflush(stdout) == EOF) {
             perror("fflush");
             free(text);
+            preproc_context_free(&ctx);
             return 1;
         }
         free(text);
+        preproc_context_free(&ctx);
     }
     return 0;
 }

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -260,7 +260,6 @@ static void cleanup_preproc_vectors(preproc_context_t *ctx, vector_t *macros,
     for (size_t i = 0; i < ctx->pragma_once_files.count; i++)
         free(((char **)ctx->pragma_once_files.data)[i]);
     vector_free(&ctx->pragma_once_files);
-    vector_free(&ctx->pack_stack);
     strbuf_free(out);
 }
 


### PR DESCRIPTION
## Summary
- avoid freeing `pack_stack` twice
- free preprocessor context in all `run_preprocessor` paths

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872aae9ee488324b45abd95001c2278