### PR TITLE
Support CPATH/C_INCLUDE_PATH

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -7,7 +7,7 @@ are produced.  `preproc_run` in `src/preproc_file.c` drives this process.
 ## File processing
 
 `preproc_run` builds a list of include search paths then calls `process_file` to
-read the initial source.  The list is released with [`free_string_vector`](memory_helpers.md) once preprocessing finishes.  Each line is inspected in order and any recognised
+read the initial source.  Directories specified with `-I` are added first and paths from the `VCPATH`, `VCINC`, `CPATH` and `C_INCLUDE_PATH` environment variables are appended before the builtin system locations.  The list is released with [`free_string_vector`](memory_helpers.md) once preprocessing finishes.  Each line is inspected in order and any recognised
 preprocessor directive is handled immediately:
 
 - `#include` resolves the requested path and recursively invokes `process_file`
@@ -103,9 +103,7 @@ the lexer for tokenization.
 quoted or angle-bracket file name and evaluate to `1` when that header would be
 found, or `0` otherwise.  The search order matches the behaviour of
 `#include` and `#include_next` respectively, consulting directories supplied with
-`-I`, the `VCPATH` and `VCINC` environment variables and the builtin system
-locations.
-
+`-I`, the `VCPATH`, `VCINC`, `CPATH` and `C_INCLUDE_PATH` environment variables and the builtin system locations.
 ```c
 #if __has_include("config.h")
 #  include "config.h"

--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -221,6 +221,14 @@ int collect_include_dirs(vector_t *search_dirs,
         free_string_vector(search_dirs);
         return 0;
     }
+    if (!append_env_paths(getenv("CPATH"), search_dirs)) {
+        free_string_vector(search_dirs);
+        return 0;
+    }
+    if (!append_env_paths(getenv("C_INCLUDE_PATH"), search_dirs)) {
+        free_string_vector(search_dirs);
+        return 0;
+    }
     return 1;
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -127,6 +127,24 @@ if ! diff -u "$DIR/fixtures/include_search.s" "${inc_env_out}"; then
 fi
 rm -f "${inc_env_out}"
 
+# verify CPATH include search
+cpath_out=$(mktemp)
+CPATH="$DIR/includes" "$BINARY" -o "${cpath_out}" "$DIR/fixtures/include_search.c"
+if ! diff -u "$DIR/fixtures/include_search.s" "${cpath_out}"; then
+    echo "Test include_cpath failed"
+    fail=1
+fi
+rm -f "${cpath_out}"
+
+# verify C_INCLUDE_PATH include search
+cinc_out=$(mktemp)
+C_INCLUDE_PATH="$DIR/includes" "$BINARY" -o "${cinc_out}" "$DIR/fixtures/include_env.c"
+if ! diff -u "$DIR/fixtures/include_env.s" "${cinc_out}"; then
+    echo "Test include_c_include_path failed"
+    fail=1
+fi
+rm -f "${cinc_out}"
+
 # verify VCFLAGS options are parsed
 vcflags_out=$(mktemp)
 VCFLAGS="--x86-64" "$BINARY" -o "${vcflags_out}" "$DIR/fixtures/simple_add.c"


### PR DESCRIPTION
## Summary
- extend `collect_include_dirs` to read `CPATH` and `C_INCLUDE_PATH`
- document the additional environment variables
- test CPATH and C_INCLUDE_PATH include search

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872c99391288324aae619fb35d8ad74