### PR TITLE
Add configurable include depth

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -43,6 +43,7 @@ The compiler supports the following options:
 - `-l<name>` – link against the specified library.
 - `-Dname[=val]` – define a preprocessor macro before compilation.
 - `-Uname` – undefine a macro before compilation.
+- `-fmax-include-depth=<n>` – set the maximum nested `#include` depth.
 - `-O<N>` – set optimization level (0 disables all passes).
 
 The compiler warns about statements that cannot be reached because a

--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -61,8 +61,9 @@ preprocessing after printing "Macro expansion limit exceeded".
 
 File inclusion works the same way and may recurse when headers themselves
 contain `#include` directives.  To guard against unbounded recursion the
-preprocessor enforces a maximum include depth of 20 files.  If this limit is
-exceeded the build stops with an "Include depth limit exceeded" error.
+preprocessor enforces a maximum include depth of 20 files.  This limit can be
+changed with the `-fmax-include-depth=` option.  If the depth is exceeded the
+build stops with an "Include depth limit exceeded" error.
 
 Conditional expressions in `#if` directives are parsed by the small recursive
 descent parser in `preproc_expr.c`.  The `defined` operator queries the current
@@ -118,7 +119,7 @@ locations.
 
 Checking for a file does not itself increase the include depth, however when a
 header is subsequently included the normal limit of 20 nested includes still
-applies.
+applies unless a different value was set with `-fmax-include-depth=`.
 ## Preprocessor context
 
 `preproc_context_t` is defined in `include/preproc_file.h` and is passed to `preproc_run`. It contains several fields:

--- a/include/cli.h
+++ b/include/cli.h
@@ -47,7 +47,8 @@ typedef enum {
     CLI_OPT_DEP_ONLY,
     CLI_OPT_DEP,
     CLI_OPT_NO_WARN_UNREACHABLE,
-    CLI_OPT_EMIT_DWARF
+    CLI_OPT_EMIT_DWARF,
+    CLI_OPT_FMAX_DEPTH
 } cli_opt_id;
 
 /* Command line options parsed from argv */
@@ -77,6 +78,7 @@ typedef struct {
     vector_t undefines;    /* macros to undefine before compilation */
     vector_t lib_dirs;     /* additional library search paths */
     vector_t libs;         /* libraries to link against */
+    size_t max_include_depth; /* maximum nested includes */
 } cli_options_t;
 
 /* Parse command line arguments. Returns 0 on success, non-zero on error. */

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -24,6 +24,9 @@
  * including the initial source and all headers. The caller is
  * responsible for freeing both vectors via `preproc_context_free()`.
  */
+/* default include depth limit */
+#define DEFAULT_INCLUDE_DEPTH 20
+
 typedef struct {
     vector_t pragma_once_files; /* vector of malloc'd char* paths */
     vector_t deps;              /* vector of malloc'd char* paths */
@@ -39,6 +42,7 @@ typedef struct {
     const char *base_file;      /* builtin __BASE_FILE__ value */
     size_t include_level;       /* builtin __INCLUDE_LEVEL__ value */
     unsigned long counter;      /* builtin __COUNTER__ value */
+    size_t max_include_depth;   /* maximum nested includes allowed */
 } preproc_context_t;
 
 /* Free the dependency lists stored in the context */

--- a/man/vc.1
+++ b/man/vc.1
@@ -122,6 +122,9 @@ the macro is set to \fB1\fR.
 .B \-U\fIname\fR
 Remove any definition of \fIname\fR before preprocessing begins.
 .TP
+.B \-fmax-include-depth=\fIn\fR
+Set the maximum nested \fB#include\fR depth (default 20).
+.TP
 .B --no-fold
 Disable constant folding optimization.
 .TP

--- a/src/cli.c
+++ b/src/cli.c
@@ -13,6 +13,7 @@
 #include "util.h"
 #include "cli_env.h"
 #include "cli_opts.h"
+#include "preproc_file.h"
 
 static void init_default_opts(cli_options_t *opts)
 {
@@ -42,6 +43,7 @@ static void init_default_opts(cli_options_t *opts)
     opts->asm_syntax = ASM_ATT;
     opts->std = STD_C99;
     opts->obj_dir = NULL;
+    opts->max_include_depth = DEFAULT_INCLUDE_DEPTH;
     vector_init(&opts->include_dirs, sizeof(char *));
     vector_init(&opts->sources, sizeof(char *));
     vector_init(&opts->defines, sizeof(char *));
@@ -118,13 +120,14 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"no-color", no_argument, 0, CLI_OPT_NO_COLOR},
         {"no-warn-unreachable", no_argument, 0, CLI_OPT_NO_WARN_UNREACHABLE},
         {"emit-dwarf", no_argument, 0, CLI_OPT_EMIT_DWARF},
+        {"fmax-include-depth", required_argument, 0, CLI_OPT_FMAX_DEPTH},
         {0, 0, 0, 0}
     };
 
     init_default_opts(opts);
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hvo:O:cD:U:I:L:l:ES", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hvo:O:cD:U:I:L:l:ESf:", long_opts, NULL)) != -1) {
         int ret;
         if ((ret = parse_optimization_opts(opt, optarg, opts)) == 1) {
             return cleanup_parse_error(opts, vcflags_argv, vcflags_buf);

--- a/src/compile.c
+++ b/src/compile.c
@@ -89,6 +89,7 @@ int run_preprocessor(const cli_options_t *cli)
     for (size_t i = 0; i < cli->sources.count; i++) {
         const char *src = ((const char **)cli->sources.data)[i];
         preproc_context_t ctx;
+        ctx.max_include_depth = cli->max_include_depth;
         char *text = preproc_run(&ctx, src, &cli->include_dirs, &cli->defines,
                                 &cli->undefines);
         if (!text) {
@@ -129,6 +130,7 @@ int generate_dependencies(const cli_options_t *cli)
     for (size_t i = 0; i < cli->sources.count; i++) {
         const char *src = ((const char **)cli->sources.data)[i];
         preproc_context_t ctx;
+        ctx.max_include_depth = cli->max_include_depth;
         char *text = preproc_run(&ctx, src, &cli->include_dirs,
                                  &cli->defines, &cli->undefines);
         if (!text) {

--- a/src/compile_tokenize.c
+++ b/src/compile_tokenize.c
@@ -191,6 +191,7 @@ static int read_stdin_source(const cli_options_t *cli,
     }
 
     preproc_context_t ctx;
+    ctx.max_include_depth = cli->max_include_depth;
     char *text = preproc_run(&ctx, path, incdirs, defines, undefines);
     if (!text) {
         perror("preproc_run");
@@ -230,6 +231,7 @@ int compile_tokenize_impl(const char *source, const cli_options_t *cli,
         }
     } else {
         preproc_context_t ctx;
+        ctx.max_include_depth = cli->max_include_depth;
         text = preproc_run(&ctx, source, incdirs, defines, undefines);
         if (!text) {
             perror("preproc_run");

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -34,9 +34,6 @@
 #include "vector.h"
 #include "strbuf.h"
 
-#define MAX_INCLUDE_DEPTH 20
-
-
 /*
  * Core file processing routine.  Reads the file, handles directives
  * and macro expansion line by line, writing the preprocessed result
@@ -47,7 +44,7 @@ int process_file(const char *path, vector_t *macros,
                         const vector_t *incdirs, vector_t *stack,
                         preproc_context_t *ctx, size_t idx)
 {
-    if (stack->count >= MAX_INCLUDE_DEPTH) {
+    if (stack->count >= ctx->max_include_depth) {
         fprintf(stderr, "Include depth limit exceeded\n");
         return 0;
     }
@@ -107,6 +104,8 @@ static void init_preproc_vectors(preproc_context_t *ctx, vector_t *macros,
     ctx->base_file = "";
     ctx->include_level = 0;
     ctx->counter = 0;
+    if (ctx->max_include_depth == 0)
+        ctx->max_include_depth = DEFAULT_INCLUDE_DEPTH;
     strbuf_init(out);
 }
 

--- a/tests/fixtures/include_depth_ok.s
+++ b/tests/fixtures/include_depth_ok.s
@@ -1,0 +1,9 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $0, %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -427,6 +427,15 @@ if [ $ret -eq 0 ] || ! grep -q "Include depth limit exceeded" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# verify custom include depth option works
+depth_ok=$(mktemp)
+"$BINARY" -fmax-include-depth=22 -o "${depth_ok}" "$DIR/invalid/include_depth.c"
+if ! diff -u "$DIR/fixtures/include_depth_ok.s" "${depth_ok}"; then
+    echo "Test include_depth_override failed"
+    fail=1
+fi
+rm -f "${depth_ok}"
+
 # negative test for duplicate switch cases
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- add `-fmax-include-depth=` option
- pass the limit to the preprocessor context
- document the new option and default depth
- test custom include depth handling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6872c9a54440832493e46ab93d563a61