### PR TITLE
Fix line handling for decreasing #line directives

### DIFF
--- a/src/preproc_file_io.c
+++ b/src/preproc_file_io.c
@@ -212,7 +212,10 @@ int process_all_lines(char **lines, const char *path, const char *dir,
 {
     /* defined in preproc_directives.c */
     for (size_t i = 0; lines[i]; i++) {
-        size_t line = (size_t)((long)(i + 1) + ctx->line_delta);
+        long line_tmp = (long)(i + 1) + ctx->line_delta;
+        if (line_tmp < 0)
+            line_tmp = 0;
+        size_t line = (size_t)line_tmp;
         preproc_set_location(ctx,
                              ctx->current_file ? ctx->current_file : path,
                              line, 1);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -204,6 +204,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_line_decrease" "$DIR/unit/test_preproc_line_decrease.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/gcc_line_marker" "$DIR/unit/test_gcc_line_marker.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -407,6 +414,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"
 "$DIR/preproc_line_macro"
+"$DIR/preproc_line_decrease"
 "$DIR/gcc_line_marker"
 "$DIR/preproc_hash_noop"
 "$DIR/preproc_crlf"

--- a/tests/unit/test_preproc_line_decrease.c
+++ b/tests/unit/test_preproc_line_decrease.c
@@ -1,0 +1,51 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#line 10\n"
+                     "int a = __LINE__;\n"
+                     "#line 5\n"
+                     "int b = __LINE__;\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int a = 10;") != NULL);
+        ASSERT(strstr(res, "int b = 0;") != NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_line_decrease tests passed\n");
+    else
+        printf("%d preproc_line_decrease test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- prevent overflow when `__LINE__` offset becomes negative
- add regression test for decreasing `#line` values

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68730258d10c8324a18fe818ae0332ad