### PR TITLE
Auto-detect multiarch triple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -Wpedantic -Wconversion -std=c99
 OPTFLAGS ?=
-MULTIARCH := $(shell $(CC) -print-multiarch 2>/dev/null || echo x86_64-linux-gnu)
+MULTIARCH ?= $(shell $(CC) -print-multiarch 2>/dev/null || echo x86_64-linux-gnu)
 GCC_INCLUDE_DIR := $(shell $(CC) -print-file-name=include | tr -d '\n')
 BIN = vc
 # The resulting binary accepts -c/--compile to assemble objects using cc

--- a/docs/building.md
+++ b/docs/building.md
@@ -32,12 +32,19 @@ make PLATFORM=generic
 This disables any NetBSD specific extensions.
 
 On Linux the compiler also searches `/usr/include/<multiarch>` for headers.
-The multiarch directory is determined at build time using `cc -print-multiarch`
-and defaults to `x86_64-linux-gnu` when detection fails. The GCC internal
-include directory reported by `cc -print-file-name=include` is also added so
-headers like `stddef.h` resolve correctly. The Makefile removes the trailing
-newline from this path using `tr -d '\n'` to ensure `src/preproc_path.c`
-receives a clean directory string without whitespace.
+The multiarch directory is determined at build time using `gcc -print-multiarch`
+(via `$(CC)` by default) and falls back to `x86_64-linux-gnu` when detection
+fails.  The detected value is passed to the build as the `MULTIARCH` variable
+and may be overridden if needed:
+
+```sh
+make MULTIARCH=arm-linux-gnueabihf
+```
+
+The GCC internal include directory reported by `cc -print-file-name=include`
+is also added so headers like `stddef.h` resolve correctly. The Makefile
+removes the trailing newline from this path using `tr -d '\n'` to ensure
+`src/preproc_path.c` receives a clean directory string without whitespace.
 
 `vc` can generate either 32-bit or 64-bit x86 assembly. Use the
 `--x86-64` flag when invoking the compiler to enable 64-bit output. The


### PR DESCRIPTION
## Summary
- allow overriding MULTIARCH on the make command line
- document the new MULTIARCH option in the build instructions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68730431dc4c832482985b57882af2e9