### PR TITLE
Add semicolon env path separator

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -71,7 +71,7 @@ source (for example `file.o`) is created in the current directory.
 
 ## Preprocessor Usage
 
-The preprocessor runs automatically before the lexer. It supports both `#include "file"` and `#include <file>` to insert the contents of another file. Additional directories to search for included files can be provided with the `-I`/`--include` option. Angle-bracket includes search those directories, then any paths listed in the `VCPATH` environment variable (colon separated), followed by the standard system locations such as `/usr/include`. Quoted includes also consult directories from `VCINC`. Entries from `VCPATH` and `VCINC` are appended after all `-I` directories so command-line paths are searched first. It also supports
+The preprocessor runs automatically before the lexer. It supports both `#include "file"` and `#include <file>` to insert the contents of another file. Additional directories to search for included files can be provided with the `-I`/`--include` option. Angle-bracket includes search those directories, then any paths listed in the `VCPATH` environment variable (colon separated, or semicolons on Windows), followed by the standard system locations such as `/usr/include`. Quoted includes also consult directories from `VCINC`. Entries from `VCPATH` and `VCINC` are appended after all `-I` directories so command-line paths are searched first. It also supports
 For example:
 
 ```sh

--- a/man/vc.1
+++ b/man/vc.1
@@ -224,12 +224,12 @@ Read source from standard input:
 .SH ENVIRONMENT
 .TP
 .B VCPATH
-Colon separated list of additional directories searched for headers after any
+Colon separated list (or semicolon separated on Windows) of additional directories searched for headers after any
 .B -I
 paths are processed.
 .TP
 .B VCINC
-Colon separated list of directories added to the include search path after any
+Colon separated list (or semicolon separated on Windows) of directories added to the include search path after any
 .B -I
 paths are processed.
 .TP

--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -231,7 +231,12 @@ int append_env_paths(const char *env, vector_t *search_dirs)
     if (!tmp)
         return 0;
     char *tok, *sp;
-    tok = strtok_r(tmp, ":", &sp);
+#if defined(_WIN32)
+    const char *sep = ";:";
+#else
+    const char *sep = ":";
+#endif
+    tok = strtok_r(tmp, sep, &sp);
     while (tok) {
         if (*tok) {
             char *dup = vc_strdup(tok);
@@ -241,7 +246,7 @@ int append_env_paths(const char *env, vector_t *search_dirs)
                 return 0;
             }
         }
-        tok = strtok_r(NULL, ":", &sp);
+        tok = strtok_r(NULL, sep, &sp);
     }
     free(tmp);
     return 1;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -116,6 +116,13 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_eintr.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_waitpid_retry.c" -o "$DIR/test_waitpid_retry.o"
 cc -o "$DIR/waitpid_retry" strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
 rm -f strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
+# build append_env_paths tests
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/append_env_paths_colon" "$DIR/unit/test_append_env_paths_colon.c" \
+    src/preproc_path.c src/vector.c src/util.c
+cc -Iinclude -Wall -Wextra -std=c99 -D_WIN32 \
+    -o "$DIR/append_env_paths_semicolon" "$DIR/unit/test_append_env_paths_semicolon.c" \
+    src/preproc_path.c src/vector.c src/util.c
 # build invalid macro parse test
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_invalid_macro.c" -o "$DIR/test_invalid_macro.o"
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_invalid.o
@@ -401,6 +408,8 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/number_overflow"
 "$DIR/number_suffix"
 "$DIR/waitpid_retry"
+"$DIR/append_env_paths_colon"
+"$DIR/append_env_paths_semicolon"
 "$DIR/temp_file_tests"
 "$DIR/compile_obj_fail"
 "$DIR/preproc_alloc_tests"

--- a/tests/unit/test_append_env_paths_colon.c
+++ b/tests/unit/test_append_env_paths_colon.c
@@ -1,0 +1,31 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_path.h"
+#include "util.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    ASSERT(append_env_paths("foo:bar", &dirs));
+    ASSERT(dirs.count == 2);
+    if (dirs.count == 2) {
+        ASSERT(strcmp(((char **)dirs.data)[0], "foo") == 0);
+        ASSERT(strcmp(((char **)dirs.data)[1], "bar") == 0);
+    }
+    free_string_vector(&dirs);
+    if (failures == 0)
+        printf("All append_env_paths_colon tests passed\n");
+    else
+        printf("%d append_env_paths_colon test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}

--- a/tests/unit/test_append_env_paths_semicolon.c
+++ b/tests/unit/test_append_env_paths_semicolon.c
@@ -1,0 +1,31 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_path.h"
+#include "util.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    ASSERT(append_env_paths("foo;bar", &dirs));
+    ASSERT(dirs.count == 2);
+    if (dirs.count == 2) {
+        ASSERT(strcmp(((char **)dirs.data)[0], "foo") == 0);
+        ASSERT(strcmp(((char **)dirs.data)[1], "bar") == 0);
+    }
+    free_string_vector(&dirs);
+    if (failures == 0)
+        printf("All append_env_paths_semicolon tests passed\n");
+    else
+        printf("%d append_env_paths_semicolon test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- support `;` as env path separator on Windows
- document the Windows separator
- add unit tests for colon and semicolon separators

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687307ca9ef48324839c987d9af45808