### PR TITLE
Add include_next outside header check

### DIFF
--- a/src/preproc_include.c
+++ b/src/preproc_include.c
@@ -145,6 +145,12 @@ int handle_include_next(char *line, const char *dir, vector_t *macros,
         strbuf_free(&expanded);
         return 0;
     }
+    if (stack->count <= 1) {
+        fprintf(stderr, "#include_next is invalid outside a header\n");
+        free(fname);
+        strbuf_free(&expanded);
+        return 0;
+    }
     int result = 1;
     size_t cur = SIZE_MAX;
     if (stack->count) {

--- a/tests/invalid/include_next_outside.c
+++ b/tests/invalid/include_next_outside.c
@@ -1,0 +1,2 @@
+#include_next <foo.h>
+int main() { return 0; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -399,6 +399,19 @@ if [ $ret -eq 0 ] || ! grep -q "Malformed include directive" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# negative test for include_next outside header
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "${out}" "$DIR/invalid/include_next_outside.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "#include_next is invalid outside a header" "${err}"; then
+    echo "Test include_next_outside failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 # macro recursion should fail without expansion limit error
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- reject `#include_next` when not inside a header
- test the new error case

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687309e5eb408324976c6c8ef7feac29