### PR TITLE
Handle 64-bit COUNTER overflow

### DIFF
--- a/docs/preprocessor.md
+++ b/docs/preprocessor.md
@@ -85,9 +85,10 @@ an explicit `#define`:
 - `__func__` yields the enclosing function name as a string literal.
 - `__BASE_FILE__` holds the name of the initial source file being
   processed.
-- `__COUNTER__` expands to an incrementing integer starting at `0`.
-  The counter is reset to zero each time `preproc_run` begins so
-  consecutive preprocessing operations behave independently.
+- `__COUNTER__` expands to an incrementing 64-bit integer starting at `0`.
+  The counter is reset to zero each time `preproc_run` begins and upon
+  overflow.  When wraparound occurs a diagnostic is printed so consecutive
+  preprocessing operations behave independently.
 
 These macros are always available and cannot be undefined. They are useful for
 diagnostics and logging as they convey file names, line numbers and processing

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -16,6 +16,7 @@
 
 #include "vector.h"
 #include "strbuf.h"
+#include <stdint.h>
 
 /* Context used by the preprocessor.
  *
@@ -41,7 +42,7 @@ typedef struct {
     const char *func;           /* builtin __func__ value */
     const char *base_file;      /* builtin __BASE_FILE__ value */
     size_t include_level;       /* builtin __INCLUDE_LEVEL__ value */
-    unsigned long counter;      /* builtin __COUNTER__ value */
+    uint64_t counter;           /* builtin __COUNTER__ value */
     size_t max_include_depth;   /* maximum nested includes allowed */
 } preproc_context_t;
 

--- a/src/preproc_builtin.c
+++ b/src/preproc_builtin.c
@@ -1,6 +1,8 @@
 #define _POSIX_C_SOURCE 200809L
 #include <string.h>
 #include <time.h>
+#include <inttypes.h>
+#include <stdio.h>
 #include "preproc_builtin.h"
 #include "util.h"
 
@@ -94,7 +96,10 @@ int handle_builtin_macro(const char *name, size_t len, size_t end,
         return 1;
     } else if (len == 11 && strncmp(name, "__COUNTER__", 11) == 0) {
         preproc_set_location(ctx, NULL, ctx->line, column);
-        strbuf_appendf(out, "%lu", ctx->counter++);
+        uint64_t value = ctx->counter++;
+        if (ctx->counter == 0)
+            fprintf(stderr, "Builtin counter overflow\n");
+        strbuf_appendf(out, "%" PRIu64, value);
         *pos = end;
         return 1;
     } else if (len == 17 && strncmp(name, "__INCLUDE_LEVEL__", 17) == 0) {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -108,6 +108,13 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strbuf.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_strbuf_overflow.c" -o "$DIR/test_strbuf_overflow.o"
 cc -o "$DIR/strbuf_overflow" strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
 rm -f strbuf_overflow_impl.o util_strbuf.o "$DIR/test_strbuf_overflow.o"
+# build builtin counter wraparound regression test
+cc -Iinclude -Wall -Wextra -std=c99 -c src/preproc_builtin.c -o preproc_builtin_wrap.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_wrap.o
+cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_wrap.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_preproc_counter_wrap.c" -o "$DIR/test_preproc_counter_wrap.o"
+cc -o "$DIR/preproc_counter_wrap" preproc_builtin_wrap.o strbuf_wrap.o util_wrap.o "$DIR/test_preproc_counter_wrap.o"
+rm -f preproc_builtin_wrap.o strbuf_wrap.o util_wrap.o "$DIR/test_preproc_counter_wrap.o"
 # build collect_funcs overflow regression test
 cc -Iinclude -Wall -Wextra -std=c99 "$DIR/unit/test_collect_funcs_overflow.c" -o "$DIR/collect_funcs_overflow"
 # build waitpid EINTR regression test
@@ -454,6 +461,17 @@ if [ $ret -ne 0 ] || ! grep -q "string buffer too large" "$err"; then
     fail=1
 fi
 rm -f "$err" "$DIR/strbuf_overflow"
+# regression test for builtin counter overflow handling
+err=$(mktemp)
+set +e
+"$DIR/preproc_counter_wrap" 2> "$err"
+ret=$?
+set -e
+if [ $ret -ne 0 ] || ! grep -q "Builtin counter overflow" "$err"; then
+    echo "Test preproc_counter_wrap failed"
+    fail=1
+fi
+rm -f "$err" "$DIR/preproc_counter_wrap"
 # regression test for constant expression overflow handling
 err=$(mktemp)
 set +e

--- a/tests/unit/test_preproc_counter_wrap.c
+++ b/tests/unit/test_preproc_counter_wrap.c
@@ -1,0 +1,15 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdint.h>
+#include "preproc_builtin.h"
+#include "strbuf.h"
+
+int main(void)
+{
+    preproc_context_t ctx = {0};
+    ctx.counter = UINT64_MAX;
+    strbuf_t sb; strbuf_init(&sb);
+    size_t pos = 0;
+    handle_builtin_macro("__COUNTER__", 11, 11, 1, &sb, &pos, &ctx);
+    strbuf_free(&sb);
+    return ctx.counter == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- switch preprocessor counter to `uint64_t`
- warn on wraparound and continue from zero
- document new behaviour
- test wraparound handling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687310ecc6ec83248a679fe7bf7c8861