### PR TITLE
Add sysroot option

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -30,6 +30,7 @@ The compiler supports the following options:
 - `-c`, `--compile` – assemble the output into an object file using `cc -c`.
 - `--link` – build an executable by assembling and linking with `cc`.
 - `--obj-dir <path>` – directory for temporary object files.
+- `--sysroot=<dir>` – prepend `<dir>` to builtin include paths.
 - `-S`, `--dump-asm` – print the generated assembly to stdout instead of creating a file.
 - `--dump-ast` – print the AST to stdout after parsing.
 - `--dump-ir` – print the IR to stdout before code generation.
@@ -71,7 +72,7 @@ source (for example `file.o`) is created in the current directory.
 
 ## Preprocessor Usage
 
-The preprocessor runs automatically before the lexer. It supports both `#include "file"` and `#include <file>` to insert the contents of another file. Additional directories to search for included files can be provided with the `-I`/`--include` option. Angle-bracket includes search those directories, then any paths listed in the `VCPATH` environment variable (colon separated, or semicolons on Windows), followed by the standard system locations such as `/usr/include`. Quoted includes also consult directories from `VCINC`. Entries from `VCPATH` and `VCINC` are appended after all `-I` directories so command-line paths are searched first. It also supports
+The preprocessor runs automatically before the lexer. It supports both `#include "file"` and `#include <file>` to insert the contents of another file. Additional directories to search for included files can be provided with the `-I`/`--include` option. Angle-bracket includes search those directories, then any paths listed in the `VCPATH` environment variable (colon separated, or semicolons on Windows), followed by the standard system locations such as `/usr/include`. Quoted includes also consult directories from `VCINC`. Entries from `VCPATH` and `VCINC` are appended after all `-I` directories so command-line paths are searched first. When `--sysroot` is used these builtin locations are prefixed with the provided directory. It also supports
 For example:
 
 ```sh

--- a/include/cli.h
+++ b/include/cli.h
@@ -48,7 +48,8 @@ typedef enum {
     CLI_OPT_DEP,
     CLI_OPT_NO_WARN_UNREACHABLE,
     CLI_OPT_EMIT_DWARF,
-    CLI_OPT_FMAX_DEPTH
+    CLI_OPT_FMAX_DEPTH,
+    CLI_OPT_SYSROOT
 } cli_opt_id;
 
 /* Command line options parsed from argv */
@@ -72,6 +73,7 @@ typedef struct {
     asm_syntax_t asm_syntax; /* assembly syntax flavor */
     c_std_t std;        /* language standard */
     char *obj_dir;      /* directory for temporary object files */
+    char *sysroot;      /* prefix for system include paths */
     vector_t include_dirs; /* additional include directories */
     vector_t sources;      /* input source files */
     vector_t defines;      /* command line macro definitions */

--- a/include/preproc_file.h
+++ b/include/preproc_file.h
@@ -55,7 +55,7 @@ void preproc_context_free(preproc_context_t *ctx);
  */
 char *preproc_run(preproc_context_t *ctx, const char *path,
                   const vector_t *include_dirs, const vector_t *defines,
-                  const vector_t *undefines);
+                  const vector_t *undefines, const char *sysroot);
 
 /* Internal helpers shared across preprocessing modules */
 int process_line(char *line, const char *dir, vector_t *macros,

--- a/include/preproc_path.h
+++ b/include/preproc_path.h
@@ -15,7 +15,8 @@ char *find_include_path(const char *fname, char endc, const char *dir,
                         const vector_t *incdirs, size_t start, size_t *out_idx);
 int append_env_paths(const char *env, vector_t *search_dirs);
 int collect_include_dirs(vector_t *search_dirs,
-                         const vector_t *include_dirs);
+                         const vector_t *include_dirs,
+                         const char *sysroot);
 
 /* Print the directories searched for an include directive */
 void print_include_search_dirs(FILE *fp, char endc, const char *dir,

--- a/src/cli.c
+++ b/src/cli.c
@@ -43,6 +43,7 @@ static void init_default_opts(cli_options_t *opts)
     opts->asm_syntax = ASM_ATT;
     opts->std = STD_C99;
     opts->obj_dir = NULL;
+    opts->sysroot = NULL;
     opts->max_include_depth = DEFAULT_INCLUDE_DEPTH;
     vector_init(&opts->include_dirs, sizeof(char *));
     vector_init(&opts->sources, sizeof(char *));
@@ -121,6 +122,7 @@ int cli_parse_args(int argc, char **argv, cli_options_t *opts)
         {"no-warn-unreachable", no_argument, 0, CLI_OPT_NO_WARN_UNREACHABLE},
         {"emit-dwarf", no_argument, 0, CLI_OPT_EMIT_DWARF},
         {"fmax-include-depth", required_argument, 0, CLI_OPT_FMAX_DEPTH},
+        {"sysroot", required_argument, 0, CLI_OPT_SYSROOT},
         {0, 0, 0, 0}
     };
 

--- a/src/cli_opts.c
+++ b/src/cli_opts.c
@@ -29,6 +29,7 @@ void print_usage(const char *prog)
         "  -c, --compile        Assemble to an object file\n",
         "      --link           Compile and link to an executable\n",
         "      --obj-dir <dir>  Directory for temporary object files\n",
+        "      --sysroot <dir>  Prefix system include paths with <dir>\n",
         "      --no-fold        Disable constant folding\n",
         "      --no-dce         Disable dead code elimination\n",
         "      --no-cprop       Disable constant propagation\n",
@@ -228,6 +229,9 @@ int parse_io_paths(int opt, const char *arg, cli_options_t *opts)
         return add_library(opts, arg);
     case CLI_OPT_OBJ_DIR:
         opts->obj_dir = (char *)arg;
+        return 0;
+    case CLI_OPT_SYSROOT:
+        opts->sysroot = (char *)arg;
         return 0;
     default:
         return -1;

--- a/src/compile.c
+++ b/src/compile.c
@@ -91,7 +91,7 @@ int run_preprocessor(const cli_options_t *cli)
         preproc_context_t ctx;
         ctx.max_include_depth = cli->max_include_depth;
         char *text = preproc_run(&ctx, src, &cli->include_dirs, &cli->defines,
-                                &cli->undefines);
+                                &cli->undefines, cli->sysroot);
         if (!text) {
             perror("preproc_run");
             preproc_context_free(&ctx);
@@ -132,7 +132,7 @@ int generate_dependencies(const cli_options_t *cli)
         preproc_context_t ctx;
         ctx.max_include_depth = cli->max_include_depth;
         char *text = preproc_run(&ctx, src, &cli->include_dirs,
-                                 &cli->defines, &cli->undefines);
+                                 &cli->defines, &cli->undefines, cli->sysroot);
         if (!text) {
             perror("preproc_run");
             return 1;

--- a/src/compile_tokenize.c
+++ b/src/compile_tokenize.c
@@ -192,7 +192,8 @@ static int read_stdin_source(const cli_options_t *cli,
 
     preproc_context_t ctx;
     ctx.max_include_depth = cli->max_include_depth;
-    char *text = preproc_run(&ctx, path, incdirs, defines, undefines);
+    char *text = preproc_run(&ctx, path, incdirs, defines, undefines,
+                             cli->sysroot);
     if (!text) {
         perror("preproc_run");
         unlink(path);
@@ -232,7 +233,8 @@ int compile_tokenize_impl(const char *source, const cli_options_t *cli,
     } else {
         preproc_context_t ctx;
         ctx.max_include_depth = cli->max_include_depth;
-        text = preproc_run(&ctx, source, incdirs, defines, undefines);
+        text = preproc_run(&ctx, source, incdirs, defines, undefines,
+                           cli->sysroot);
         if (!text) {
             perror("preproc_run");
             return 0;

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -329,13 +329,14 @@ static int process_input_file(const char *path, vector_t *macros,
  */
 char *preproc_run(preproc_context_t *ctx, const char *path,
                   const vector_t *include_dirs,
-                  const vector_t *defines, const vector_t *undefines)
+                  const vector_t *defines, const vector_t *undefines,
+                  const char *sysroot)
 {
     vector_t search_dirs, macros, conds, stack;
     strbuf_t out;
 
     /* Build include search list from CLI options and environment */
-    if (!collect_include_dirs(&search_dirs, include_dirs))
+    if (!collect_include_dirs(&search_dirs, include_dirs, sysroot))
         return NULL;
 
     /* Prepare all vectors used during preprocessing */

--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -253,7 +253,8 @@ int append_env_paths(const char *env, vector_t *search_dirs)
 }
 
 int collect_include_dirs(vector_t *search_dirs,
-                         const vector_t *include_dirs)
+                         const vector_t *include_dirs,
+                         const char *sysroot)
 {
     init_std_include_dirs();
     const char *gcc_dir = get_gcc_include_dir();
@@ -284,6 +285,25 @@ int collect_include_dirs(vector_t *search_dirs,
     if (!append_env_paths(getenv("C_INCLUDE_PATH"), search_dirs)) {
         free_string_vector(search_dirs);
         return 0;
+    }
+
+    if (sysroot && *sysroot) {
+        for (size_t i = 0; std_include_dirs[i]; i++) {
+            const char *base = std_include_dirs[i];
+            size_t len = strlen(sysroot) + strlen(base);
+            char *dup = malloc(len + 1);
+            if (!dup) {
+                free_string_vector(search_dirs);
+                return 0;
+            }
+            strcpy(dup, sysroot);
+            strcat(dup, base);
+            if (!vector_push(search_dirs, &dup)) {
+                free(dup);
+                free_string_vector(search_dirs);
+                return 0;
+            }
+        }
     }
     return 1;
 }


### PR DESCRIPTION
## Summary
- support `--sysroot=<dir>` in CLI
- respect the sysroot option in include search paths
- document sysroot option

## Testing
- `make`
- `tests/run.sh` *(fails: 'stmt_t has no member named ...')*

------
https://chatgpt.com/codex/tasks/task_e_687315fe2360832487a6a96b4885b2fb