### PR TITLE
Add skip-aware stdio preprocessor test

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -194,6 +194,14 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
+    -o "$DIR/preproc_stdio_skip" "$DIR/unit/test_preproc_stdio_skip.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_has_include" "$DIR/unit/test_preproc_has_include.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -438,6 +446,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/pack_pragma_tests"
 "$DIR/read_file_lines_large"
 "$DIR/preproc_stdio"
+"$DIR/preproc_stdio_skip"
 "$DIR/preproc_has_include"
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"

--- a/tests/unit/test_preproc_stdio_skip.c
+++ b/tests/unit/test_preproc_stdio_skip.c
@@ -1,0 +1,58 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    if (access("/usr/include/stdio.h", R_OK) != 0) {
+        char multi_path[256];
+        snprintf(multi_path, sizeof(multi_path), "/usr/include/%s/stdio.h", MULTIARCH);
+        if (access(multi_path, R_OK) != 0) {
+            printf("Skipping preproc_stdio_skip tests (stdio.h not found)\n");
+            return 0;
+        }
+    }
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *line = "#include <stdio.h>\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, line, strlen(line)) == (ssize_t)strlen(line));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    if (!res) {
+        printf("Skipping preproc_stdio_skip tests (preprocessing failed)\n");
+        preproc_context_free(&ctx);
+        vector_free(&dirs);
+        unlink(tmpl);
+        return 0;
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_stdio_skip tests passed\n");
+    else
+        printf("%d preproc_stdio_skip test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- create `test_preproc_stdio_skip.c` that tries to preprocess `<stdio.h>`
- skip when the header does not exist or preprocessing fails
- build and run the new test from `tests/run.sh`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873177c9a7083249dcc2e77fb8ff678