### PR TITLE
Add include depth context to error

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -45,7 +45,8 @@ int process_file(const char *path, vector_t *macros,
                         preproc_context_t *ctx, size_t idx)
 {
     if (stack->count >= ctx->max_include_depth) {
-        fprintf(stderr, "Include depth limit exceeded\n");
+        fprintf(stderr, "Include depth limit exceeded: %s (depth %zu)\n",
+                path, stack->count);
         return 0;
     }
     char **lines;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -471,7 +471,7 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/include_depth.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Include depth limit exceeded" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "Include depth limit exceeded: .*depth20.h (depth 20)" "${err}"; then
     echo "Test include_depth failed"
     fail=1
 fi


### PR DESCRIPTION
## Summary
- show the file and depth when the include depth limit is hit
- update include depth test to expect the new error output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687318a850248324b916009b4e36870d