### PR TITLE
Fix token pasting at macro boundaries

### DIFF
--- a/src/preproc_expand.c
+++ b/src/preproc_expand.c
@@ -112,13 +112,34 @@ static int append_pasted_tokens(const char *value, size_t i, size_t len,
     size_t k = i + len;
     while (value[k] == ' ' || value[k] == '\t')
         k++;
-    if (value[k] != '#' || value[k + 1] != '#')
-        return 0;
-    k += 2;
-    while (value[k] == ' ' || value[k] == '\t')
-        k++;
+    if (value[k] != '#' || value[k + 1] != '#') {
+        /* check for pasting operator before the identifier */
+        size_t j = i;
+        while (j >= 2 && (value[j-1]==' ' || value[j-1]=='\t'))
+            j--;
+        if (j >= 2 && value[j-2]=='#' && value[j-1]=='#') {
+            trim_trailing_ws(sb);
+            if (sb->len >= 2 && sb->data[sb->len-2]=='#' && sb->data[sb->len-1]=='#') {
+                sb->len -= 2;
+                sb->data[sb->len] = '\0';
+            }
+        } else {
+            return 0;
+        }
+    } else {
+        k += 2;
+        while (value[k] == ' ' || value[k] == '\t')
+            k++;
+    }
 
-    if (isalpha((unsigned char)value[k]) || value[k] == '_') {
+    if (!value[k]) {
+        trim_trailing_ws(sb);
+        if (rep)
+            strbuf_append(sb, rep);
+        else
+            strbuf_appendf(sb, "%.*s", (int)len, value + i);
+        *out_i = k;
+    } else if (isalpha((unsigned char)value[k]) || value[k] == '_') {
         size_t l = parse_ident(value + k);
         const char *rep2 = lookup_param(value + k, l, params, args);
         if (!rep2 && variadic && l == 11 &&
@@ -168,6 +189,16 @@ static char *expand_params(const char *value, const vector_t *params, char **arg
          */
         if (value[i] == '#' && value[i + 1] != '#') {
             i = append_stringized_param(value, i, params, args, variadic, &sb);
+            continue;
+        }
+
+        if (value[i] == '#' && value[i + 1] == '#') {
+            strbuf_append(&sb, "##");
+            i += 2;
+            while (value[i] == ' ' || value[i] == '\t') {
+                strbuf_appendf(&sb, "%c", value[i]);
+                i++;
+            }
             continue;
         }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -323,6 +323,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_token_paste" "$DIR/unit/test_preproc_token_paste.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
     -o "$DIR/preproc_counter_base" "$DIR/unit/test_predef_counter_base.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
@@ -464,6 +471,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_pragma_unknown"
 "$DIR/preproc_builtin_extra"
 "$DIR/preproc_charlit"
+"$DIR/preproc_token_paste"
 "$DIR/preproc_counter_base"
 "$DIR/preproc_counter_reset"
 "$DIR/preproc_independent"

--- a/tests/unit/test_preproc_token_paste.c
+++ b/tests/unit/test_preproc_token_paste.c
@@ -1,0 +1,58 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/tpasteXXXXXX";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src =
+        "#define PREFIX(name) prefix##name\n"
+        "#define SUFFIX(name) name##suffix\n"
+        "#define BEGIN(name) ##name\n"
+        "#define END(name) name##\n"
+        "int PREFIX(foo) = 1;\n"
+        "int SUFFIX(bar) = 2;\n"
+        "int BEGIN(baz) = 3;\n"
+        "int END(qux) = 4;\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int prefixfoo = 1;") != NULL);
+        ASSERT(strstr(res, "int barsuffix = 2;") != NULL);
+        ASSERT(strstr(res, "int baz = 3;") != NULL);
+        ASSERT(strstr(res, "int qux = 4;") != NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_token_paste tests passed\n");
+    else
+        printf("%d preproc_token_paste test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- handle `##` at the start or end of macro bodies
- add tests covering token pasting edge cases

## Testing
- `cc -Iinclude -Wall -Wextra -std=c99 -o /tmp/preproc_token_paste tests/unit/test_preproc_token_paste.c src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c src/preproc_args.c src/preproc_cond.c src/preproc_expr.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c src/vector.c src/strbuf.c src/util.c src/error.c`
- `/tmp/preproc_token_paste > /tmp/paste_run.log && cat /tmp/paste_run.log`

------
https://chatgpt.com/codex/tasks/task_e_687318ec48488324a7735c1f39440956