### PR TITLE
Handle pragma system_header per file

### DIFF
--- a/include/preproc_file_io.h
+++ b/include/preproc_file_io.h
@@ -12,6 +12,7 @@
 typedef struct {
     char *path;
     size_t dir_index;
+    int prev_system_header;
 } include_entry_t;
 
 int include_stack_contains(vector_t *stack, const char *path);

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -56,6 +56,8 @@ int process_file(const char *path, vector_t *macros,
     if (!load_and_register_file(path, stack, idx, &lines, &dir, &text, ctx))
         return 0;
 
+    ctx->system_header = 0;
+
     char *prev_file;
     long prev_delta;
     line_state_push(ctx, path, 0, &prev_file, &prev_delta);

--- a/src/preproc_file_io.c
+++ b/src/preproc_file_io.c
@@ -75,7 +75,7 @@ int include_stack_push(vector_t *stack, const char *path, size_t idx,
         vc_oom();
         return 0;
     }
-    include_entry_t ent = { canon, idx };
+    include_entry_t ent = { canon, idx, ctx->system_header };
     if (!vector_push(stack, &ent)) {
         free(canon);
         vc_oom();
@@ -91,6 +91,7 @@ void include_stack_pop(vector_t *stack, preproc_context_t *ctx)
 {
     if (stack->count) {
         include_entry_t *e = &((include_entry_t *)stack->data)[stack->count - 1];
+        ctx->system_header = e->prev_system_header;
         free(e->path);
         stack->count--;
     }

--- a/tests/unit/test_preproc_system_header.c
+++ b/tests/unit/test_preproc_system_header.c
@@ -29,12 +29,12 @@ int main(void)
 
     vector_t dirs; vector_init(&dirs, sizeof(char *));
     preproc_context_t ctx;
-    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL, NULL);
     ASSERT(res != NULL);
     if (res) {
         ASSERT(strstr(res, "#pragma system_header") == NULL);
     }
-    ASSERT(ctx.system_header);
+    ASSERT(!ctx.system_header);
     free(res);
     preproc_context_free(&ctx);
     vector_free(&dirs);


### PR DESCRIPTION
## Summary
- track previous `system_header` flag in include stack
- reset `system_header` when entering a file and restore on exit
- adapt system header test to new semantics

## Testing
- `make -s`

------
https://chatgpt.com/codex/tasks/task_e_687325ee81fc8324a8ac6102be89ab77