### PR TITLE
Add preprocessor include path cleanup

### DIFF
--- a/include/preproc_path.h
+++ b/include/preproc_path.h
@@ -22,4 +22,7 @@ int collect_include_dirs(vector_t *search_dirs,
 void print_include_search_dirs(FILE *fp, char endc, const char *dir,
                                const vector_t *incdirs, size_t start);
 
+/* Release cached include path resources */
+void preproc_path_cleanup(void);
+
 #endif /* VC_PREPROC_PATH_H */

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -274,6 +274,7 @@ void preproc_context_free(preproc_context_t *ctx)
     vector_free(&ctx->deps);
     free(ctx->current_file);
     vector_free(&ctx->pack_stack);
+    preproc_path_cleanup();
 }
 
 /*


### PR DESCRIPTION
## Summary
- free cached gcc include path via new `preproc_path_cleanup()`
- reset standard include directory state on cleanup
- call cleanup from `preproc_context_free`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68732889952c83249057acc276a283d9