### PR TITLE
Handle whitespace after include path

### DIFF
--- a/src/preproc_include.c
+++ b/src/preproc_include.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <ctype.h>
 
 #include "util.h"
 #include "preproc_include.h"
@@ -48,6 +49,11 @@ static char *parse_include_name(char *line, char *endc)
         return NULL;
     char *end = strchr(start + 1, *endc);
     if (!end)
+        return NULL;
+    char *p = end + 1;
+    while (isspace((unsigned char)*p))
+        p++;
+    if (*p && !(p[0] == '/' && (p[1] == '*' || p[1] == '/')))
         return NULL;
     size_t len = (size_t)(end - start - 1);
     return vc_strndup(start + 1, len);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -216,6 +216,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_include_comment" "$DIR/unit/test_preproc_include_comment.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_ifmacro" "$DIR/unit/test_preproc_ifmacro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -463,6 +470,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_stdio_skip"
 "$DIR/preproc_has_include"
 "$DIR/preproc_has_include_macro"
+"$DIR/preproc_include_comment"
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"
 "$DIR/preproc_line_macro"

--- a/tests/unit/test_preproc_include_comment.c
+++ b/tests/unit/test_preproc_include_comment.c
@@ -1,0 +1,64 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char dir[] = "/tmp/incXXXXXX";
+    ASSERT(mkdtemp(dir) != NULL);
+
+    char hdr[256];
+    snprintf(hdr, sizeof(hdr), "%s/foo.h", dir);
+    FILE *f = fopen(hdr, "w");
+    ASSERT(f != NULL);
+    if (f) {
+        fputs("int foo = 42;\n", f);
+        fclose(f);
+    }
+
+    char src[] = "/tmp/srcXXXXXX.c";
+    int fd = mkstemp(src);
+    ASSERT(fd >= 0);
+    if (fd >= 0) {
+        dprintf(fd, "#include <foo.h> /*comment*/\n");
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    char *d = strdup(dir);
+    vector_push(&dirs, &d);
+
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, src, &dirs, NULL, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strstr(res, "int foo = 42;") != NULL);
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    free(d);
+    vector_free(&dirs);
+    unlink(src);
+    unlink(hdr);
+    rmdir(dir);
+
+    if (failures == 0)
+        printf("All preproc_include_comment tests passed\n");
+    else
+        printf("%d preproc_include_comment test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- validate trailing characters after `#include` path
- add unit test for angle-bracket includes followed by comments
- run test suite

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68732c01f3288324a205f9d6def12f68