### PR TITLE
Check vc_strdup results

### DIFF
--- a/src/preproc_args.c
+++ b/src/preproc_args.c
@@ -114,6 +114,8 @@ int gather_varargs(vector_t *args, size_t fixed,
     }
     char *va = vc_strdup(sb.data ? sb.data : "");
     strbuf_free(&sb);
+    if (!va)
+        return 0;
     char **ap = malloc((fixed + 1) * sizeof(char *));
     if (!ap) {
         vc_oom();

--- a/src/preproc_expand.c
+++ b/src/preproc_expand.c
@@ -237,6 +237,8 @@ static char *expand_params(const char *value, const vector_t *params, char **arg
     }
     char *out = vc_strdup(sb.data ? sb.data : "");
     strbuf_free(&sb);
+    if (!out)
+        vc_oom();
     return out;
 }
 
@@ -515,6 +517,8 @@ static char *decode_string_literal(const char *s, size_t len)
 
     char *res = vc_strdup(sb.data ? sb.data : "");
     strbuf_free(&sb);
+    if (!res)
+        vc_oom();
     return res;
 }
 

--- a/src/preproc_includes.c
+++ b/src/preproc_includes.c
@@ -157,6 +157,11 @@ int handle_pragma_directive(char *line, const char *dir, vector_t *macros,
         strbuf_appendf(&tmp, "#pragma %s", exp.data ? exp.data : "");
         char *dup = vc_strdup(tmp.data ? tmp.data : "");
         strbuf_free(&tmp);
+        if (!dup) {
+            strbuf_free(&exp);
+            vc_oom();
+            return 0;
+        }
         strbuf_free(&exp);
         int r = process_line(dup, dir, macros, conds, out, incdirs, stack, ctx);
         free(dup);


### PR DESCRIPTION
## Summary
- validate `vc_strdup` return value in several preprocessor helpers
- report memory failures and exit preprocessing cleanly

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873332058948324b79a4264ff5c374c