### PR TITLE
Fix sysroot path handling

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -331,13 +331,18 @@ int collect_include_dirs(vector_t *search_dirs,
     if (sysroot && *sysroot) {
         for (size_t i = 0; std_include_dirs[i]; i++) {
             const char *base = std_include_dirs[i];
-            size_t len = strlen(sysroot) + strlen(base);
+            size_t root_len = strlen(sysroot);
+            while (root_len && (sysroot[root_len - 1] == '/' ||
+                                sysroot[root_len - 1] == '\\'))
+                root_len--; /* strip trailing slash */
+            size_t len = root_len + strlen(base);
             char *dup = malloc(len + 1);
             if (!dup) {
                 free_string_vector(search_dirs);
                 return 0;
             }
-            strcpy(dup, sysroot);
+            memcpy(dup, sysroot, root_len);
+            dup[root_len] = '\0';
             strcat(dup, base);
             if (!vector_push(search_dirs, &dup)) {
                 free(dup);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -386,6 +386,10 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
+    -o "$DIR/collect_include_sysroot" "$DIR/unit/test_collect_include_sysroot.c" \
+    src/preproc_path.c src/vector.c src/util.c
 # build create_temp_file path length regression test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
@@ -501,6 +505,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_independent"
 "$DIR/preproc_errwarn"
 "$DIR/preproc_system_header"
+"$DIR/collect_include_sysroot"
 "$DIR/invalid_macro_tests"
 # separator for clarity
 echo "======="

--- a/tests/unit/test_collect_include_sysroot.c
+++ b/tests/unit/test_collect_include_sysroot.c
@@ -1,0 +1,55 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_path.h"
+#include "util.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    vector_t empty; vector_init(&empty, sizeof(char *));
+    vector_t base; ASSERT(collect_include_dirs(&base, &empty, NULL));
+    size_t count = base.count;
+    char **paths = calloc(count, sizeof(char*));
+    for (size_t i = 0; i < count; i++)
+        paths[i] = strdup(((char **)base.data)[i]);
+    free_string_vector(&base);
+
+    const char *sysroot = "/tmp/sysroot";
+    vector_t pref; ASSERT(collect_include_dirs(&pref, &empty, sysroot));
+    ASSERT(pref.count == count);
+    for (size_t i = 0; i < count; i++) {
+        char expect[4096];
+        snprintf(expect, sizeof(expect), "%s%s", sysroot, paths[i]);
+        ASSERT(strcmp(((char **)pref.data)[i], expect) == 0);
+    }
+    free_string_vector(&pref);
+
+    vector_t pref_slash; ASSERT(collect_include_dirs(&pref_slash, &empty, "/tmp/sysroot/"));
+    ASSERT(pref_slash.count == count);
+    for (size_t i = 0; i < count; i++) {
+        char expect[4096];
+        snprintf(expect, sizeof(expect), "%s%s", sysroot, paths[i]);
+        ASSERT(strcmp(((char **)pref_slash.data)[i], expect) == 0);
+    }
+    free_string_vector(&pref_slash);
+
+    for (size_t i = 0; i < count; i++)
+        free(paths[i]);
+    free(paths);
+    vector_free(&empty);
+
+    if (failures == 0)
+        printf("All collect_include_sysroot tests passed\n");
+    else
+        printf("%d collect_include_sysroot test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- trim trailing slashes from `sysroot` before appending builtin include paths
- add regression test verifying sysroot handling

## Testing
- `tests/run.sh` *(fails: `test_lexer_parser.c` build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687335f0dce48324b176888a49a0aace