### PR TITLE
Add preprocessor test for multiple headers

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -209,6 +209,13 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_multi_stdheaders" "$DIR/unit/test_preproc_multi_stdheaders.c" \
+    src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
+    src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
+    src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
+    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/vector.c src/strbuf.c src/util.c src/error.c
+cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_has_include" "$DIR/unit/test_preproc_has_include.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -480,6 +487,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/read_file_lines_large"
 "$DIR/preproc_stdio"
 "$DIR/preproc_stdio_skip"
+"$DIR/preproc_multi_stdheaders"
 "$DIR/preproc_has_include"
 "$DIR/preproc_has_include_macro"
 "$DIR/preproc_include_comment"

--- a/tests/unit/test_preproc_multi_stdheaders.c
+++ b/tests/unit/test_preproc_multi_stdheaders.c
@@ -1,0 +1,47 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "preproc_file.h"
+
+size_t semantic_pack_alignment = 0;
+void semantic_set_pack(size_t align) { (void)align; }
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char tmpl[] = "/tmp/ppXXXXXX.c";
+    int fd = mkstemp(tmpl);
+    ASSERT(fd >= 0);
+    const char *src = "#include <stdlib.h>\n#include <string.h>\n";
+    if (fd >= 0) {
+        ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
+        close(fd);
+    }
+
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    preproc_context_t ctx;
+    char *res = preproc_run(&ctx, tmpl, &dirs, NULL, NULL);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(res[0] != '\0');
+    }
+    free(res);
+    preproc_context_free(&ctx);
+    vector_free(&dirs);
+    unlink(tmpl);
+
+    if (failures == 0)
+        printf("All preproc_multi_stdheaders tests passed\n");
+    else
+        printf("%d preproc_multi_stdheaders test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- test preprocessing a file that includes <stdlib.h> and <string.h>
- compile/run the new test in the test harness

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687339c01e8c832498ea950c54030224