### PR TITLE
Handle popen/fgets failures in include path logic

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -33,7 +33,9 @@ static const char *get_multiarch_dir(void)
     if (!multiarch_initialized) {
         multiarch_initialized = 1;
         FILE *fp = popen("gcc -print-multiarch 2>/dev/null", "r");
-        if (fp) {
+        if (!fp) {
+            perror("popen");
+        } else {
             char buf[256];
             if (fgets(buf, sizeof(buf), fp)) {
                 size_t len = strlen(buf);
@@ -41,6 +43,8 @@ static const char *get_multiarch_dir(void)
                     buf[--len] = '\0';
                 if (len)
                     multiarch_cached = vc_strndup(buf, len);
+            } else {
+                perror("fgets");
             }
             pclose(fp);
         }
@@ -66,7 +70,9 @@ static const char *get_gcc_include_dir(void)
     if (!gcc_include_initialized) {
         gcc_include_initialized = 1;
         FILE *fp = popen("gcc -print-file-name=include 2>/dev/null", "r");
-        if (fp) {
+        if (!fp) {
+            perror("popen");
+        } else {
             char buf[4096];
             if (fgets(buf, sizeof(buf), fp)) {
                 size_t len = strlen(buf);
@@ -74,6 +80,8 @@ static const char *get_gcc_include_dir(void)
                     buf[--len] = '\0';
                 if (len)
                     gcc_include_cached = vc_strndup(buf, len);
+            } else {
+                perror("fgets");
             }
             pclose(fp);
         }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -397,6 +397,9 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
     -o "$DIR/collect_include_sysroot" "$DIR/unit/test_collect_include_sysroot.c" \
     src/preproc_path.c src/vector.c src/util.c
+cc -Iinclude -Wall -Wextra -std=c99 -Dpopen=test_popen -DUNIT_TESTING -DNO_VECTOR_FREE_STUB \
+    -o "$DIR/preproc_popen_fail" "$DIR/unit/test_preproc_popen_fail.c" \
+    src/preproc_path.c src/vector.c src/util.c
 # build create_temp_file path length regression test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
@@ -514,6 +517,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_errwarn"
 "$DIR/preproc_system_header"
 "$DIR/collect_include_sysroot"
+"$DIR/preproc_popen_fail"
 "$DIR/invalid_macro_tests"
 # separator for clarity
 echo "======="

--- a/tests/unit/test_preproc_popen_fail.c
+++ b/tests/unit/test_preproc_popen_fail.c
@@ -1,0 +1,97 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include "preproc_path.h"
+#include "util.h"
+
+/* stub popen that always fails */
+FILE *test_popen(const char *cmd, const char *mode)
+{
+    (void)cmd; (void)mode;
+    errno = ENOSYS;
+    return NULL;
+}
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    unsetenv("VCPATH");
+    unsetenv("VCINC");
+    unsetenv("CPATH");
+    unsetenv("C_INCLUDE_PATH");
+
+    vector_t empty; vector_init(&empty, sizeof(char *));
+    FILE *tmp = tmpfile();
+    if (!tmp) {
+        perror("tmpfile");
+        exit(1);
+    }
+    int saved = dup(fileno(stderr));
+    dup2(fileno(tmp), fileno(stderr));
+
+    vector_t dirs;
+    ASSERT(collect_include_dirs(&dirs, &empty, "/tmp/sysroot"));
+
+    fflush(stderr);
+    fseek(tmp, 0, SEEK_SET);
+    char buf[256];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    buf[n] = '\0';
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+    fclose(tmp);
+
+#if defined(__linux__)
+#ifndef MULTIARCH_FALLBACK
+#define MULTIARCH_FALLBACK "x86_64-linux-gnu"
+#endif
+#ifdef MULTIARCH
+#define MARCH MULTIARCH
+#else
+#define MARCH MULTIARCH_FALLBACK
+#endif
+    char expect[256];
+    snprintf(expect, sizeof(expect), "/tmp/sysroot/usr/lib/gcc/%s/include", MARCH);
+    int found = 0;
+    for (size_t i = 0; i < dirs.count; i++) {
+        if (strcmp(((char **)dirs.data)[i], expect) == 0) {
+            found = 1;
+            break;
+        }
+    }
+    ASSERT(found);
+#else
+    const char *expect = "/tmp/sysroot/usr/lib/gcc/include";
+    int found = 0;
+    for (size_t i = 0; i < dirs.count; i++) {
+        if (strcmp(((char **)dirs.data)[i], expect) == 0) {
+            found = 1;
+            break;
+        }
+    }
+    ASSERT(found);
+#endif
+
+    free_string_vector(&dirs);
+    vector_free(&empty);
+    preproc_path_cleanup();
+
+    ASSERT(strstr(buf, "popen") != NULL);
+
+    if (failures == 0)
+        printf("All preproc_popen_fail tests passed\n");
+    else
+        printf("%d preproc_popen_fail test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- log errors if `popen` or `fgets` fail while probing gcc paths
- add unit test for fallback path logic when `popen` fails

## Testing
- `cc -Iinclude -Wall -Wextra -std=c99 -Dpopen=test_popen -DUNIT_TESTING -DNO_VECTOR_FREE_STUB -o tests/preproc_popen_fail tests/unit/test_preproc_popen_fail.c src/preproc_path.c src/vector.c src/util.c && ./tests/preproc_popen_fail`
- `tests/run.sh` *(fails: test compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc9f5d5c8324bd6e92f7cadab8c9