### PR TITLE
Check for duplicate macro parameters

### DIFF
--- a/src/preproc_table.c
+++ b/src/preproc_table.c
@@ -171,6 +171,19 @@ static char *parse_macro_params(char *p, vector_t *out, int *variadic)
             out->count--;
         }
     }
+
+    /* check for duplicate parameter names */
+    for (size_t i = 0; i < out->count; i++) {
+        char *name_i = ((char **)out->data)[i];
+        for (size_t j = i + 1; j < out->count; j++) {
+            char *name_j = ((char **)out->data)[j];
+            if (strcmp(name_i, name_j) == 0) {
+                fprintf(stderr, "Duplicate macro parameter name: %s\n", name_j);
+                free_param_vector(out);
+                return NULL;
+            }
+        }
+    }
     return p;
 }
 

--- a/tests/invalid/macro_param_dup.c
+++ b/tests/invalid/macro_param_dup.c
@@ -1,0 +1,2 @@
+#define X(a, a)
+int main() { return 0; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -464,6 +464,19 @@ if [ $ret -eq 0 ] || ! grep -q "Missing ')' in macro definition" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# negative test for duplicate macro parameter names
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" -o "${out}" "$DIR/invalid/macro_param_dup.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "Duplicate macro parameter name" "${err}"; then
+    echo "Test macro_param_dup failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 # negative test for include depth limit
 err=$(mktemp)
 out=$(mktemp)


### PR DESCRIPTION
## Summary
- detect duplicate names in `parse_macro_params`
- report an error when a duplicate macro parameter occurs
- add regression test for duplicate macro parameters

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687403896c0083248732c92425486232