### PR TITLE
Add builtin macros for standard and architecture

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -87,13 +87,18 @@ under `tests/`. It returns a non-zero status if any test fails.
 
 ## Builtin preprocessor macros
 
-Several macros commonly provided by GCC are defined automatically during
-compilation. Their values are taken from the output of `$(CC) -dM -E` so the
-preprocessor sees the same definitions as system headers. This includes:
+Several macros expected by system headers are defined automatically during
+compilation. Most values mirror the output of `$(CC) -dM -E` so the
+preprocessor behaves like GCC.  The compiler also provides a set of standard
+definitions:
 
+- `__STDC__` and `__STDC_HOSTED__` evaluate to `1`.
+- `__i386__` or `__x86_64__` is defined based on the selected bit width.
+- `__SIZE_TYPE__` and `__PTRDIFF_TYPE__` use `unsigned int`/`int` on ILP32 and
+  `unsigned long`/`long` on LP64.
 - `__GNUC__`, `__GNUC_MINOR__`, `__GNUC_PATCHLEVEL__`
-- `__SIZE_TYPE__`, `__PTRDIFF_TYPE__`, `__WCHAR_TYPE__`, `__WINT_TYPE__`
-- `__INTMAX_TYPE__`, `__UINTMAX_TYPE__`, `__INTPTR_TYPE__`, `__UINTPTR_TYPE__`
+- `__WCHAR_TYPE__`, `__WINT_TYPE__`, `__INTMAX_TYPE__`, `__UINTMAX_TYPE__`,
+  `__INTPTR_TYPE__`, `__UINTPTR_TYPE__`
 
 These defaults prevent runaway expansions when processing standard library
 headers.

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -132,25 +132,30 @@ static int define_default_macros(vector_t *macros, const char *base_file)
 #define STR2(x) #x
 #define STR(x) STR2(x)
 
+    /* basic language environment */
+    define_simple_macro(macros, "__STDC__", "1");
+    define_simple_macro(macros, "__STDC_HOSTED__", "1");
+
+#if UINTPTR_MAX == 0xffffffffffffffffULL
+    define_simple_macro(macros, "__x86_64__", "1");
+    define_simple_macro(macros, "__SIZE_TYPE__", "unsigned long");
+    define_simple_macro(macros, "__PTRDIFF_TYPE__", "long");
+#else
+    define_simple_macro(macros, "__i386__", "1");
+    define_simple_macro(macros, "__SIZE_TYPE__", "unsigned int");
+    define_simple_macro(macros, "__PTRDIFF_TYPE__", "int");
+#endif
+
 #ifdef __linux__
     define_simple_macro(macros, "__linux__", "1");
     define_simple_macro(macros, "__unix__", "1");
 #endif
 
-#if defined(__x86_64__) || defined(__amd64__)
-    define_simple_macro(macros, "__x86_64__", "1");
-# ifdef __LP64__
-    define_simple_macro(macros, "__LP64__", "1");
-# endif
-#endif
 
 #ifdef __GNUC__
     define_simple_macro(macros, "__GNUC__", STR(__GNUC__));
     define_simple_macro(macros, "__GNUC_MINOR__", STR(__GNUC_MINOR__));
     define_simple_macro(macros, "__GNUC_PATCHLEVEL__", STR(__GNUC_PATCHLEVEL__));
-#endif
-#ifdef __STDC_HOSTED__
-    define_simple_macro(macros, "__STDC_HOSTED__", STR(__STDC_HOSTED__));
 #endif
 #ifdef __STDC_UTF_16__
     define_simple_macro(macros, "__STDC_UTF_16__", STR(__STDC_UTF_16__));
@@ -174,12 +179,6 @@ static int define_default_macros(vector_t *macros, const char *base_file)
     define_simple_macro(macros, "__STDC_IEC_60559_COMPLEX__", STR(__STDC_IEC_60559_COMPLEX__));
 #endif
 
-#ifdef __SIZE_TYPE__
-    define_simple_macro(macros, "__SIZE_TYPE__", STR(__SIZE_TYPE__));
-#endif
-#ifdef __PTRDIFF_TYPE__
-    define_simple_macro(macros, "__PTRDIFF_TYPE__", STR(__PTRDIFF_TYPE__));
-#endif
 #ifdef __WCHAR_TYPE__
     define_simple_macro(macros, "__WCHAR_TYPE__", STR(__WCHAR_TYPE__));
 #endif


### PR DESCRIPTION
## Summary
- define `__STDC__` and `__STDC_HOSTED__`
- set pointer-size macros for 32/64-bit output
- document the new defaults

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68755933234c832499dceb16d03068e2