### PR TITLE
Update build targets for libc integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man
 LIBC_MAKE = $(MAKE) -C libc
 
-all: $(BIN) libc
+all: test
 
-test: $(BIN)
+test: $(BIN) libc
 	./tests/run_tests.sh
 
 $(BIN): $(OBJ)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,8 +4,8 @@ set -e
 DIR=$(dirname "$0")
 # track failing regression tests
 fail=0
-# build the compiler
-make
+# build the compiler and internal libc
+make vc libc
 # build unit test binary
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/unit_tests" "$DIR/unit/test_lexer_parser.c" \


### PR DESCRIPTION
## Summary
- run tests as part of the default `all` target
- depend on libc when running tests
- build compiler and libc in the test harness

## Testing
- `make vc libc`
- `tests/run_tests.sh` *(fails: Unexpected token 'typedef')*

------
https://chatgpt.com/codex/tasks/task_e_687564dc93d88324a18ff4180c46888e