### PR TITLE
Fix stdio header for vc and adjust libc puts fixture

### DIFF
--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -8,7 +8,12 @@
 #ifndef VC_STDIO_H
 #define VC_STDIO_H
 
+#ifdef __VC__
+int puts();
+int printf();
+#else
 int puts(const char *);
 int printf(const char *, ...);
+#endif
 
 #endif /* VC_STDIO_H */

--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -135,6 +135,8 @@ static int define_default_macros(vector_t *macros, const char *base_file)
     /* basic language environment */
     define_simple_macro(macros, "__STDC__", "1");
     define_simple_macro(macros, "__STDC_HOSTED__", "1");
+    /* identify the vc compiler */
+    define_simple_macro(macros, "__VC__", "1");
 
 #if UINTPTR_MAX == 0xffffffffffffffffULL
     define_simple_macro(macros, "__x86_64__", "1");

--- a/tests/fixtures/libc_puts.c
+++ b/tests/fixtures/libc_puts.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    puts("hello");
+    return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -793,6 +793,25 @@ if ! od -An -t x1 "${libm_exe}" | head -n 1 | grep -q "7f 45 4c 46"; then
 fi
 rm -f "${libm_exe}"
 
+# build and run simple program with internal libc (32-bit and 64-bit)
+libc32=$(mktemp)
+rm -f "${libc32}"
+"$BINARY" --link --internal-libc -o "${libc32}" "$DIR/fixtures/libc_puts.c"
+if [ "$("${libc32}")" != "hello" ]; then
+    echo "Test libc_puts_32 failed"
+    fail=1
+fi
+rm -f "${libc32}"
+
+libc64=$(mktemp)
+rm -f "${libc64}"
+"$BINARY" --x86-64 --link --internal-libc -o "${libc64}" "$DIR/fixtures/libc_puts.c"
+if [ "$("${libc64}")" != "hello" ]; then
+    echo "Test libc_puts_64 failed"
+    fail=1
+fi
+rm -f "${libc64}"
+
 # dependency generation with -MD
 dep_obj=depobj$$.o
 "$BINARY" -MD -c -I "$DIR/includes" -o "$dep_obj" "$DIR/fixtures/include_search.c"


### PR DESCRIPTION
## Summary
- mark the compiler with `__VC__`
- use simpler prototypes in `stdio.h` when compiling with vc
- adjust `libc_puts.c` to avoid `void` argument list

## Testing
- `bash tests/run_tests.sh` *(fails: libc_puts fixture still fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_687561be17008324bc6a304054661a06