### PR TITLE
Add libc docs and flag references

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -6,6 +6,7 @@ See the [documentation index](README.md) for a list of all available pages.
 
 - [Requirements](#requirements)
 - [Build options](#build-options)
+- [Bundled libc](#bundled-libc)
 - [Additional build steps](#additional-build-steps)
 - [Running the test suite](#running-the-test-suite)
 - [Builtin preprocessor macros](#builtin-preprocessor-macros)
@@ -59,6 +60,22 @@ invoke `cc -c` on the generated assembly to produce the object file.
 When the `--intel-syntax` flag is used together with `--compile` or the
 `--link` option, the build requires `nasm` to assemble the Intel-style
 output.
+
+## Bundled libc
+
+The repository includes a small C library under `libc` used for tests and
+examples. Running `make` builds the compiler and both `libc/libc32.a` and
+`libc/libc64.a`. They may also be built individually:
+
+```sh
+make libc32
+make libc64
+```
+
+Invoke the compiler with `--internal-libc` to search `libc/include` before
+system directories and link the appropriate archive. Additional system
+header locations can be supplied with `--vc-sysinclude=<dir>` or the
+`VC_SYSINCLUDE` environment variable.
 
 ## Additional build steps
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -32,6 +32,7 @@ The compiler supports the following options:
 - `--obj-dir <path>` – directory for temporary object files.
 - `--sysroot=<dir>` – prepend `<dir>` to builtin include paths.
 - `--vc-sysinclude=<dir>` – prepend `<dir>` to the system header list.
+- `--internal-libc` – use the bundled libc headers and archive when linking.
 - `--verbose-includes` – print each include directory searched and the
   final resolved path.
 - `-S`, `--dump-asm` – print the generated assembly to stdout instead of creating a file.
@@ -78,14 +79,28 @@ source (for example `file.o`) is created in the current directory.
 
 ## Preprocessor Usage
 
-The preprocessor runs automatically before the lexer. It supports both `#include "file"` and `#include <file>` to insert the contents of another file. Additional directories to search for included files can be provided with the `-I`/`--include` option. Angle-bracket includes search those directories, then any paths listed in the `VCPATH` environment variable (colon separated, or semicolons on Windows), followed by the standard system locations such as `/usr/include`. Quoted includes also consult directories from `VCINC`. Entries from `VCPATH` and `VCINC` are appended after all `-I` directories so command-line paths are searched first. Directories from `VC_SYSINCLUDE` are searched before the builtin list. When `--sysroot` is used these builtin locations are prefixed with the provided directory. It also supports
+The preprocessor runs automatically before the lexer. It supports both
+`#include "file"` and `#include <file>` to insert the contents of another
+file. Additional directories to search for included files can be provided
+with the `-I`/`--include` option. Angle‑bracket includes search those
+directories, then any paths listed in the `VCPATH` environment variable
+(colon separated, or semicolons on Windows), followed by the standard
+system locations such as `/usr/include`. Quoted includes also consult
+directories from `VCINC`. Entries from `VCPATH` and `VCINC` are appended
+after all `-I` directories so command-line paths are searched first.
+Directories from `VC_SYSINCLUDE` or the `--vc-sysinclude` option are
+searched before the builtin list. When `--internal-libc` is used
+`libc/include` is inserted automatically. When `--sysroot` is used these
+builtin locations are prefixed with the provided directory.
 For example:
 
 ```sh
 VCPATH=/opt/headers VCINC=./quoted vc -I ./inc -o prog.s prog.c
 ```
 
-The compiler will search `./inc` first, then `/opt/headers` for `<...>` includes and `./quoted` for `"..."` includes before falling back to the system directories.
+The compiler will search `./inc` first, then `/opt/headers` for `<...>`
+includes and `./quoted` for `"..."` includes before falling back to the
+system directories.
 
 object-like `#define` macros and parameterized
 macros such as `#define NAME(a, b)`; macro bodies are expanded recursively.

--- a/libc/README.md
+++ b/libc/README.md
@@ -1,0 +1,25 @@
+# vc Internal libc
+
+This directory contains a minimal C standard library used by the compiler's
+integration tests and small example programs. It currently targets two
+architectures:
+
+- **i386** following the ILP32 model
+- **x86‑64** following the LP64 model
+
+## Building
+
+Run the following commands from the repository root:
+
+```sh
+make libc32    # build libc/libc32.a for 32-bit code
+make libc64    # build libc/libc64.a for 64-bit code
+make all       # build both archives alongside the compiler
+```
+
+## Extending the library
+
+Public headers live in `libc/include` and must use traditional include guards.
+Implementations belong in `libc/src`. When adding new files update
+`libc/Makefile` so they are compiled for both bit widths. Keep the
+implementations simple and portable.


### PR DESCRIPTION
## Summary
- document internal libc build steps
- mention `--internal-libc` and `--vc-sysinclude` in command line docs
- describe how to use the bundled libc in building guide

## Testing
- `bash tests/run.sh` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_68756c49f4008324be3e6e1c18488273