### PR TITLE
Implement low level syscall helpers

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c99
 
-SRC := $(wildcard src/*.c)
+SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c
 OBJ32 := $(SRC:src/%.c=src/%.32.o)
 OBJ64 := $(SRC:src/%.c=src/%.64.o)
 

--- a/libc/internal/_vc_syscalls.h
+++ b/libc/internal/_vc_syscalls.h
@@ -11,14 +11,12 @@
 #ifdef __x86_64__
 #define VC_SYS_WRITE 1
 #define VC_SYS_EXIT 60
+#define VC_SYS_BRK 12
 #elif defined(__i386__)
 #define VC_SYS_WRITE 4
 #define VC_SYS_EXIT 1
+#define VC_SYS_BRK 45
 #endif
 
-long _vc_write(int fd, const void *buf, unsigned long count);
-void _vc_exit(int status);
-void *_vc_malloc(unsigned long size);
-void _vc_free(void *ptr);
 
 #endif /* VC__VC_SYSCALLS_H */

--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -1,0 +1,85 @@
+#include "../internal/_vc_syscalls.h"
+
+#ifdef __x86_64__
+#define SYSCALL_INVOKE(num, a1, a2, a3) \
+    long ret; \
+    __asm__ volatile ("syscall" \
+                      : "=a"(ret) \
+                      : "a"(num), "D"(a1), "S"(a2), "d"(a3) \
+                      : "rcx", "r11", "memory"); \
+    return ret
+#elif defined(__i386__)
+#define SYSCALL_INVOKE(num, a1, a2, a3) \
+    long ret; \
+    __asm__ volatile ("int $0x80" \
+                      : "=a"(ret) \
+                      : "a"(num), "b"(a1), "c"(a2), "d"(a3) \
+                      : "memory"); \
+    return ret
+#endif
+
+long _vc_write(int fd, const void *buf, unsigned long count)
+{
+    SYSCALL_INVOKE(VC_SYS_WRITE, fd, buf, count);
+}
+
+void _vc_exit(int status)
+{
+#ifdef __x86_64__
+    __asm__ volatile ("syscall" 
+                      :
+                      : "a"(VC_SYS_EXIT), "D"(status)
+                      : "rcx", "r11", "memory");
+#elif defined(__i386__)
+    __asm__ volatile ("int $0x80" 
+                      :
+                      : "a"(VC_SYS_EXIT), "b"(status)
+                      : "memory");
+#endif
+    for (;;);
+}
+
+void *_vc_malloc(unsigned long size)
+{
+    static unsigned long cur_brk = 0;
+    long ret;
+    if (cur_brk == 0) {
+#ifdef __x86_64__
+        __asm__ volatile ("syscall"
+                          : "=a"(ret)
+                          : "a"(VC_SYS_BRK), "D"(0)
+                          : "rcx", "r11", "memory");
+#elif defined(__i386__)
+        __asm__ volatile ("int $0x80"
+                          : "=a"(ret)
+                          : "a"(VC_SYS_BRK), "b"(0)
+                          : "memory");
+#endif
+        if (ret <= 0)
+            return 0;
+        cur_brk = (unsigned long)ret;
+    }
+    unsigned long prev = cur_brk;
+    unsigned long new_brk = cur_brk + size;
+#ifdef __x86_64__
+    __asm__ volatile ("syscall"
+                      : "=a"(ret)
+                      : "a"(VC_SYS_BRK), "D"(new_brk)
+                      : "rcx", "r11", "memory");
+#elif defined(__i386__)
+    __asm__ volatile ("int $0x80"
+                      : "=a"(ret)
+                      : "a"(VC_SYS_BRK), "b"(new_brk)
+                      : "memory");
+#endif
+    if (ret < 0 || (unsigned long)ret < new_brk) {
+        return 0;
+    }
+    cur_brk = new_brk;
+    return (void *)prev;
+}
+
+void _vc_free(void *ptr)
+{
+    (void)ptr;
+}


### PR DESCRIPTION
## Summary
- add internal syscall implementations for libc
- expose new `VC_SYS_BRK` constant
- compile `syscalls.c` for both 32- and 64-bit targets

## Testing
- `make -C libc`
- `make test` *(fails: machine/ansi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68756e368e7c83248ab3a928fda67fe1