### PR TITLE
Update example build script for internal libc

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -6,11 +6,16 @@ VC="$DIR/../vc"
 for src in "$DIR"/*.c; do
     [ -e "$src" ] || continue
     base=$(basename "$src" .c)
-    obj="$DIR/${base}.o"
     exe="$DIR/${base}"
 
     echo "Building $exe"
-    "$VC" -c -o "$obj" "$src"
-    cc -o "$exe" "$obj"
-    rm -f "$obj"
+
+    flags="--link --internal-libc"
+    case "$base" in
+        *_x86-64)
+            flags="$flags --x86-64"
+            ;;
+    esac
+
+    "$VC" $flags -o "$exe" "$src"
 done


### PR DESCRIPTION
## Summary
- use internal libc archive when building examples
- support 64-bit examples automatically

## Testing
- `make test` *(fails: Unexpected token due to missing system headers)*

------
https://chatgpt.com/codex/tasks/task_e_6875700c623483249a1307e568fe7518