### PR TITLE
Add parameter names to libc headers

### DIFF
--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -8,7 +8,7 @@
 #ifndef VC_STDIO_H
 #define VC_STDIO_H
 
-int puts(const char *);
-int printf(const char *, ...);
+int puts(const char *s);
+int printf(const char *format, ...);
 
 #endif /* VC_STDIO_H */

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -10,8 +10,8 @@
 
 #include <stddef.h>
 
-void exit(int);
-void *malloc(size_t);
-void free(void *);
+void exit(int status);
+void *malloc(size_t size);
+void free(void *ptr);
 
 #endif /* VC_STDLIB_H */

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -10,7 +10,7 @@
 
 #include <stddef.h>
 
-size_t strlen(const char *);
-void *memcpy(void *, const void *, size_t);
+size_t strlen(const char *s);
+void *memcpy(void *dest, const void *src, size_t n);
 
 #endif /* VC_STRING_H */

--- a/src/parser_core.c
+++ b/src/parser_core.c
@@ -163,6 +163,9 @@ static int parse_param_decl(parser_t *p, symtable_t *symtab,
     type_kind_t pt;
     char *tag = NULL;
 
+    match(p, TOK_KW_CONST);
+    match(p, TOK_KW_VOLATILE);
+
     if (match(p, TOK_KW_STRUCT) || match(p, TOK_KW_UNION)) {
         token_type_t kw = p->tokens[p->pos - 1].type;
         token_t *id = peek(p);

--- a/src/parser_toplevel_func.c
+++ b/src/parser_toplevel_func.c
@@ -81,6 +81,8 @@ static int parse_param_list_proto(parser_t *p, symtable_t *funcs,
 
     if (!match(p, TOK_RPAREN)) {
         do {
+            match(p, TOK_KW_CONST);
+            match(p, TOK_KW_VOLATILE);
             if (match(p, TOK_ELLIPSIS)) {
                 *is_variadic = 1;
                 break;


### PR DESCRIPTION
## Summary
- name parameters for prototypes in internal libc headers
- teach the parser to handle `const`/`volatile` qualifiers in parameter lists so the headers parse correctly

## Testing
- `tests/run_tests.sh` *(fails: missing `machine/ansi.h`)*

------
https://chatgpt.com/codex/tasks/task_e_6875733c8c688324b7bffae6558e5afe