### PR TITLE
Add void parameter list support

### DIFF
--- a/src/parser_core.c
+++ b/src/parser_core.c
@@ -225,6 +225,14 @@ static int parse_param_list(parser_t *p, symtable_t *symtab,
     *is_variadic = 0;
 
     if (!match(p, TOK_RPAREN)) {
+        if (match(p, TOK_KW_VOID)) {
+            token_t *next = peek(p);
+            if (next && next->type == TOK_RPAREN) {
+                p->pos++; /* consume ')' */
+                goto done_params;
+            }
+            p->pos--; /* treat 'void' as normal type */
+        }
         do {
             if (match(p, TOK_ELLIPSIS)) {
                 *is_variadic = 1;
@@ -244,6 +252,7 @@ static int parse_param_list(parser_t *p, symtable_t *symtab,
         }
     }
 
+done_params:
     if (!validate_param_info(names_v.count, *is_variadic)) {
         cleanup_param_vectors(&names_v, &types_v,
                              &sizes_v, &restrict_v, &tags_v);

--- a/src/parser_toplevel_func.c
+++ b/src/parser_toplevel_func.c
@@ -80,6 +80,14 @@ static int parse_param_list_proto(parser_t *p, symtable_t *funcs,
     *is_variadic = 0;
 
     if (!match(p, TOK_RPAREN)) {
+        if (match(p, TOK_KW_VOID)) {
+            token_t *next = peek(p);
+            if (next && next->type == TOK_RPAREN) {
+                p->pos++; /* consume ')' */
+                goto done_proto;
+            }
+            p->pos--; /* treat 'void' as normal type */
+        }
         do {
             match(p, TOK_KW_CONST);
             match(p, TOK_KW_VOLATILE);
@@ -124,6 +132,7 @@ static int parse_param_list_proto(parser_t *p, symtable_t *funcs,
             return 0;
     }
 
+done_proto:
     return 1;
 }
 


### PR DESCRIPTION
## Summary
- handle `(void)` parameter lists in function definitions and prototypes
- rebuild internal libc archives

## Testing
- `make -C libc libc32.a libc64.a`
- `make test` *(fails: Unexpected token from glibc headers)*

------
https://chatgpt.com/codex/tasks/task_e_68757622bba48324a8edbb2a7f14c047