### PR TITLE
Simplify example build script

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -10,12 +10,5 @@ for src in "$DIR"/*.c; do
 
     echo "Building $exe"
 
-    flags="--link --internal-libc"
-    case "$base" in
-        *_x86-64)
-            flags="$flags --x86-64"
-            ;;
-    esac
-
-    "$VC" $flags -o "$exe" "$src"
+    "$VC" --link --internal-libc -o "$exe" "$src"
 done


### PR DESCRIPTION
## Summary
- simplify `build_examples.sh` by passing flags directly to the compiler

## Testing
- `CC=/tmp/ccnopie VCFLAGS="--x86-64" ./examples/build_examples.sh` *(fails: linker failed)*

------
https://chatgpt.com/codex/tasks/task_e_68757ecd51a083249b2cbf224550a457