### PR TITLE
Fix internal libc build warnings

### DIFF
--- a/libc/README.md
+++ b/libc/README.md
@@ -7,6 +7,16 @@ architectures:
 - **i386** following the ILP32 model
 - **x86‑64** following the LP64 model
 
+Only a few functions are implemented:
+
+- `puts` and a very small `printf`
+- `exit`, `malloc` and `free`
+- `strlen` and `memcpy`
+
+Other standard interfaces are intentionally omitted for now. Programs that
+require features like file I/O must be built against the host system libc
+instead of the bundled one.
+
 ## Building
 
 Run the following commands from the repository root:

--- a/libc/internal/_vc_syscalls.h
+++ b/libc/internal/_vc_syscalls.h
@@ -8,6 +8,8 @@
 #ifndef VC__VC_SYSCALLS_H
 #define VC__VC_SYSCALLS_H
 
+#include <stddef.h>
+
 #ifdef __x86_64__
 #define VC_SYS_WRITE 1
 #define VC_SYS_EXIT 60
@@ -17,6 +19,12 @@
 #define VC_SYS_EXIT 1
 #define VC_SYS_BRK 45
 #endif
+
+
+long _vc_write(int fd, const void *buf, unsigned long count);
+void _vc_exit(int status);
+void *_vc_malloc(unsigned long size);
+void _vc_free(void *ptr);
 
 
 #endif /* VC__VC_SYSCALLS_H */


### PR DESCRIPTION
## Summary
- add missing prototypes for system call helpers
- document which functions the internal libc currently provides

## Testing
- `make -C libc`

------
https://chatgpt.com/codex/tasks/task_e_68759ecc21008324b898b63187d72d09