### PR TITLE
Fix internal libc path handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CC ?= gcc
-CFLAGS ?= -Wall -Wextra -Wpedantic -Wconversion -std=c99
+PROJECT_ROOT := $(CURDIR)
+CFLAGS ?= -Wall -Wextra -Wpedantic -Wconversion -std=c99 \
+    -DPROJECT_ROOT=\"$(PROJECT_ROOT)\"
 OPTFLAGS ?=
 MULTIARCH ?= $(shell $(CC) -print-multiarch 2>/dev/null || echo x86_64-linux-gnu)
 GCC_INCLUDE_DIR := $(shell $(CC) -print-file-name=include | tr -d '\n')

--- a/docs/building.md
+++ b/docs/building.md
@@ -72,8 +72,9 @@ make libc32
 make libc64
 ```
 
-Invoke the compiler with `--internal-libc` to search `libc/include` before
-system directories and link the appropriate archive. Additional system
+Invoke the compiler with `--internal-libc` to search the bundled
+`libc/include` directory before system paths and link the matching
+archive regardless of the current working directory. Additional system
 header locations can be supplied with `--vc-sysinclude=<dir>` or the
 `VC_SYSINCLUDE` environment variable.
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -89,9 +89,10 @@ system locations such as `/usr/include`. Quoted includes also consult
 directories from `VCINC`. Entries from `VCPATH` and `VCINC` are appended
 after all `-I` directories so command-line paths are searched first.
 Directories from `VC_SYSINCLUDE` or the `--vc-sysinclude` option are
-searched before the builtin list. When `--internal-libc` is used
-`libc/include` is inserted automatically. When `--sysroot` is used these
-builtin locations are prefixed with the provided directory.
+searched before the builtin list. When `--internal-libc` is used the
+compiler automatically inserts the bundled `libc/include` directory using
+an absolute path, so it works from any directory. When `--sysroot` is
+used these builtin locations are prefixed with the provided directory.
 For example:
 
 ```sh

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,5 +1,6 @@
 CC ?= gcc
-CFLAGS ?= -Wall -Wextra -std=c99
+PROJECT_ROOT := $(abspath ..)
+CFLAGS ?= -Wall -Wextra -std=c99 -DPROJECT_ROOT=\"$(PROJECT_ROOT)\"
 
 SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c
 OBJ32 := $(SRC:src/%.c=src/%.32.o)

--- a/src/cli_opts.c
+++ b/src/cli_opts.c
@@ -355,7 +355,8 @@ int finalize_options(int argc, char **argv, const char *prog,
 
     if (opts->internal_libc) {
         const char *dir = (opts->vc_sysinclude && *opts->vc_sysinclude)
-                            ? opts->vc_sysinclude : "libc/include";
+                            ? opts->vc_sysinclude
+                            : PROJECT_ROOT "/libc/include";
         char hdr[PATH_MAX];
         snprintf(hdr, sizeof(hdr), "%s/stdio.h", dir);
         if (access(hdr, F_OK) != 0) {
@@ -367,7 +368,8 @@ int finalize_options(int argc, char **argv, const char *prog,
         }
 
         const char *archive = opts->use_x86_64 ?
-                               "libc/libc64.a" : "libc/libc32.a";
+                               PROJECT_ROOT "/libc/libc64.a" :
+                               PROJECT_ROOT "/libc/libc32.a";
         if (access(archive, F_OK) != 0) {
             fprintf(stderr,
                     "Error: internal libc archive '%s' not found.\n",

--- a/src/compile_link.c
+++ b/src/compile_link.c
@@ -287,9 +287,11 @@ static int build_and_link_objects(vector_t *objs, const cli_options_t *cli)
     }
 
     if (cli->internal_libc && !disable_stdlib) {
-        const char *dir = "libc";
+        const char *dir = PROJECT_ROOT "/libc";
         const char *libname = cli->use_x86_64 ? "c64" : "c32";
-        const char *archive = cli->use_x86_64 ? "libc/libc64.a" : "libc/libc32.a";
+        const char *archive = cli->use_x86_64 ?
+                             PROJECT_ROOT "/libc/libc64.a" :
+                             PROJECT_ROOT "/libc/libc32.a";
 
         if (access(archive, F_OK) != 0) {
             fprintf(stderr, "vc: internal libc archive '%s' not found\n", archive);

--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -395,7 +395,7 @@ int collect_include_dirs(vector_t *search_dirs,
     free_string_vector(&extra_sys_dirs);
     vector_init(&extra_sys_dirs, sizeof(char *));
     if (internal_libc) {
-        char *dup = vc_strdup("libc/include");
+        char *dup = vc_strdup(PROJECT_ROOT "/libc/include");
         if (!dup || !vector_push(&extra_sys_dirs, &dup)) {
             free(dup);
             free_string_vector(search_dirs);


### PR DESCRIPTION
## Summary
- define PROJECT_ROOT macro with absolute repo path
- compile libc and compiler with PROJECT_ROOT
- use PROJECT_ROOT when locating internal libc headers and archives
- document that `--internal-libc` works from any directory

## Testing
- `make test` *(fails: features.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68759ecc21008324b898b63187d72d09