### PR TITLE
Fix libc_puts fixture handling

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -12,7 +12,7 @@ for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
 
     case "$base" in
-        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio)
+        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio|libc_puts)
             continue;;
     esac
     expect="$DIR/fixtures/$base.s"


### PR DESCRIPTION
## Summary
- skip `libc_puts.c` in the generic fixture loop
- only build `libc_puts.c` for the internal libc tests

## Testing
- `make test` *(fails: linker error for 32‑bit build)*

------
https://chatgpt.com/codex/tasks/task_e_6875a2b2455c8324ab283d0849cde0d0