### PR TITLE
Fix string constant emission for newline

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -176,7 +176,28 @@ void codegen_emit_x86(FILE *out, ir_builder_t *ir, int x64,
             if (ins->op == IR_GLOB_VAR) {
                 fprintf(out, "    %s %lld\n", size_directive, ins->imm);
             } else if (ins->op == IR_GLOB_STRING) {
-                fprintf(out, "    .asciz \"%s\"\n", ins->data);
+                const char *s = ins->data;
+                fputs("    .asciz \"", out);
+                for (; *s; s++) {
+                    unsigned char c = (unsigned char)*s;
+                    switch (c) {
+                    case '\\': fputs("\\\\", out); break;
+                    case '"':  fputs("\\\"", out); break;
+                    case '\n': fputs("\\n", out); break;
+                    case '\t': fputs("\\t", out); break;
+                    case '\r': fputs("\\r", out); break;
+                    case '\b': fputs("\\b", out); break;
+                    case '\f': fputs("\\f", out); break;
+                    case '\v': fputs("\\v", out); break;
+                    case '\a': fputs("\\a", out); break;
+                    default:
+                        if (c < 32 || c > 126)
+                            fprintf(out, "\\x%02x", c);
+                        else
+                            fputc(c, out);
+                    }
+                }
+                fputs("\"\n", out);
             } else if (ins->op == IR_GLOB_WSTRING) {
                 long long *vals = (long long *)ins->data;
                 for (long long i = 0; i < ins->imm; i++)

--- a/tests/fixtures/libc_printf.c
+++ b/tests/fixtures/libc_printf.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("hi\n");
+    return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -21,7 +21,7 @@ for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
 
     case "$base" in
-        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio|libc_puts)
+        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio|libc_puts|libc_printf)
             continue;;
     esac
     expect="$DIR/fixtures/$base.s"
@@ -822,6 +822,26 @@ if [ "$("${libc64}")" != "hello" ]; then
     fail=1
 fi
 rm -f "${libc64}"
+
+if [ $CAN_COMPILE_32 -eq 0 ]; then
+    libc_printf32=$(mktemp)
+    rm -f "${libc_printf32}"
+    "$BINARY" --link --internal-libc -o "${libc_printf32}" "$DIR/fixtures/libc_printf.c"
+    if [ "$("${libc_printf32}")" != "hi" ]; then
+        echo "Test libc_printf_32 failed"
+        fail=1
+    fi
+    rm -f "${libc_printf32}"
+fi
+
+libc_printf64=$(mktemp)
+rm -f "${libc_printf64}"
+"$BINARY" --x86-64 --link --internal-libc -o "${libc_printf64}" "$DIR/fixtures/libc_printf.c"
+if [ "$("${libc_printf64}")" != "hi" ]; then
+    echo "Test libc_printf_64 failed"
+    fail=1
+fi
+rm -f "${libc_printf64}"
 
 # dependency generation with -MD
 dep_obj=depobj$$.o


### PR DESCRIPTION
## Summary
- handle escape sequences when emitting `.asciz` strings
- skip `libc_printf.c` in fixture loop and add new libc printf tests
- new fixture exercising `printf` with a newline

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6875afcacf5083248e0b8fd0419b0046