### PR TITLE
Update example build logging

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,9 @@ To compile every example at once run the helper script:
 ./build_examples.sh
 ```
 
+If a build fails, check the generated `<program>.log` files in this
+directory for compiler output.
+
 ## Programs
 
 ### hello.c

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -21,5 +21,5 @@ for src in "$DIR"/*.c; do
 
     echo "Building $exe"
 
-    "$VC" --link --internal-libc $ARCH_OPT -o "$exe" "$src"
+    "$VC" --link --internal-libc $ARCH_OPT -o "$exe" "$src" >"$exe.log" 2>&1
 done


### PR DESCRIPTION
## Summary
- capture compiler output to log files in `build_examples.sh`
- document where logs are written when example builds fail

## Testing
- `make test` *(fails: linker segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6875bbb07c9c83248a3f46869c843f1e