### PR TITLE
Fix stack variable naming after constant propagation

### DIFF
--- a/src/semantic_expr.c
+++ b/src/semantic_expr.c
@@ -233,9 +233,9 @@ static type_kind_t check_assign_expr(expr_t *expr, symtable_t *vars,
     if (sym->param_index >= 0)
         ir_build_store_param(ir, sym->param_index, val);
     else if (sym->is_volatile)
-        ir_build_store_vol(ir, expr->data.assign.name, val);
+        ir_build_store_vol(ir, sym->ir_name, val);
     else
-        ir_build_store(ir, expr->data.assign.name, val);
+        ir_build_store(ir, sym->ir_name, val);
 
     if (out)
         *out = val;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -865,6 +865,15 @@ if [ "$("${local64}")" != "$expected" ]; then
 fi
 rm -f "${local64}"
 
+# verify stack offsets in generated assembly for local_program
+asm_chk=$(mktemp)
+"$BINARY" --x86-64 --internal-libc -o "${asm_chk}" "$DIR/fixtures/local_program.c"
+if grep -q "\bsum\b" "${asm_chk}"; then
+    echo "Test local_program_stack failed"
+    fail=1
+fi
+rm -f "${asm_chk}"
+
 # dependency generation with -MD
 dep_obj=depobj$$.o
 "$BINARY" -MD -c -I "$DIR/includes" -o "$dep_obj" "$DIR/fixtures/include_search.c"


### PR DESCRIPTION
## Summary
- preserve IR name for assignments using the symbol's `ir_name`
- add regression test ensuring `local_program.c` stores to a stack offset

## Testing
- `examples/build_examples.sh`
- `./vc --x86-64 --internal-libc -o /tmp/local_test.s tests/fixtures/local_program.c`

------
https://chatgpt.com/codex/tasks/task_e_6875c1c5dd9c8324b37be84f771c9a57