### PR TITLE
Gracefully skip libc32 when host lacks -m32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ libc32:
 libc64:
 	$(LIBC_MAKE) libc64
 
-libc: libc32 libc64
+libc:
+	$(LIBC_MAKE)
 
 install: $(BIN)
 	install -d $(DESTDIR)$(INCLUDEDIR)

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -2,24 +2,38 @@ CC ?= gcc
 PROJECT_ROOT := $(abspath ..)
 CFLAGS ?= -Wall -Wextra -std=c99 -DPROJECT_ROOT=\"$(PROJECT_ROOT)\"
 
+# determine if the host toolchain can build 32-bit objects
+CAN_COMPILE_32 := $(shell $(CC) -m32 -xc /dev/null -o /dev/null \
+    >/dev/null 2>&1 && echo yes || echo no)
+
 SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c
 OBJ32 := $(SRC:src/%.c=src/%.32.o)
 OBJ64 := $(SRC:src/%.c=src/%.64.o)
 
+ifeq ($(CAN_COMPILE_32),yes)
 all: libc32 libc64
+else
+all: libc64
+	@echo "Notice: 32-bit compilation not available, skipping libc32 build"
+endif
 
+ifeq ($(CAN_COMPILE_32),yes)
 libc32: libc32.a
-
-libc64: libc64.a
 
 libc32.a: $(OBJ32)
 	ar rcs $@ $(OBJ32)
 
-libc64.a: $(OBJ64)
-	ar rcs $@ $(OBJ64)
-
 src/%.32.o: src/%.c
 	$(CC) $(CFLAGS) -m32 -Iinclude -c $< -o $@
+else
+libc32 libc32.a:
+	@echo "Notice: 32-bit compilation not available, skipping libc32 build"
+endif
+
+libc64: libc64.a
+
+libc64.a: $(OBJ64)
+	ar rcs $@ $(OBJ64)
 
 src/%.64.o: src/%.c
 	$(CC) $(CFLAGS) -m64 -Iinclude -c $< -o $@


### PR DESCRIPTION
## Summary
- detect 32-bit compiler availability in `libc/Makefile`
- print a notice and only build `libc64.a` when `-m32` fails
- update the top-level Makefile so the `libc` target relies on the sub-Makefile's logic

## Testing
- `make libc`
- `make test` *(fails: Test intel_while_loop failed, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6875c4f9dddc8324810d2abd454b5afb