### PR TITLE
Allow independent example builds

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
-set -e
+
+# do not exit on first failure so all examples are attempted
 DIR="$(dirname "$0")"
 VC="$DIR/../vc"
 
 # detect 32-bit compilation capability
-set +e
 gcc -m32 -xc /dev/null -o /dev/null 2>/dev/null
 HAS_32=$?
-set -e
 ARCH_OPT=""
 if [ $HAS_32 -ne 0 ]; then
     echo "32-bit compilation not available, building examples in 64-bit mode"
     ARCH_OPT="--x86-64"
 fi
+
+success=0
+fail=0
 
 for src in "$DIR"/*.c; do
     [ -e "$src" ] || continue
@@ -22,4 +24,15 @@ for src in "$DIR"/*.c; do
     echo "Building $exe"
 
     "$VC" --link --internal-libc $ARCH_OPT -o "$exe" "$src" >"$exe.log" 2>&1
+    if [ $? -eq 0 ]; then
+        success=$((success + 1))
+    else
+        echo "Failed to build $exe (see $exe.log)"
+        fail=$((fail + 1))
+    fi
 done
+
+total=$((success + fail))
+echo "Build summary: ${success} succeeded, ${fail} failed, ${total} total"
+
+[ $fail -eq 0 ]


### PR DESCRIPTION
## Summary
- run each example build without stopping on error
- record success/failure counts and print summary at end

## Testing
- `make test` *(fails: Test intel_while_loop failed, etc.)*
- `examples/build_examples.sh` *(fails building file_io)*

------
https://chatgpt.com/codex/tasks/task_e_6875c650e45083248d7c80543d63d8c5