### PR TITLE
Add local_assign fixture and stack-relative test

### DIFF
--- a/tests/fixtures/local_assign.c
+++ b/tests/fixtures/local_assign.c
@@ -1,0 +1,6 @@
+int main() {
+    int i = 0;
+    while (i < 3)
+        i = i + 1;
+    return i;
+}

--- a/tests/fixtures/local_assign.s
+++ b/tests/fixtures/local_assign.s
@@ -1,0 +1,20 @@
+main:
+    pushq %rbp
+    movq %rsp, %rbp
+    subq $16, %rsp
+    movq $0, %rax
+    movq %rax, -4(%rbp)
+L0_start:
+    movq $1, %rax
+    cmpq $0, %rax
+    je L0_end
+    movq $1, %rax
+    movq %rax, -4(%rbp)
+    jmp L0_start
+L0_end:
+    movq -4(%rbp), %rax
+    movq %rax, %rax
+    ret
+    movq %rbp, %rsp
+    popq %rbp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -21,7 +21,7 @@ for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
 
     case "$base" in
-        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio|libc_puts|libc_printf|local_program)
+        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio|libc_puts|libc_printf|local_program|local_assign)
             continue;;
     esac
     expect="$DIR/fixtures/$base.s"
@@ -873,6 +873,15 @@ if grep -q "\bsum\b" "${asm_chk}"; then
     fail=1
 fi
 rm -f "${asm_chk}"
+
+# verify assembly for local_assign with internal libc
+assign_out=$(mktemp)
+"$BINARY" --x86-64 --internal-libc -o "${assign_out}" "$DIR/fixtures/local_assign.c"
+if ! diff -u "$DIR/fixtures/local_assign.s" "${assign_out}"; then
+    echo "Test local_assign_libc failed"
+    fail=1
+fi
+rm -f "${assign_out}"
 
 # dependency generation with -MD
 dep_obj=depobj$$.o


### PR DESCRIPTION
## Summary
- add `local_assign.c` with simple increment loop
- provide expected assembly `local_assign.s` using stack-relative addressing
- test new fixture with `--internal-libc` in `run_tests.sh`

## Testing
- `./tests/run_tests.sh` *(fails: Test intel_while_loop failed)*

------
https://chatgpt.com/codex/tasks/task_e_6875c73c47848324a18b30ba014c3653