### PR TITLE
Improve missing internal libc diagnostic

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -78,6 +78,9 @@ archive regardless of the current working directory. Additional system
 header locations can be supplied with `--vc-sysinclude=<dir>` or the
 `VC_SYSINCLUDE` environment variable.
 
+If the selected archive is missing the compiler prints an error similar to
+`vc: internal libc archive 'libc/libc64.a' not found. Build it with 'make libc64'`.
+
 ## Additional build steps
 
 Extra source files can be passed to the build using the `EXTRA_SRC`

--- a/src/compile_link.c
+++ b/src/compile_link.c
@@ -311,7 +311,10 @@ static int build_and_link_objects(vector_t *objs, const cli_options_t *cli)
         }
 
         if (access(archive, F_OK) != 0) {
-            fprintf(stderr, "vc: internal libc archive '%s' not found\n", archive);
+            const char *make_target = cli->use_x86_64 ? "libc64" : "libc32";
+            fprintf(stderr,
+                    "vc: internal libc archive '%s' not found. Build it with 'make %s'\n",
+                    archive, make_target);
             vector_free(&lib_dirs);
             vector_free(&libs);
             return 0;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -843,6 +843,22 @@ if [ "$("${libc_printf64}")" != "hi" ]; then
 fi
 rm -f "${libc_printf64}"
 
+# verify error message when internal libc archive is missing
+archive_path="$DIR/../libc/libc64.a"
+mv "$archive_path" "$archive_path.bak"
+err=$(mktemp)
+out=$(mktemp)
+set +e
+"$BINARY" --x86-64 --internal-libc -o "${out}" "$DIR/fixtures/simple_add.c" 2> "$err"
+ret=$?
+set -e
+mv "$archive_path.bak" "$archive_path"
+if [ $ret -eq 0 ] || ! grep -q "make libc64" "$err"; then
+    echo "Test internal_libc_missing failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
 # build and run program with locals using internal libc
 expected="5 + 2 = 7\n5 - 2 = 3\n5 * 2 = 10\n5 / 2 = 2\nSum 1..10 = 55"
 if [ $CAN_COMPILE_32 -eq 0 ]; then


### PR DESCRIPTION
## Summary
- clarify missing bundled libc archive error message
- note missing archive behavior in docs
- test compiler output when libc64.a is absent

## Testing
- `make test` *(fails: Test intel_while_loop failed)*

------
https://chatgpt.com/codex/tasks/task_e_6875c8e77af083248633b1356566b0b8