### PR TITLE
Build libc before examples

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -13,6 +13,12 @@ if [ $HAS_32 -ne 0 ]; then
     ARCH_OPT="--x86-64"
 fi
 
+# build internal libc archives quietly
+if ! make -s -C "$DIR/../libc"; then
+    echo "Failed to build internal libc" >&2
+    exit 1
+fi
+
 success=0
 fail=0
 


### PR DESCRIPTION
## Summary
- build internal libc archives before compiling examples
- report failures if the libc build step fails

## Testing
- `make test` *(fails: Test intel_while_loop failed)*

------
https://chatgpt.com/codex/tasks/task_e_6875ca9ff42c8324bb7e8fbc0de0de45