### PR TITLE
Fix 64-bit argument order

### DIFF
--- a/include/semantic_global.h
+++ b/include/semantic_global.h
@@ -18,6 +18,9 @@
 extern size_t semantic_pack_alignment;
 extern int semantic_stack_offset;
 void semantic_set_pack(size_t align);
+/* Target architecture flag used by semantic analysis */
+extern int semantic_use_x86_64;
+void semantic_set_use_x86_64(int flag);
 
 int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
                ir_builder_t *ir);

--- a/src/compile_stage.c
+++ b/src/compile_stage.c
@@ -250,6 +250,7 @@ static void init_compile_context(compile_context_t *ctx, const char *source,
     codegen_set_debug(cli->debug || cli->emit_dwarf);
     codegen_set_dwarf(cli->emit_dwarf);
     compile_ctx_init(ctx);
+    semantic_set_use_x86_64(cli->use_x86_64);
 }
 
 static void finalize_compile_context(compile_context_t *ctx)

--- a/src/compile_tokenize.c
+++ b/src/compile_tokenize.c
@@ -204,6 +204,7 @@ static int read_stdin_source(const cli_options_t *cli,
         return 0;
     }
     semantic_set_pack(ctx.pack_alignment);
+    semantic_set_use_x86_64(cli->use_x86_64);
     if (ctx.system_header)
         semantic_suppress_warnings = true;
     preproc_context_free(&ctx);
@@ -259,6 +260,7 @@ int compile_tokenize_impl(const char *source, const cli_options_t *cli,
             }
         }
         semantic_set_pack(ctx.pack_alignment);
+        semantic_set_use_x86_64(cli->use_x86_64);
         if (ctx.system_header)
             semantic_suppress_warnings = true;
         preproc_context_free(&ctx);

--- a/src/semantic_call.c
+++ b/src/semantic_call.c
@@ -14,6 +14,7 @@
 #include "semantic_expr.h"
 #include "consteval.h"
 #include "symtable.h"
+#include "semantic_global.h"
 #include "util.h"
 #include "label.h"
 #include "error.h"
@@ -81,14 +82,13 @@ type_kind_t check_call_expr(expr_t *expr, symtable_t *vars,
             }
         }
     }
-    for (size_t i = expr->data.call.arg_count; i > 0; i--) {
-        size_t idx = i - 1;
-        type_kind_t at = atypes[idx];
-        if (idx >= expected &&
-            (at == TYPE_FLOAT || at == TYPE_DOUBLE || at == TYPE_LDOUBLE)) {
-            ir_build_arg(ir, vals[idx], at);
-        } else {
-            ir_build_arg(ir, vals[idx], at);
+    if (semantic_use_x86_64) {
+        for (size_t idx = 0; idx < expr->data.call.arg_count; idx++)
+            ir_build_arg(ir, vals[idx], atypes[idx]);
+    } else {
+        for (size_t i = expr->data.call.arg_count; i > 0; i--) {
+            size_t idx = i - 1;
+            ir_build_arg(ir, vals[idx], atypes[idx]);
         }
     }
     free(vals);

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -35,6 +35,14 @@ size_t semantic_pack_alignment = 0;
 /* total bytes of automatic storage for the current function */
 int semantic_stack_offset = 0;
 
+/* whether 64-bit code generation is enabled */
+int semantic_use_x86_64 = 0;
+
+void semantic_set_use_x86_64(int flag)
+{
+    semantic_use_x86_64 = flag;
+}
+
 void semantic_set_pack(size_t align)
 {
     semantic_pack_alignment = align;


### PR DESCRIPTION
## Summary
- track the target architecture in the semantic phase
- set the architecture flag during compilation
- adjust call argument ordering for x86-64

## Testing
- `make test` *(fails: Test intel_while_loop failed)*
- `./build_examples.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875ce8c58988324813c898c4ca607c1