### PR TITLE
Add minimal file IO to internal libc

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -29,7 +29,14 @@ for src in "$DIR"/*.c; do
 
     echo "Building $exe"
 
-    "$VC" --link --internal-libc $ARCH_OPT -o "$exe" "$src" >"$exe.log" 2>&1
+    opts="--link $ARCH_OPT"
+    if [ "$base" = "file_io" ]; then
+        opts="$opts --internal-libc"
+    else
+        opts="$opts --internal-libc"
+    fi
+
+    "$VC" $opts -o "$exe" "$src" >"$exe.log" 2>&1
     if [ $? -eq 0 ]; then
         success=$((success + 1))
     else

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -6,7 +6,7 @@ CFLAGS ?= -Wall -Wextra -std=c99 -DPROJECT_ROOT=\"$(PROJECT_ROOT)\"
 CAN_COMPILE_32 := $(shell $(CC) -m32 -xc /dev/null -o /dev/null \
     >/dev/null 2>&1 && echo yes || echo no)
 
-SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c
+SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c src/file.c
 OBJ32 := $(SRC:src/%.c=src/%.32.o)
 OBJ64 := $(SRC:src/%.c=src/%.64.o)
 

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -13,5 +13,15 @@
 int puts(const char *s);
 int printf(const char *format, ...);
 
+typedef struct FILE {
+    int fd;
+} FILE;
+
+FILE *fopen(const char *path, const char *mode);
+int fclose(FILE *stream);
+int fprintf(FILE *stream, const char *format, ...);
+char *fgets(char *s, int size, FILE *stream);
+void perror(const char *msg);
+
 
 #endif /* VC_STDIO_H */

--- a/libc/internal/_vc_syscalls.h
+++ b/libc/internal/_vc_syscalls.h
@@ -12,16 +12,25 @@
 
 #ifdef __x86_64__
 #define VC_SYS_WRITE 1
+#define VC_SYS_READ 0
+#define VC_SYS_OPEN 2
+#define VC_SYS_CLOSE 3
 #define VC_SYS_EXIT 60
 #define VC_SYS_BRK 12
 #elif defined(__i386__)
 #define VC_SYS_WRITE 4
+#define VC_SYS_READ 3
+#define VC_SYS_OPEN 5
+#define VC_SYS_CLOSE 6
 #define VC_SYS_EXIT 1
 #define VC_SYS_BRK 45
 #endif
 
 
 long _vc_write(int, const void *, unsigned long);
+long _vc_read(int, void *, unsigned long);
+long _vc_open(const char *, int, int);
+long _vc_close(int);
 void _vc_exit(int);
 void *_vc_malloc(unsigned long);
 void _vc_free(void *);

--- a/libc/src/file.c
+++ b/libc/src/file.c
@@ -1,0 +1,146 @@
+#include <stddef.h>
+#include <stdarg.h>
+#include <string.h>
+#include "stdio.h"
+#include "stdlib.h"
+#include "../internal/_vc_syscalls.h"
+
+FILE *fopen(const char *path, const char *mode)
+{
+    int flags = 0;
+    int perm = 0;
+    if (mode && mode[0] == 'r') {
+        flags = 0; /* O_RDONLY */
+    } else if (mode && mode[0] == 'w') {
+        flags = 1 | 64 | 512; /* O_WRONLY | O_CREAT | O_TRUNC */
+        perm = 0666;
+    } else {
+        return NULL;
+    }
+
+    long fd = _vc_open(path, flags, perm);
+    if (fd < 0)
+        return NULL;
+
+    FILE *f = malloc(sizeof(FILE));
+    if (!f) {
+        _vc_close(fd);
+        return NULL;
+    }
+    f->fd = (int)fd;
+    return f;
+}
+
+int fclose(FILE *stream)
+{
+    if (!stream)
+        return -1;
+    int ret = (int)_vc_close(stream->fd);
+    free(stream);
+    return ret;
+}
+
+static void flush_buf_fd(int fd, const char *buf, size_t *pos, int *total)
+{
+    if (*pos > 0) {
+        _vc_write(fd, buf, *pos);
+        if (total)
+            *total += (int)(*pos);
+        *pos = 0;
+    }
+}
+
+int fprintf(FILE *stream, const char *fmt, ...)
+{
+    va_list ap;
+    char out[64];
+    size_t pos = 0;
+    int written = 0;
+
+    va_start(ap, fmt);
+    for (const char *p = fmt; *p; ++p) {
+        if (*p != '%') {
+            out[pos++] = *p;
+            if (pos == sizeof(out))
+                flush_buf_fd(stream->fd, out, &pos, &written);
+            continue;
+        }
+
+        p++;
+        if (*p == '%') {
+            out[pos++] = '%';
+            if (pos == sizeof(out))
+                flush_buf_fd(stream->fd, out, &pos, &written);
+            continue;
+        }
+
+        flush_buf_fd(stream->fd, out, &pos, &written);
+
+        if (*p == 's') {
+            const char *s = va_arg(ap, const char *);
+            size_t len = strlen(s);
+            _vc_write(stream->fd, s, len);
+            written += (int)len;
+        } else if (*p == 'd') {
+            int n = va_arg(ap, int);
+            char num[32];
+            char *q = num + sizeof(num);
+            unsigned int u = (n < 0) ? (unsigned int)(-n) : (unsigned int)n;
+            if (n == 0) {
+                *--q = '0';
+            } else {
+                while (u) {
+                    *--q = (char)('0' + (u % 10));
+                    u /= 10;
+                }
+                if (n < 0)
+                    *--q = '-';
+            }
+            size_t len = num + sizeof(num) - q;
+            _vc_write(stream->fd, q, len);
+            written += (int)len;
+        } else {
+            out[pos++] = '%';
+            if (pos == sizeof(out))
+                flush_buf_fd(stream->fd, out, &pos, &written);
+            out[pos++] = *p;
+            if (pos == sizeof(out))
+                flush_buf_fd(stream->fd, out, &pos, &written);
+        }
+    }
+
+    flush_buf_fd(stream->fd, out, &pos, &written);
+    va_end(ap);
+    return written;
+}
+
+char *fgets(char *s, int size, FILE *stream)
+{
+    if (size <= 0)
+        return NULL;
+    int i = 0;
+    while (i < size - 1) {
+        char c;
+        long r = _vc_read(stream->fd, &c, 1);
+        if (r <= 0) {
+            if (i == 0)
+                return NULL;
+            break;
+        }
+        s[i++] = c;
+        if (c == '\n')
+            break;
+    }
+    s[i] = '\0';
+    return s;
+}
+
+void perror(const char *msg)
+{
+    if (msg && *msg) {
+        size_t len = strlen(msg);
+        _vc_write(2, msg, len);
+        _vc_write(2, ": ", 2);
+    }
+    _vc_write(2, "error\n", 6);
+}

--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -23,6 +23,21 @@ long _vc_write(int fd, const void *buf, unsigned long count)
     SYSCALL_INVOKE(VC_SYS_WRITE, fd, buf, count);
 }
 
+long _vc_read(int fd, void *buf, unsigned long count)
+{
+    SYSCALL_INVOKE(VC_SYS_READ, fd, buf, count);
+}
+
+long _vc_open(const char *path, int flags, int mode)
+{
+    SYSCALL_INVOKE(VC_SYS_OPEN, path, flags, mode);
+}
+
+long _vc_close(int fd)
+{
+    SYSCALL_INVOKE(VC_SYS_CLOSE, fd, 0, 0);
+}
+
 __attribute__((noreturn, naked)) void _vc_exit(int status)
 {
 #ifdef __x86_64__

--- a/tests/fixtures/libc_fileio.c
+++ b/tests/fixtures/libc_fileio.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+int main(void)
+{
+    FILE *f = fopen("input.txt", "r");
+    if (!f)
+        return 1;
+    char buf[64];
+    if (fgets(buf, sizeof(buf), f))
+        printf("%s", buf);
+    fclose(f);
+    return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -903,6 +903,29 @@ if ! diff -u "$DIR/fixtures/local_assign.s" "${assign_out}"; then
 fi
 rm -f "${assign_out}"
 
+# build and run simple file I/O program with internal libc
+io_file="$DIR/input.txt"
+echo "hello" > "$io_file"
+if [ $CAN_COMPILE_32 -eq 0 ]; then
+    fileio32=$(mktemp)
+    rm -f "${fileio32}"
+    "$BINARY" --link --internal-libc -o "${fileio32}" "$DIR/fixtures/libc_fileio.c"
+    if [ "$("${fileio32}")" != "hello" ]; then
+        echo "Test libc_fileio_32 failed"
+        fail=1
+    fi
+    rm -f "${fileio32}"
+fi
+
+fileio64=$(mktemp)
+rm -f "${fileio64}"
+"$BINARY" --x86-64 --link --internal-libc -o "${fileio64}" "$DIR/fixtures/libc_fileio.c"
+if [ "$("${fileio64}")" != "hello" ]; then
+    echo "Test libc_fileio_64 failed"
+    fail=1
+fi
+rm -f "${fileio64}" "$io_file"
+
 # dependency generation with -MD
 dep_obj=depobj$$.o
 "$BINARY" -MD -c -I "$DIR/includes" -o "$dep_obj" "$DIR/fixtures/include_search.c"


### PR DESCRIPTION
## Summary
- add `FILE` structure and file I/O prototypes
- implement `fopen`, `fclose`, `fprintf`, `fgets` and `perror`
- extend syscall wrappers for `open`, `read` and `close`
- compile new object in libc Makefile
- adjust example build script
- test fopen/fgets in regression suite

## Testing
- `make -C libc`
- `make vc`
- `tests/run_tests.sh` *(fails: machine/ansi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876658d7b8c8324a68a16e3b5cda2d5