### PR TITLE
Add example test runner

### DIFF
--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -e
+DIR="$(dirname "$0")"
+EX_DIR="$DIR/../examples"
+VC="$DIR/../vc"
+
+# detect 32-bit compilation capability
+set +e
+gcc -m32 -xc /dev/null -o /dev/null 2>/dev/null
+CAN_COMPILE_32=$?
+set -e
+ARCH_OPT=""
+if [ $CAN_COMPILE_32 -ne 0 ]; then
+    echo "32-bit compilation not available, using 64-bit mode"
+    ARCH_OPT="--x86-64"
+fi
+
+# build internal libc quietly
+make -s -C "$DIR/../libc" >/dev/null
+
+fail=0
+for src in "$EX_DIR"/*.c; do
+    [ -e "$src" ] || continue
+    base=$(basename "$src" .c)
+    exe="$EX_DIR/$base"
+    log="$exe.log"
+
+    echo "Building $exe"
+    set +e
+    "$VC" --link $ARCH_OPT --internal-libc -o "$exe" "$src" >"$log" 2>&1
+    status=$?
+    set -e
+    if [ $status -ne 0 ]; then
+        echo "Build failed for $exe (see $log)"
+        fail=1
+        continue
+    fi
+
+    echo "Running $exe"
+    set +e
+    "$exe"
+    status=$?
+    set -e
+    if [ $status -ne 0 ]; then
+        echo "Execution failed for $exe"
+        fail=1
+    fi
+
+done
+exit $fail

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1070,6 +1070,12 @@ if ! grep -q "warning: unreachable statement" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# build and run example programs with internal libc
+if ! "$DIR/run_examples.sh"; then
+    echo "Test run_examples failed"
+    fail=1
+fi
+
 if [ $fail -eq 0 ]; then
     echo "All tests passed"
 else


### PR DESCRIPTION
## Summary
- add a script that builds and runs example programs against vc's bundled libc
- invoke the example script from the integration test suite

## Testing
- `tests/run_examples.sh` *(fails: Unexpected token due to missing headers)*
- `tests/run_tests.sh` *(fails: gnu/stubs-32.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766b9663288324bad2d355224901dc