### PR TITLE
Add stdarg support to internal libc

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,12 +1,16 @@
 CC ?= gcc
 PROJECT_ROOT := $(abspath ..)
 CFLAGS ?= -Wall -Wextra -std=c99 -DPROJECT_ROOT=\"$(PROJECT_ROOT)\"
+PREFIX ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include/vc
 
 # determine if the host toolchain can build 32-bit objects
 CAN_COMPILE_32 := $(shell $(CC) -m32 -xc /dev/null -o /dev/null \
     >/dev/null 2>&1 && echo yes || echo no)
 
 SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c src/file.c
+HDR := include/stdarg.h include/stddef.h include/stdio.h \
+       include/stdlib.h include/string.h
 OBJ32 := $(SRC:src/%.c=src/%.32.o)
 OBJ64 := $(SRC:src/%.c=src/%.64.o)
 
@@ -38,7 +42,11 @@ libc64.a: $(OBJ64)
 src/%.64.o: src/%.c
 	$(CC) $(CFLAGS) -m64 -Iinclude -c $< -o $@
 
+install:
+	install -d $(DESTDIR)$(INCLUDEDIR)
+	install -m 644 $(HDR) $(DESTDIR)$(INCLUDEDIR)
+
 clean:
 	rm -f src/*.32.o src/*.64.o libc32.a libc64.a
 
-.PHONY: all libc32 libc64 clean
+.PHONY: all libc32 libc64 clean install

--- a/libc/include/stdarg.h
+++ b/libc/include/stdarg.h
@@ -1,0 +1,17 @@
+/*
+ * Minimal stdarg definitions for vc's internal libc.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_STDARG_H
+#define VC_STDARG_H
+
+#define va_list char *
+#define va_start(ap, last) (ap = (char *)&(last) + sizeof(last))
+#define va_arg(ap, type) (*(type *)((ap += sizeof(type)) - sizeof(type)))
+#define va_end(ap)       (ap = (va_list)0)
+#define va_copy(dest, src) ((dest) = (src))
+
+#endif /* VC_STDARG_H */


### PR DESCRIPTION
## Summary
- implement minimal `<stdarg.h>` for vc's bundled libc
- install libc headers via new `install` target

## Testing
- `make -C libc`
- `./tests/run_tests.sh` *(fails: preproc_run Invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_687670fc0334832488c42e61a98d7118