### PR TITLE
Use internal libc headers in tests

### DIFF
--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -13,9 +13,10 @@
 int puts(const char *s);
 int printf(const char *format, ...);
 
-typedef struct FILE {
+struct FILE_struct {
     int fd;
-} FILE;
+};
+#define FILE struct FILE_struct
 
 FILE *fopen(const char *path, const char *mode);
 int fclose(FILE *stream);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -15,6 +15,9 @@ fi
 fail=0
 # ensure internal libc archive is available for tests
 make -s -C "$DIR/../libc" >/dev/null
+# ensure host headers are not used
+NO_SYSROOT="$DIR/empty_sysroot"
+export VCFLAGS="--sysroot=$NO_SYSROOT"
 # compile each fixture, including vla.c which exercises
 # variable length array support
 for cfile in "$DIR"/fixtures/*.c; do
@@ -167,7 +170,7 @@ rm -f "$err"
 
 # verify VCFLAGS options are parsed
 vcflags_out=$(mktemp)
-VCFLAGS="--x86-64" "$BINARY" -o "${vcflags_out}" "$DIR/fixtures/simple_add.c"
+VCFLAGS="--x86-64 --sysroot=$NO_SYSROOT" "$BINARY" -o "${vcflags_out}" "$DIR/fixtures/simple_add.c"
 if ! diff -u "$DIR/fixtures/simple_add_x86-64.s" "${vcflags_out}"; then
     echo "Test vcflags_x86_64 failed"
     fail=1
@@ -175,7 +178,7 @@ fi
 rm -f "${vcflags_out}"
 
 vcflags_out=$(mktemp)
-VCFLAGS="--intel-syntax" "$BINARY" -o "${vcflags_out}" "$DIR/fixtures/pointer_add.c"
+VCFLAGS="--intel-syntax --sysroot=$NO_SYSROOT" "$BINARY" -o "${vcflags_out}" "$DIR/fixtures/pointer_add.c"
 if ! diff -u "$DIR/fixtures/pointer_add_intel.s" "${vcflags_out}"; then
     echo "Test vcflags_intel failed"
     fail=1


### PR DESCRIPTION
## Summary
- use our bundled libc headers by default in tests
- define a `FILE` macro in `libc/include/stdio.h`

## Testing
- `tests/run_tests.sh > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68767ae99cd88324a0f45470c15adc8c