### PR TITLE
Add unified temp file helper

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -61,6 +61,8 @@ Temporary object and assembly files are written to the directory given with
 the `--obj-dir` option when provided.  Without this flag the compiler
 consults the `TMPDIR` environment variable and then `P_tmpdir` when set.
 Only if neither variable is available does it fall back to `/tmp`.
+Temporary files are created with `mkstemp(3)` and the returned descriptor
+has `FD_CLOEXEC` set so it is not inherited by child processes.
 The assembler can be overridden with the `AS` environment variable while
 `CC` specifies the linker command and the default assembler for AT&T
 syntax.  When unset they default to `nasm` (Intel mode) and `cc`.

--- a/include/util.h
+++ b/include/util.h
@@ -42,10 +42,21 @@ void free_string_vector(vector_t *v);
 /* Release a vector of macro_t elements */
 void free_macro_vector(vector_t *v);
 
+/* Assemble a temporary file name using cli->obj_dir and open it.
+ *
+ * On success the path of the new file is stored in *out_path and the
+ * descriptor is returned.  The caller is responsible for unlinking and
+ * freeing the returned path.
+ *
+ * If an error occurs -1 is returned, *out_path is set to NULL and errno is
+ * left to indicate the cause.  ENAMETOOLONG signals that the resulting path
+ * would exceed PATH_MAX or snprintf detected truncation.  Other values come
+ * from malloc, mkstemp or fcntl.
+ */
+int create_temp_file(const cli_options_t *cli, const char *prefix,
+                     char **out_path);
+
 /* Assemble an mkstemp template path using cli->obj_dir */
 char *create_temp_template(const cli_options_t *cli, const char *prefix);
-
-/* Create and open the temporary file described by tmpl */
-int open_temp_file(char *tmpl);
 
 #endif /* VC_UTIL_H */

--- a/man/vc.1
+++ b/man/vc.1
@@ -171,7 +171,8 @@ Assemble and link the output to create an executable with \fBcc\fR.
 Place temporary object files in \fIdir\fR.  When this option is
 omitted the compiler first checks \fBTMPDIR\fR and \fBP_tmpdir\fR for
 a directory.  Only if neither variable is set does it default to
-\fB/tmp\fR.
+\fB/tmp\fR.  Temporary files are created with \fBmkstemp(3)\fR and the
+resulting descriptor has \fBFD_CLOEXEC\fR set.
 .TP
 .BR -S "," \fB--dump-asm\fR
 Print generated assembly to stdout rather than creating a file.

--- a/src/compile.c
+++ b/src/compile.c
@@ -63,25 +63,6 @@ char *vc_obj_name(const char *source);
  *   ENAMETOOLONG - path would exceed PATH_MAX or snprintf truncated
  *   others       - from malloc, mkstemp or fcntl
  */
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path)
-{
-    char *tmpl = create_temp_template(cli, prefix);
-    if (!tmpl) {
-        *out_path = NULL;
-        return -1;
-    }
-
-    int fd = open_temp_file(tmpl);
-    if (fd < 0) {
-        free(tmpl);
-        *out_path = NULL;
-        return -1;
-    }
-
-    *out_path = tmpl;
-    return fd;
-}
 
 /* Run the preprocessor and print the result. */
 int run_preprocessor(const cli_options_t *cli)

--- a/src/compile_link.c
+++ b/src/compile_link.c
@@ -20,8 +20,6 @@
 #include "cli.h"
 
 /* external helpers from other compilation units */
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
 const char *get_cc(void);
 
 /*

--- a/src/compile_output.c
+++ b/src/compile_output.c
@@ -38,9 +38,6 @@ get_as(int intel)
     return intel ? "nasm" : "cc";
 }
 
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
-
 static const char nasm_macros[] =
     "%macro movl 2\n    mov %1, %2\n%endmacro\n"
     "%macro movq 2\n    mov %1, %2\n%endmacro\n"

--- a/src/compile_tokenize.c
+++ b/src/compile_tokenize.c
@@ -22,9 +22,6 @@
 # define TEMP_FOPEN_MODE "w"
 #endif
 
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
-
 /* Table mapping token types to printable names */
 static const char *tok_names[] = {
     [TOK_EOF] = "end of file",

--- a/src/startup.c
+++ b/src/startup.c
@@ -15,6 +15,7 @@
 #include "cli.h"
 #include "command.h"
 #include "startup.h"
+#include "util.h"
 
 /* Use binary mode for temporary files on platforms that require it */
 #if defined(_WIN32)
@@ -23,8 +24,6 @@
 # define TEMP_FOPEN_MODE "w"
 #endif
 
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
 const char *get_cc(void);
 const char *get_as(int intel);
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -412,10 +412,10 @@ cc -Iinclude -Wall -Wextra -std=c99 -Dpopen=test_popen -DUNIT_TESTING -DNO_VECTO
     -o "$DIR/preproc_popen_fail" "$DIR/unit/test_preproc_popen_fail.c" \
     src/preproc_path.c src/vector.c src/util.c
 # build create_temp_file path length regression test
-cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
+cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/util.c -o util_temp.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
-cc -Wl,--gc-sections -o "$DIR/temp_file_tests" compile_temp.o "$DIR/test_temp_file.o"
-rm -f compile_temp.o "$DIR/test_temp_file.o"
+cc -Wl,--gc-sections -o "$DIR/temp_file_tests" util_temp.o "$DIR/test_temp_file.o"
+rm -f util_temp.o "$DIR/test_temp_file.o"
 # build compile_source_obj temp file failure test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -Dcompile_unit=test_compile_unit -ffunction-sections -fdata-sections -c src/compile.c -o compile_obj_fail.o
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -Dcompile_unit=test_compile_unit -ffunction-sections -fdata-sections -c src/compile_link.c -o compile_link_obj_fail.o


### PR DESCRIPTION
## Summary
- merge template creation and opening into util::create_temp_file
- remove old duplicate implementations
- mention P_tmpdir and FD_CLOEXEC in docs
- adjust tests to build util.c for temp file tests

## Testing
- `gcc -Iinclude -c src/util.c -o /tmp/util.o`
- `gcc -Iinclude -c src/compile_output.c -o /tmp/compile_output.o`
- `make` *(fails: gnu/stubs-32.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876830a3d808324854c3f0e5117fb3c