### PR TITLE
Refactor environ declaration

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -11,6 +11,12 @@
 #ifndef VC_COMMAND_H
 #define VC_COMMAND_H
 
+/*
+ * Declare environ for use with posix_spawnp.  Some systems require the
+ * variable to be visible when spawning child processes.
+ */
+extern char **environ;
+
 /* Convert an argument vector into a single string for debugging.
  * Arguments containing spaces or shell metacharacters are quoted using
  * single quotes. The returned buffer is heap allocated and must be freed

--- a/src/command.c
+++ b/src/command.c
@@ -22,8 +22,6 @@
 #include "util.h"
 #include "strbuf.h"
 
-extern char **environ;
-
 /* Determine if an argument contains characters that require shell quoting */
 static int needs_quotes(const char *arg)
 {

--- a/src/compile.c
+++ b/src/compile.c
@@ -50,7 +50,6 @@
 /* Active diagnostic context */
 extern const char *error_current_file;
 extern const char *error_current_function;
-extern char **environ;
 
 char *vc_obj_name(const char *source);
 


### PR DESCRIPTION
## Summary
- share `extern char **environ` declaration via `command.h`
- remove duplicate declarations from `command.c` and `compile.c`
- note why `environ` needs to be visible when spawning commands

## Testing
- `make test` *(fails: gnu/stubs-32.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68769736d28883248d7a88a74a317e9a