### PR TITLE
Add note on error colors

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -42,7 +42,10 @@ void error_set(size_t line, size_t col, const char *file, const char *func)
  */
 void error_print(const char *msg)
 {
+    /* Use colored output only when error_use_color is true and
+     * isatty(stderr) reports a terminal. */
     int color = error_use_color && isatty(fileno(stderr));
+    /* \x1b[1;31m sets bold red text; \x1b[0m resets formatting. */
     if (color)
         fprintf(stderr, "\x1b[1;31m");
     if (error_func)


### PR DESCRIPTION
## Summary
- clarify color output in `error_print`

## Testing
- `make` *(fails: `machine/ansi.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68769972a7e483248e27c2f32838b579