### PR TITLE
Ensure libc built before tests

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -107,6 +107,16 @@ executed from the repository root with:
 tests/run.sh
 ```
 
+Before running the suite ensure the bundled libc archives are available. Build
+them once with:
+
+```sh
+make libc
+```
+
+The helper script `start.sh` performs this step automatically before invoking
+the tests.
+
 This script builds the compiler, compiles the unit test harness for the lexer
 and parser, and then runs both the unit tests and the integration tests found
 under `tests/`. It returns a non-zero status if any test fails.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Build bundled libc required by the test suite
+make libc
+
+# Run the test suite by default
+exec tests/run.sh "$@"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,8 +4,12 @@ set -e
 DIR=$(dirname "$0")
 # track failing regression tests
 fail=0
-# build the compiler and internal libc
-make vc libc
+# build the compiler
+make vc
+# ensure internal libc archives are present
+if [ ! -f libc/libc32.a ] || [ ! -f libc/libc64.a ]; then
+    make libc
+fi
 # build unit test binary
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/unit_tests" "$DIR/unit/test_lexer_parser.c" \


### PR DESCRIPTION
## Summary
- add `start.sh` wrapper that builds libc and runs the test suite
- document the need to build libc before running tests
- check for libc archives in `tests/run.sh` and build them if missing

## Testing
- `make libc`
- `./tests/run.sh > /tmp/test.log 2>&1 && tail -n 15 /tmp/test.log` *(fails: undefined reference to `parse_cast`)*

------
https://chatgpt.com/codex/tasks/task_e_68769ea832d48324a83a5a9ed435d75c