### PR TITLE
Skip sub in zero-frame functions

### DIFF
--- a/include/semantic_global.h
+++ b/include/semantic_global.h
@@ -17,6 +17,7 @@
 /* Current maximum alignment for struct packing */
 extern size_t semantic_pack_alignment;
 extern int semantic_stack_offset;
+extern int semantic_stack_zero;
 extern int semantic_named_locals;
 void semantic_set_pack(size_t align);
 void semantic_set_named_locals(int flag);

--- a/src/codegen_branch.c
+++ b/src/codegen_branch.c
@@ -187,7 +187,7 @@ static void emit_func_frame(strbuf_t *sb, ir_instr_t *ins,
         frame += (int)ins->imm;
         if (x64 && frame % 16 != 0)
             frame += 16 - (frame % 16);
-        if (frame > 0) {
+        if (frame != 0) {
             if (syntax == ASM_INTEL)
                 strbuf_appendf(sb, "    sub%s %s, %d\n", sfx, sp, frame);
             else

--- a/src/semantic_decl_stmt.c
+++ b/src/semantic_decl_stmt.c
@@ -168,6 +168,7 @@ static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
         size_t sz = local_sym_size(sym);
         sz = (sz + 3) & ~3u;
         semantic_stack_offset += (int)sz;
+        semantic_stack_zero = 0;
         sym->stack_offset = semantic_stack_offset;
         char sbuf[32];
         snprintf(sbuf, sizeof(sbuf), "stack:%d", sym->stack_offset);

--- a/src/semantic_global.c
+++ b/src/semantic_global.c
@@ -35,6 +35,7 @@ size_t semantic_pack_alignment = 0;
 
 /* total bytes of automatic storage for the current function */
 int semantic_stack_offset = 0;
+int semantic_stack_zero = 1;
 
 /* keep named locals in IR rather than stack offsets */
 int semantic_named_locals = 0;
@@ -105,6 +106,7 @@ int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
     symtable_init(&locals);
     locals.globals = globals ? globals->globals : NULL;
     semantic_stack_offset = 0;
+    semantic_stack_zero = 1;
 
     for (size_t i = 0; i < func->param_count; i++)
         symtable_add_param(&locals, func->param_names[i],
@@ -123,7 +125,7 @@ int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
         ok = check_stmt(func->body[i], &locals, funcs, &labels, ir, func->return_type,
                         NULL, NULL);
 
-    if (func_begin)
+    if (func_begin && !semantic_stack_zero)
         func_begin->imm = semantic_stack_offset;
     ir_build_func_end(ir);
 


### PR DESCRIPTION
## Summary
- track when a function has no stack locals
- avoid setting frame size when no locals exist
- only emit `sub` on non-zero frames

## Testing
- `make test` *(fails: Test O0_const_load failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876a80d8b248324b35f897033d52bb5