### PR TITLE
Split memory helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c \
            src/semantic_block.c src/semantic_decl.c src/semantic_decl_stmt.c src/semantic_expr_stmt.c src/semantic_label.c src/semantic_return.c src/semantic_static_assert.c \
            src/semantic_layout.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
-           src/codegen.c src/codegen_mem.c src/codegen_load.c src/codegen_store.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
+           src/codegen.c src/codegen_mem_common.c src/codegen_mem_x86.c src/codegen_load.c src/codegen_store.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c src/codegen_x86.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
            src/preproc_expand.c src/preproc_builtin.c src/preproc_args.c src/preproc_table.c src/preproc_expr.c src/preproc_cond.c src/preproc_file.c \
@@ -260,8 +260,11 @@ src/ir_global.o: src/ir_global.c $(HDR)
 src/codegen.o: src/codegen.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen.c -o src/codegen.o
 
-src/codegen_mem.o: src/codegen_mem.c $(HDR)
-	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_mem.c -o src/codegen_mem.o
+src/codegen_mem_common.o: src/codegen_mem_common.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_mem_common.c -o src/codegen_mem_common.o
+
+src/codegen_mem_x86.o: src/codegen_mem_x86.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_mem_x86.c -o src/codegen_mem_x86.o
 
 src/codegen_load.o: src/codegen_load.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/codegen_load.c -o src/codegen_load.o

--- a/include/codegen_mem.h
+++ b/include/codegen_mem.h
@@ -17,11 +17,20 @@
 #include "regalloc.h"
 #include "cli.h"
 
+/* Architecture specific emitter function type. */
+typedef void (*mem_emit_fn)(strbuf_t *, ir_instr_t *, regalloc_t *, int,
+                            asm_syntax_t);
+
+/* Table of emitter callbacks defined by the target backend. */
+extern mem_emit_fn mem_emitters[];
+
 /*
- * Emit assembly for a memory-related instruction.
+ * Emit assembly for a single memory-related instruction.
  *
  * Operands are looked up in `ra` and the `x64` parameter controls the
- * pointer size used in addressing modes.
+ * pointer size used in addressing modes.  `regalloc` must populate
+ * `ra->loc` for all values referenced by `ins`.  `codegen.c` invokes
+ * this helper after performing register allocation.
  */
 void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
                        regalloc_t *ra, int x64,

--- a/src/codegen_mem_common.c
+++ b/src/codegen_mem_common.c
@@ -1,0 +1,28 @@
+#include "codegen_mem.h"
+
+/* Current argument stack size for the active call. */
+size_t arg_stack_bytes = 0;
+/* Next argument register index used for x86-64 calls. */
+int arg_reg_idx = 0;
+
+/* Architecture specific memory emitters. */
+typedef void (*mem_emit_fn)(strbuf_t *, ir_instr_t *, regalloc_t *, int,
+                            asm_syntax_t);
+extern mem_emit_fn mem_emitters[];
+
+/*
+ * Dispatch a single memory related IR instruction using the
+ * architecture specific emitter table. This function is used by
+ * codegen.c after register allocation has assigned locations to IR
+ * values.
+ */
+void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
+                       regalloc_t *ra, int x64,
+                       asm_syntax_t syntax)
+{
+    if (!ins || ins->op < 0 || ins->op > IR_LABEL)
+        return;
+    mem_emit_fn fn = mem_emitters[ins->op];
+    if (fn)
+        fn(sb, ins, ra, x64, syntax);
+}


### PR DESCRIPTION
## Summary
- split platform-agnostic memory emitter helpers into `codegen_mem_common.c`
- keep x86 specific logic in `codegen_mem_x86.c`
- document the interface expected by `regalloc` and `codegen.c`

## Testing
- `make vc`

------
https://chatgpt.com/codex/tasks/task_e_6876ea9ab7788324afc6c70fdc92e929