### PR TITLE
Refactor semantic verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/semantic_arith.c src/semantic_mem.c src/semantic_call.c \
            src/semantic_loops.c src/semantic_control.c src/semantic_init.c src/semantic_var.c src/semantic_stmt.c \
            src/semantic_block.c src/semantic_decl.c src/semantic_decl_stmt.c src/semantic_expr_stmt.c src/semantic_label.c src/semantic_return.c src/semantic_static_assert.c \
-           src/semantic_layout.c src/semantic_inline.c src/semantic_global.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
+           src/semantic_layout.c src/semantic_inline.c src/semantic_decl_global.c src/semantic_func_ir.c src/consteval.c src/error.c src/ir_core.c src/ir_const.c src/ir_memory.c src/ir_control.c src/ir_global.c \
            src/codegen.c src/codegen_mem_common.c src/codegen_mem_x86.c src/codegen_load.c src/codegen_store.c src/codegen_arith_int.c src/codegen_arith_float.c src/codegen_branch.c \
            src/codegen_float.c src/codegen_complex.c src/codegen_x86.c \
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
@@ -234,13 +234,15 @@ src/semantic_return.o: src/semantic_return.c $(HDR)
 src/semantic_static_assert.o: src/semantic_static_assert.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_static_assert.c -o src/semantic_static_assert.o
 src/semantic_layout.o: src/semantic_layout.c $(HDR)
-	        $(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_layout.c -o src/semantic_layout.o
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_layout.c -o src/semantic_layout.o
 src/semantic_inline.o: src/semantic_inline.c $(HDR)
-		$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_inline.c -o src/semantic_inline.o
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_inline.c -o src/semantic_inline.o
 
 
-src/semantic_global.o: src/semantic_global.c $(HDR)
-	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_global.c -o src/semantic_global.o
+src/semantic_decl_global.o: src/semantic_decl_global.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_decl_global.c -o src/semantic_decl_global.o
+src/semantic_func_ir.o: src/semantic_func_ir.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/semantic_func_ir.c -o src/semantic_func_ir.o
 
 src/consteval.o: src/consteval.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/consteval.c -o src/consteval.o

--- a/include/semantic_global.h
+++ b/include/semantic_global.h
@@ -24,6 +24,8 @@ void semantic_set_named_locals(int flag);
 
 int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
                ir_builder_t *ir);
+int emit_func_ir(func_t *func, symtable_t *funcs, symtable_t *globals,
+                 ir_builder_t *ir);
 int check_global(stmt_t *decl, symtable_t *globals, ir_builder_t *ir);
 void semantic_global_cleanup(void);
 

--- a/src/semantic_decl_global.c
+++ b/src/semantic_decl_global.c
@@ -102,36 +102,7 @@ int check_func(func_t *func, symtable_t *funcs, symtable_t *globals,
         return 0;
     }
 
-    symtable_t locals;
-    symtable_init(&locals);
-    locals.globals = globals ? globals->globals : NULL;
-    semantic_stack_offset = 0;
-    semantic_stack_zero = 1;
-
-    for (size_t i = 0; i < func->param_count; i++)
-        symtable_add_param(&locals, func->param_names[i],
-                           func->param_types[i],
-                           func->param_elem_sizes ? func->param_elem_sizes[i] : 4,
-                           (int)i,
-                           func->param_is_restrict ? func->param_is_restrict[i] : 0);
-
-    ir_instr_t *func_begin = ir_build_func_begin(ir, func->name);
-
-    label_table_t labels;
-    label_table_init(&labels);
-
-    int ok = 1;
-    for (size_t i = 0; i < func->body_count && ok; i++)
-        ok = check_stmt(func->body[i], &locals, funcs, &labels, ir, func->return_type,
-                        NULL, NULL);
-
-    if (func_begin && !semantic_stack_zero)
-        func_begin->imm = semantic_stack_offset;
-    ir_build_func_end(ir);
-
-    label_table_free(&labels);
-    locals.globals = NULL;
-    symtable_free(&locals);
+    int ok = emit_func_ir(func, funcs, globals, ir);
     if (decl->is_inline && !semantic_mark_inline_emitted(func->name)) {
         error_set(0, 0, error_current_file, error_current_function);
         preproc_set_function(&func_ctx, NULL);

--- a/src/semantic_func_ir.c
+++ b/src/semantic_func_ir.c
@@ -1,0 +1,57 @@
+/*
+ * Function body IR generation helpers.
+ * Contains the routines responsible for emitting IR
+ * for validated function definitions.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "semantic_global.h"
+#include "semantic_stmt.h"
+#include "semantic_control.h"
+#include "symtable.h"
+#include "label.h"
+#include "error.h"
+
+int emit_func_ir(func_t *func, symtable_t *funcs, symtable_t *globals,
+                 ir_builder_t *ir)
+{
+    if (!func)
+        return 0;
+
+    symtable_t locals;
+    symtable_init(&locals);
+    locals.globals = globals ? globals->globals : NULL;
+    semantic_stack_offset = 0;
+    semantic_stack_zero = 1;
+
+    for (size_t i = 0; i < func->param_count; i++)
+        symtable_add_param(&locals, func->param_names[i],
+                           func->param_types[i],
+                           func->param_elem_sizes ? func->param_elem_sizes[i] : 4,
+                           (int)i,
+                           func->param_is_restrict ? func->param_is_restrict[i] : 0);
+
+    ir_instr_t *func_begin = ir_build_func_begin(ir, func->name);
+
+    label_table_t labels;
+    label_table_init(&labels);
+
+    int ok = 1;
+    for (size_t i = 0; i < func->body_count && ok; i++)
+        ok = check_stmt(func->body[i], &locals, funcs, &labels, ir,
+                        func->return_type, NULL, NULL);
+
+    if (func_begin && !semantic_stack_zero)
+        func_begin->imm = semantic_stack_offset;
+    ir_build_func_end(ir);
+
+    label_table_free(&labels);
+    locals.globals = NULL;
+    symtable_free(&locals);
+    return ok;
+}
+


### PR DESCRIPTION
## Summary
- split semantic global logic into dedicated modules
- add IR emission helper for functions
- update Makefile for new compilation units

## Testing
- `make test` *(fails: Makefile:47: test Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_6876ff1da9108324bc273bb7b0e4d04f