### PR TITLE
Refactor include path caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CORE_SRC = src/main.c src/compile.c src/compile_stage.c src/compile_link.c src/c
            src/regalloc.c src/regalloc_x86.c src/strbuf.c src/util.c src/vector.c src/ir_dump.c src/ir_builder.c src/ast_dump.c src/label.c \
            src/preproc_expand.c src/preproc_macro_utils.c src/preproc_paste.c src/preproc_builtin.c src/preproc_args.c src/preproc_table.c \
            src/preproc_expr_parse.c src/preproc_expr_lex.c src/preproc_expr_eval.c src/preproc_cond.c src/preproc_file.c \
-           src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+           src/preproc_directives.c src/preproc_file_io.c src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
            src/token_names.c
 
 # Optional optimization sources
@@ -35,7 +35,7 @@ HDR = include/token.h include/token_names.h include/ast.h include/ast_clone.h in
     include/ir_core.h include/ir_const.h include/ir_memory.h include/ir_control.h include/ir_builder.h include/ir_global.h include/ir_dump.h include/ast_dump.h include/opt.h include/codegen.h include/codegen_mem.h include/codegen_loadstore.h include/codegen_arith.h include/codegen_arith_int.h include/codegen_arith_float.h include/codegen_branch.h include/strbuf.h \
     include/util.h include/command.h include/cli.h include/vector.h include/regalloc_x86.h include/label.h include/error.h include/lexer_internal.h \
     include/opt_inline_helpers.h \
-    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_includes.h include/preproc_expr.h include/preproc_expr_parse.h include/preproc_expr_lex.h include/preproc_cond.h include/preproc_path.h include/preproc_utils.h include/preproc_macro_utils.h include/preproc_paste.h include/parser_types.h include/parser_core.h include/startup.h include/compile_stage.h include/compile_optimize.h
+    include/preproc.h include/preproc_file.h include/preproc_macros.h include/preproc_includes.h include/preproc_expr.h include/preproc_expr_parse.h include/preproc_expr_lex.h include/preproc_cond.h include/preproc_path.h include/include_path_cache.h include/preproc_utils.h include/preproc_macro_utils.h include/preproc_paste.h include/parser_types.h include/parser_core.h include/startup.h include/compile_stage.h include/compile_optimize.h
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man
@@ -368,11 +368,16 @@ src/preproc_include.o: src/preproc_include.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_include.c -o src/preproc_include.o
 src/preproc_includes.o: src/preproc_includes.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/preproc_includes.c -o src/preproc_includes.o
+src/include_path_cache.o: src/include_path_cache.c $(HDR)
+	$(CC) $(CFLAGS) $(OPTFLAGS) \
+	-DMULTIARCH=\"$(MULTIARCH)\" \
+	-DGCC_INCLUDE_DIR=\"$(GCC_INCLUDE_DIR)\" \
+	-Iinclude -c src/include_path_cache.c -o src/include_path_cache.o
 src/preproc_path.o: src/preproc_path.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) \
-		-DMULTIARCH=\"$(MULTIARCH)\" \
-		-DGCC_INCLUDE_DIR=\"$(GCC_INCLUDE_DIR)\" \
-		-Iinclude -c src/preproc_path.c -o src/preproc_path.o
+	-DMULTIARCH=\"$(MULTIARCH)\" \
+	-DGCC_INCLUDE_DIR=\"$(GCC_INCLUDE_DIR)\" \
+	-Iinclude -c src/preproc_path.c -o src/preproc_path.o
 
 src/opt.o: src/opt.c $(HDR)
 	$(CC) $(CFLAGS) $(OPTFLAGS) -Iinclude -c src/opt.c -o src/opt.o

--- a/include/include_path_cache.h
+++ b/include/include_path_cache.h
@@ -1,0 +1,25 @@
+/*
+ * Caches for system include path discovery.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+#ifndef VC_INCLUDE_PATH_CACHE_H
+#define VC_INCLUDE_PATH_CACHE_H
+
+/* Initialize cached include path information */
+void include_path_cache_init(void);
+
+/* Clean up cached include path information */
+void include_path_cache_cleanup(void);
+
+/* Obtain the multiarch triple directory (or NULL) */
+const char *include_path_cache_multiarch(void);
+
+/* Obtain the GCC include directory path */
+const char *include_path_cache_gcc_dir(void);
+
+/* Standard include directory list terminated by NULL */
+const char * const *include_path_cache_std_dirs(void);
+
+#endif /* VC_INCLUDE_PATH_CACHE_H */

--- a/src/include_path_cache.c
+++ b/src/include_path_cache.c
@@ -1,0 +1,181 @@
+#define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include "include_path_cache.h"
+#include "util.h"
+
+/* Default system include search paths */
+#ifdef __linux__
+#ifndef MULTIARCH_FALLBACK
+#define MULTIARCH_FALLBACK "x86_64-linux-gnu"
+#endif
+#endif
+
+#if !defined(GCC_INCLUDE_DIR)
+static char *gcc_include_cached = NULL;
+static int gcc_include_initialized = 0;
+#endif
+
+static char *multiarch_cached = NULL;
+static int multiarch_initialized = 0;
+static int std_dirs_initialized = 0;
+static int gcc_query_failed = 0;
+static int sys_header_warned = 0;
+
+static const char *std_include_dirs[] = {
+#if defined(__linux__)
+    NULL, /* /usr/include/<multiarch> */
+    NULL, /* gcc include */
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
+    NULL, /* gcc include */
+#endif
+    "/usr/local/include",
+    "/usr/include",
+    NULL
+};
+
+static const char *get_multiarch_dir(void)
+{
+#if defined(__linux__)
+    if (!multiarch_initialized) {
+        multiarch_initialized = 1;
+        FILE *fp = popen("gcc -print-multiarch 2>/dev/null", "r");
+        if (!fp) {
+            perror("popen");
+            gcc_query_failed = 1;
+        } else {
+            char buf[256];
+            if (fgets(buf, sizeof(buf), fp)) {
+                size_t len = strlen(buf);
+                while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
+                    buf[--len] = '\0';
+                if (len)
+                    multiarch_cached = vc_strndup(buf, len);
+            } else {
+                perror("fgets");
+                gcc_query_failed = 1;
+            }
+            pclose(fp);
+        }
+        if (!multiarch_cached) {
+#ifdef MULTIARCH
+            multiarch_cached = vc_strdup(MULTIARCH);
+#else
+            multiarch_cached = vc_strdup(MULTIARCH_FALLBACK);
+#endif
+        }
+    }
+    return multiarch_cached;
+#else
+    return NULL;
+#endif
+}
+
+static const char *get_gcc_include_dir(void)
+{
+#ifdef GCC_INCLUDE_DIR
+    return GCC_INCLUDE_DIR;
+#else
+    if (!gcc_include_initialized) {
+        gcc_include_initialized = 1;
+        FILE *fp = popen("gcc -print-file-name=include 2>/dev/null", "r");
+        if (!fp) {
+            perror("popen");
+            gcc_query_failed = 1;
+        } else {
+            char buf[4096];
+            if (fgets(buf, sizeof(buf), fp)) {
+                size_t len = strlen(buf);
+                while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
+                    buf[--len] = '\0';
+                if (len)
+                    gcc_include_cached = vc_strndup(buf, len);
+            } else {
+                perror("fgets");
+                gcc_query_failed = 1;
+            }
+            pclose(fp);
+        }
+        if (!gcc_include_cached) {
+#if defined(__linux__)
+            const char *multi = get_multiarch_dir();
+            size_t len = strlen("/usr/lib/gcc/") + strlen(multi) + strlen("/include");
+            gcc_include_cached = vc_alloc_or_exit(len + 1);
+            snprintf(gcc_include_cached, len + 1, "/usr/lib/gcc/%s/include", multi);
+#else
+            gcc_include_cached = vc_strdup("/usr/lib/gcc/include");
+#endif
+        }
+        if (gcc_query_failed && !sys_header_warned) {
+            fprintf(stderr,
+                    "vc: system headers could not be located. Use --vc-sysinclude=<dir> or VC_SYSINCLUDE\n");
+            sys_header_warned = 1;
+        }
+    }
+    return gcc_include_cached;
+#endif
+}
+
+static void init_std_include_dirs(void)
+{
+    if (std_dirs_initialized)
+        return;
+#if defined(__linux__)
+    const char *multi = get_multiarch_dir();
+    size_t len = strlen("/usr/include/") + strlen(multi);
+    char *path = vc_alloc_or_exit(len + 1);
+    snprintf(path, len + 1, "/usr/include/%s", multi);
+    std_include_dirs[0] = path;
+    std_include_dirs[1] = get_gcc_include_dir();
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
+    std_include_dirs[0] = get_gcc_include_dir();
+#endif
+    std_dirs_initialized = 1;
+}
+
+void include_path_cache_init(void)
+{
+    init_std_include_dirs();
+}
+
+const char *include_path_cache_multiarch(void)
+{
+    return get_multiarch_dir();
+}
+
+const char *include_path_cache_gcc_dir(void)
+{
+    init_std_include_dirs();
+    return get_gcc_include_dir();
+}
+
+const char * const *include_path_cache_std_dirs(void)
+{
+    init_std_include_dirs();
+    return std_include_dirs;
+}
+
+void include_path_cache_cleanup(void)
+{
+#ifndef GCC_INCLUDE_DIR
+    free(gcc_include_cached);
+    gcc_include_cached = NULL;
+    gcc_include_initialized = 0;
+#endif
+#if defined(__linux__)
+    free((char *)std_include_dirs[0]);
+    std_include_dirs[0] = NULL;
+    std_include_dirs[1] = NULL;
+    free(multiarch_cached);
+    multiarch_cached = NULL;
+    multiarch_initialized = 0;
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
+    std_include_dirs[0] = NULL;
+#endif
+    std_dirs_initialized = 0;
+    gcc_query_failed = 0;
+    sys_header_warned = 0;
+}

--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -9,6 +9,7 @@
 
 #include "util.h"
 #include "preproc_path.h"
+#include "include_path_cache.h"
 #include <stdbool.h>
 
 /* Default system include search paths */
@@ -19,133 +20,9 @@
 #endif
 
 
-#if !defined(GCC_INCLUDE_DIR)
-static char *gcc_include_cached = NULL;
-static int gcc_include_initialized = 0;
-#endif
-
-static char *multiarch_cached = NULL;
-static int multiarch_initialized = 0;
-static int std_dirs_initialized = 0;
-static int gcc_query_failed = 0;
-static int sys_header_warned = 0;
 static vector_t extra_sys_dirs;
 static int verbose_includes = 0;
 static const char *internal_libc_dir = PROJECT_ROOT "/libc/include";
-
-static const char *get_multiarch_dir(void)
-{
-#if defined(__linux__)
-    if (!multiarch_initialized) {
-        multiarch_initialized = 1;
-        FILE *fp = popen("gcc -print-multiarch 2>/dev/null", "r");
-        if (!fp) {
-            perror("popen");
-            gcc_query_failed = 1;
-        } else {
-            char buf[256];
-            if (fgets(buf, sizeof(buf), fp)) {
-                size_t len = strlen(buf);
-                while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
-                    buf[--len] = '\0';
-                if (len)
-                    multiarch_cached = vc_strndup(buf, len);
-            } else {
-                perror("fgets");
-                gcc_query_failed = 1;
-            }
-            pclose(fp);
-        }
-        if (!multiarch_cached) {
-#ifdef MULTIARCH
-            multiarch_cached = vc_strdup(MULTIARCH);
-#else
-            multiarch_cached = vc_strdup(MULTIARCH_FALLBACK);
-#endif
-        }
-    }
-    return multiarch_cached;
-#else
-    return NULL;
-#endif
-}
-
-static const char *get_gcc_include_dir(void)
-{
-#ifdef GCC_INCLUDE_DIR
-    return GCC_INCLUDE_DIR;
-#else
-    if (!gcc_include_initialized) {
-        gcc_include_initialized = 1;
-        FILE *fp = popen("gcc -print-file-name=include 2>/dev/null", "r");
-        if (!fp) {
-            perror("popen");
-            gcc_query_failed = 1;
-        } else {
-            char buf[4096];
-            if (fgets(buf, sizeof(buf), fp)) {
-                size_t len = strlen(buf);
-                while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
-                    buf[--len] = '\0';
-                if (len)
-                    gcc_include_cached = vc_strndup(buf, len);
-            } else {
-                perror("fgets");
-                gcc_query_failed = 1;
-            }
-            pclose(fp);
-        }
-        if (!gcc_include_cached) {
-#if defined(__linux__)
-            const char *multi = get_multiarch_dir();
-            size_t len = strlen("/usr/lib/gcc/") + strlen(multi) + strlen("/include");
-            gcc_include_cached = vc_alloc_or_exit(len + 1);
-            snprintf(gcc_include_cached, len + 1, "/usr/lib/gcc/%s/include", multi);
-#else
-            gcc_include_cached = vc_strdup("/usr/lib/gcc/include");
-#endif
-        }
-        if (gcc_query_failed && !sys_header_warned) {
-            fprintf(stderr,
-                    "vc: system headers could not be located. Use --vc-sysinclude=<dir> or VC_SYSINCLUDE\n");
-            sys_header_warned = 1;
-        }
-    }
-    return gcc_include_cached;
-#endif
-}
-
-static void init_std_include_dirs(void);
-
-static const char *std_include_dirs[] = {
-#if defined(__linux__)
-    NULL, /* /usr/include/<multiarch> */
-    NULL, /* gcc include */
-#elif defined(__NetBSD__) || defined(__FreeBSD__)
-    NULL, /* gcc include */
-#endif
-    "/usr/local/include",
-    "/usr/include",
-    NULL
-};
-
-static void init_std_include_dirs(void)
-{
-    if (std_dirs_initialized)
-        return;
-    vector_init(&extra_sys_dirs, sizeof(char *));
-#if defined(__linux__)
-    const char *multi = get_multiarch_dir();
-    size_t len = strlen("/usr/include/") + strlen(multi);
-    char *path = vc_alloc_or_exit(len + 1);
-    snprintf(path, len + 1, "/usr/include/%s", multi);
-    std_include_dirs[0] = path;
-    std_include_dirs[1] = get_gcc_include_dir();
-#elif defined(__NetBSD__) || defined(__FreeBSD__)
-    std_include_dirs[0] = get_gcc_include_dir();
-#endif
-    std_dirs_initialized = 1;
-}
 
 int record_dependency(preproc_context_t *ctx, const char *path)
 {
@@ -216,7 +93,8 @@ int pragma_once_add(preproc_context_t *ctx, const char *path)
 char *find_include_path(const char *fname, char endc, const char *dir,
                         const vector_t *incdirs, size_t start, size_t *out_idx)
 {
-    init_std_include_dirs();
+    include_path_cache_init();
+    const char * const *std_include_dirs = include_path_cache_std_dirs();
     size_t fname_len = strlen(fname);
     size_t max_len = fname_len;
     if (endc == '"' && dir && start == 0) {
@@ -373,8 +251,9 @@ int collect_include_dirs(vector_t *search_dirs,
                          const char *vc_sysinclude,
                          bool internal_libc)
 {
-    init_std_include_dirs();
-    const char *gcc_dir = get_gcc_include_dir();
+    include_path_cache_init();
+    const char *gcc_dir = include_path_cache_gcc_dir();
+    const char * const *std_include_dirs = include_path_cache_std_dirs();
     assert(strcspn(gcc_dir, " \t\n") == strlen(gcc_dir));
     vector_init(search_dirs, sizeof(char *));
     for (size_t i = 0; i < include_dirs->count; i++) {
@@ -459,7 +338,8 @@ int collect_include_dirs(vector_t *search_dirs,
 void print_include_search_dirs(FILE *fp, char endc, const char *dir,
                                const vector_t *incdirs, size_t start)
 {
-    init_std_include_dirs();
+    include_path_cache_init();
+    const char * const *std_include_dirs = include_path_cache_std_dirs();
     if (endc == '"' && dir && start == 0)
         fprintf(fp, "  %s\n", dir);
     for (size_t i = start; i < incdirs->count; i++) {
@@ -491,24 +371,7 @@ void preproc_set_internal_libc_dir(const char *path)
 
 void preproc_path_cleanup(void)
 {
-#ifndef GCC_INCLUDE_DIR
-    free(gcc_include_cached);
-    gcc_include_cached = NULL;
-    gcc_include_initialized = 0;
-#endif
-#if defined(__linux__)
-    free((char *)std_include_dirs[0]);
-    std_include_dirs[0] = NULL;
-    std_include_dirs[1] = NULL;
-    free(multiarch_cached);
-    multiarch_cached = NULL;
-    multiarch_initialized = 0;
-#elif defined(__NetBSD__) || defined(__FreeBSD__)
-    std_include_dirs[0] = NULL;
-#endif
-    std_dirs_initialized = 0;
+    include_path_cache_cleanup();
     free_string_vector(&extra_sys_dirs);
-    gcc_query_failed = 0;
-    sys_header_warned = 0;
 }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -137,10 +137,10 @@ rm -f strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
 # build append_env_paths tests
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/append_env_paths_colon" "$DIR/unit/test_append_env_paths_colon.c" \
-    src/preproc_path.c src/vector.c src/util.c
+    src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
 cc -Iinclude -Wall -Wextra -std=c99 -D_WIN32 \
     -o "$DIR/append_env_paths_semicolon" "$DIR/unit/test_append_env_paths_semicolon.c" \
-    src/preproc_path.c src/vector.c src/util.c
+    src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
 # build invalid macro parse test
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_invalid_macro.c" -o "$DIR/test_invalid_macro.o"
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_invalid.o
@@ -202,7 +202,7 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
@@ -210,119 +210,119 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_multi_stdheaders" "$DIR/unit/test_preproc_multi_stdheaders.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_has_include" "$DIR/unit/test_preproc_has_include.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_has_include_macro" "$DIR/unit/test_preproc_has_include_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_include_comment" "$DIR/unit/test_preproc_include_comment.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_ifmacro" "$DIR/unit/test_preproc_ifmacro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_line" "$DIR/unit/test_preproc_line.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_line_macro" "$DIR/unit/test_preproc_line_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_line_decrease" "$DIR/unit/test_preproc_line_decrease.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/gcc_line_marker" "$DIR/unit/test_gcc_line_marker.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_hash_noop" "$DIR/unit/test_preproc_hash_noop.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_crlf" "$DIR/unit/test_preproc_crlf.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_pack_macro" "$DIR/unit/test_preproc_pack_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_pack_push" "$DIR/unit/test_preproc_pack_push.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_pragma_macro" "$DIR/unit/test_preproc_pragma_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_defined_macro" "$DIR/unit/test_preproc_defined_macro.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_unterm_comment" "$DIR/unit/test_preproc_unterm_comment.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
@@ -330,14 +330,14 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_pragma_unknown" "$DIR/unit/test_preproc_pragma_unknown.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
@@ -345,21 +345,21 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_charlit" "$DIR/unit/test_preproc_charlit.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_token_paste" "$DIR/unit/test_preproc_token_paste.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
@@ -367,57 +367,65 @@ cc -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_independent" "$DIR/unit/test_preproc_independent.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_counter_reset" "$DIR/unit/test_preproc_counter_reset.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_errwarn" "$DIR/unit/test_preproc_errwarn.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_expand_size" "$DIR/unit/test_preproc_expand_size.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_system_header" "$DIR/unit/test_preproc_system_header.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
     src/preproc_args.c src/preproc_cond.c src/preproc_expr.c \
-    src/preproc_include.c src/preproc_includes.c src/preproc_path.c \
+    src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
     -o "$DIR/collect_include_sysroot" "$DIR/unit/test_collect_include_sysroot.c" \
-    src/preproc_path.c src/vector.c src/util.c
+    src/include_path_cache.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
 cc -Iinclude -Wall -Wextra -std=c99 \
     -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
     -o "$DIR/internal_libc_sysroot" "$DIR/unit/test_internal_libc_sysroot.c" \
-    src/preproc_path.c src/vector.c src/util.c
+    src/include_path_cache.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
+cc -Iinclude -Wall -Wextra -std=c99 \
+    -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
+    -o "$DIR/vc_sysinclude" "$DIR/unit/test_vc_sysinclude.c" \
+    src/include_path_cache.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
+cc -Iinclude -Wall -Wextra -std=c99 -D_WIN32 \
+    -DMULTIARCH="${MULTIARCH}" -DGCC_INCLUDE_DIR="${GCC_INCLUDE_DIR}" \
+    -o "$DIR/vc_sysinclude_win" "$DIR/unit/test_vc_sysinclude.c" \
+    src/include_path_cache.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
 cc -Iinclude -Wall -Wextra -std=c99 -Dpopen=test_popen -DUNIT_TESTING -DNO_VECTOR_FREE_STUB \
     -o "$DIR/preproc_popen_fail" "$DIR/unit/test_preproc_popen_fail.c" \
-    src/preproc_path.c src/vector.c src/util.c
+    src/include_path_cache.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
 cc -Iinclude -Wall -Wextra -std=c99 -Dpopen=test_popen -DUNIT_TESTING -DNO_VECTOR_FREE_STUB \
     -o "$DIR/preproc_sysheaders_fail" "$DIR/unit/test_preproc_sysheaders_fail.c" \
-    src/preproc_path.c src/vector.c src/util.c
+    src/include_path_cache.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
 # build create_temp_file path length regression test
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
@@ -537,6 +545,8 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_system_header"
 "$DIR/collect_include_sysroot"
 "$DIR/internal_libc_sysroot"
+"$DIR/vc_sysinclude"
+"$DIR/vc_sysinclude_win"
 "$DIR/preproc_sysheaders_fail"
 "$DIR/preproc_popen_fail"
 "$DIR/invalid_macro_tests"

--- a/tests/unit/test_vc_sysinclude.c
+++ b/tests/unit/test_vc_sysinclude.c
@@ -1,0 +1,59 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "preproc_path.h"
+#include "util.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    char dir_template[] = "/tmp/vc_sysXXXXXX";
+    char *d = mkdtemp(dir_template);
+    ASSERT(d != NULL);
+    char path[4096];
+    snprintf(path, sizeof(path), "%s/foo.h", d);
+    FILE *fp = fopen(path, "w");
+    ASSERT(fp != NULL);
+    if (fp) {
+        fputs("/* test */\n", fp);
+        fclose(fp);
+    }
+    char envbuf[8192];
+#ifdef _WIN32
+    snprintf(envbuf, sizeof(envbuf), "%s;%s", d, d);
+#else
+    snprintf(envbuf, sizeof(envbuf), "%s:%s", d, d);
+#endif
+    setenv("VC_SYSINCLUDE", envbuf, 1);
+    vector_t empty; vector_init(&empty, sizeof(char *));
+    vector_t dirs; ASSERT(collect_include_dirs(&dirs, &empty, NULL, NULL, false));
+    size_t idx = SIZE_MAX;
+    char *res = find_include_path("foo.h", '<', NULL, &dirs, 0, &idx);
+    ASSERT(res != NULL);
+    if (res) {
+        ASSERT(strcmp(res, path) == 0);
+        free(res);
+    }
+    free_string_vector(&dirs);
+    vector_free(&empty);
+    unsetenv("VC_SYSINCLUDE");
+    unlink(path);
+    rmdir(d);
+    preproc_path_cleanup();
+
+    if (failures == 0)
+        printf("All vc_sysinclude tests passed\n");
+    else
+        printf("%d vc_sysinclude test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- create `include_path_cache` module
- use `include_path_cache` from preprocessing logic
- test VC_SYSINCLUDE paths with Windows and Unix separators

## Testing
- `make test` *(fails: make: *** [Makefile:47: test] Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_687700c17a6483249dadd006d796b237