### PR TITLE
Remove duplicate typedef from mem common

### DIFF
--- a/src/codegen_mem_common.c
+++ b/src/codegen_mem_common.c
@@ -6,8 +6,6 @@ size_t arg_stack_bytes = 0;
 int arg_reg_idx = 0;
 
 /* Architecture specific memory emitters. */
-typedef void (*mem_emit_fn)(strbuf_t *, ir_instr_t *, regalloc_t *, int,
-                            asm_syntax_t);
 extern mem_emit_fn mem_emitters[];
 
 /*


### PR DESCRIPTION
## Summary
- clean up duplicate `mem_emit_fn` typedef in `codegen_mem_common.c`

## Testing
- `make test` *(fails: Makefile:47: test Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_687706bc5eb08324a2afedc7b0ca4d3e