### PR TITLE
Fix unused parameter warning

### DIFF
--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -40,6 +40,7 @@ long _vc_close(int fd)
 
 __attribute__((noreturn, naked)) void _vc_exit(int status)
 {
+    (void)status;
 #ifdef __x86_64__
     __asm__ volatile(
         "mov $60, %rax\n"


### PR DESCRIPTION
## Summary
- silence unused parameter warning in `_vc_exit`

## Testing
- `make -C libc clean`
- `make -C libc`

------
https://chatgpt.com/codex/tasks/task_e_68770a3013808324957b74c3e10036d1