### PR TITLE
Fix unused parameter warning

### DIFF
--- a/src/preproc_include.c
+++ b/src/preproc_include.c
@@ -95,6 +95,7 @@ static int process_include_file(const char *fname, const char *chosen,
 {
     vector_t subconds;
     vector_init(&subconds, sizeof(cond_state_t));
+    (void)fname; /* unused */
     int ok = 1;
     if (is_active(conds)) {
         if (!chosen) {


### PR DESCRIPTION
## Summary
- silence compiler warning in `process_include_file`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68770a238ff88324a36b31b924aa20a8