### PR TITLE
Adjust default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ INCLUDEDIR ?= $(PREFIX)/include/vc
 MANDIR ?= $(PREFIX)/share/man
 LIBC_MAKE = $(MAKE) -C libc
 
-all: test
+all: $(BIN) libc
 
 test: $(BIN) libc
 	./tests/run_tests.sh


### PR DESCRIPTION
## Summary
- build the compiler and bundled libc when running `make`
- keep `make test` for running the tests

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68770b2742348324b012eb086c5c8d9b