### PR TITLE
Silence leftover warnings

### DIFF
--- a/include/compile_helpers.h
+++ b/include/compile_helpers.h
@@ -1,0 +1,20 @@
+#ifndef VC_COMPILE_HELPERS_H
+#define VC_COMPILE_HELPERS_H
+
+#include "cli.h"
+
+/* Create a temporary file and return its descriptor. On success the path is
+ * stored in *out_path. Returns -1 on failure. */
+int create_temp_file(const cli_options_t *cli, const char *prefix,
+                     char **out_path);
+
+/* Generate an object filename from the given source path. Caller frees result. */
+char *vc_obj_name(const char *source);
+
+/* Retrieve the C compiler command path. */
+const char *get_cc(void);
+
+/* Retrieve the assembler command path. */
+const char *get_as(int intel);
+
+#endif /* VC_COMPILE_HELPERS_H */

--- a/src/compile.c
+++ b/src/compile.c
@@ -39,6 +39,7 @@
 #include "compile.h"
 #include "compile_stage.h"
 #include "startup.h"
+#include "compile_helpers.h"
 
 /* Use binary mode for temporary files on platforms that require it */
 #if defined(_WIN32)
@@ -51,7 +52,6 @@
 extern const char *error_current_file;
 extern const char *error_current_function;
 
-char *vc_obj_name(const char *source);
 
 
 

--- a/src/compile_link.c
+++ b/src/compile_link.c
@@ -18,11 +18,7 @@
 #include "compile.h"
 #include "startup.h"
 #include "cli.h"
-
-/* external helpers from other compilation units */
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
-const char *get_cc(void);
+#include "compile_helpers.h"
 
 /*
  * Return a newly allocated object file name for the given source path.

--- a/src/compile_output.c
+++ b/src/compile_output.c
@@ -12,6 +12,7 @@
 #include "ir_dump.h"
 #include "codegen.h"
 #include "command.h"
+#include "compile_helpers.h"
 
 #if defined(_WIN32)
 # define TEMP_FOPEN_MODE "wb"
@@ -19,8 +20,7 @@
 # define TEMP_FOPEN_MODE "w"
 #endif
 
-const char *get_cc(void);
-const char *get_as(int intel);
+
 
 const char *
 get_cc(void)
@@ -38,8 +38,6 @@ get_as(int intel)
     return intel ? "nasm" : "cc";
 }
 
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
 
 static const char nasm_macros[] =
     "%macro movl 2\n    mov %1, %2\n%endmacro\n"

--- a/src/compile_tokenize.c
+++ b/src/compile_tokenize.c
@@ -14,6 +14,7 @@
 #include "strbuf.h"
 #include "semantic_global.h"
 #include "semantic_stmt.h"
+#include "compile_helpers.h"
 
 /* Use binary mode for temporary files on platforms that require it */
 #if defined(_WIN32)
@@ -22,8 +23,6 @@
 # define TEMP_FOPEN_MODE "w"
 #endif
 
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
 
 /* Table mapping token types to printable names */
 static const char *tok_names[] = {

--- a/src/startup.c
+++ b/src/startup.c
@@ -15,6 +15,7 @@
 #include "cli.h"
 #include "command.h"
 #include "startup.h"
+#include "compile_helpers.h"
 
 /* Use binary mode for temporary files on platforms that require it */
 #if defined(_WIN32)
@@ -23,10 +24,6 @@
 # define TEMP_FOPEN_MODE "w"
 #endif
 
-int create_temp_file(const cli_options_t *cli, const char *prefix,
-                     char **out_path);
-const char *get_cc(void);
-const char *get_as(int intel);
 
 /* Write the entry stub assembly to a temporary file. */
 int write_startup_asm(int use_x86_64, asm_syntax_t syntax,


### PR DESCRIPTION
## Summary
- centralize helper prototypes in `compile_helpers.h`
- remove redundant function declarations
- include the new header in modules that use these helpers

## Testing
- `make vc`
- `make test` *(fails: Makefile rule)*

------
https://chatgpt.com/codex/tasks/task_e_68770b355f6c8324aae5db713a702df4