### PR TITLE
Fix util_alloc compilation for unit tests

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -69,7 +69,7 @@ cc -Iinclude -Wall -Wextra -std=c99 -c src/ast_stmt_create.c -o ast_stmt_create_
 cc -Iinclude -Wall -Wextra -std=c99 -c src/ast_stmt_free.c -o ast_stmt_free_fail.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/lexer.c -o lexer_alloc.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_alloc.o
-cc -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_alloc.o
+cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -c src/util.c -o util_alloc.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_alloc.o
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_parser_alloc_fail.c" -o "$DIR/test_parser_alloc_fail.o"
 cc -o "$DIR/parser_alloc_tests" parser_core_fail.o parser_init_fail.o parser_decl_var_fail.o parser_decl_struct_fail.o parser_decl_enum_fail.o parser_flow_fail.o parser_toplevel_fail.o parser_expr_fail.o parser_expr_primary_fail.o parser_expr_binary_fail.o parser_stmt_fail.o parser_types_fail.o parser_toplevel_func_fail.o parser_toplevel_var_fail.o parser_expr_ops_fail.o parser_expr_literal_fail.o lexer_ident_fail.o lexer_scan_numeric_fail.o ast_expr_binary_fail.o ast_expr_control_fail.o ast_expr_literal_fail.o ast_expr_type_fail.o token_names_fail.o preproc_table_fail.o symtable_core_fail.o symtable_globals_fail.o symtable_struct_fail.o ast_clone_fail.o ast_expr_fail.o ast_stmt_create_fail.o ast_stmt_free_fail.o lexer_alloc.o vector_alloc.o util_alloc.o error_alloc.o "$DIR/test_parser_alloc_fail.o"


### PR DESCRIPTION
## Summary
- build util_alloc.c with UNIT_TESTING flag when compiling parser alloc tests

## Testing
- `tests/run.sh` *(fails: undefined reference to `preproc_set_internal_libc_dir` in cli tests)*

------
https://chatgpt.com/codex/tasks/task_e_68770a1a3414832489c4cff0a8de70a2