### PR TITLE
Fix pclose handling

### DIFF
--- a/src/include_path_cache.c
+++ b/src/include_path_cache.c
@@ -58,7 +58,10 @@ static const char *get_multiarch_dir(void)
                 perror("fgets");
                 gcc_query_failed = 1;
             }
-            pclose(fp);
+            if (pclose(fp) == -1) {
+                perror("pclose");
+                gcc_query_failed = 1;
+            }
         }
         if (!multiarch_cached) {
 #ifdef MULTIARCH
@@ -97,7 +100,10 @@ static const char *get_gcc_include_dir(void)
                 perror("fgets");
                 gcc_query_failed = 1;
             }
-            pclose(fp);
+            if (pclose(fp) == -1) {
+                perror("pclose");
+                gcc_query_failed = 1;
+            }
         }
         if (!gcc_include_cached) {
 #if defined(__linux__)


### PR DESCRIPTION
## Summary
- check `pclose` return values in include path cache

## Testing
- `make test` *(fails: Makefile:47: test Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_687710389ba08324a81e2c4d702a38db