### PR TITLE
Fix overflow in _vc_malloc brk calculation

### DIFF
--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -1,4 +1,5 @@
 #include "../internal/_vc_syscalls.h"
+#include <limits.h>
 
 #ifdef __x86_64__
 #define SYSCALL_INVOKE(num, a1, a2, a3) \
@@ -76,6 +77,8 @@ void *_vc_malloc(unsigned long size)
             return 0;
         cur_brk = (unsigned long)ret;
     }
+    if (size > ULONG_MAX - cur_brk)
+        return 0;
     unsigned long prev = cur_brk;
     unsigned long new_brk = cur_brk + size;
 #ifdef __x86_64__


### PR DESCRIPTION
## Summary
- ensure _vc_malloc checks for pointer overflow before calling brk

## Testing
- `make` *(fails: 32-bit compilation unavailable)*
- `make test` *(fails: linker errors in unit tests)*
- `tests/run.sh` *(fails: undefined references when linking tests)*

------
https://chatgpt.com/codex/tasks/task_e_687710315588832484031abaa398fb49