### PR TITLE
Skip 32-bit libc build when unsupported

### DIFF
--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -16,7 +16,12 @@ if [ $CAN_COMPILE_32 -ne 0 ]; then
 fi
 
 # build internal libc quietly
-make -s -C "$DIR/../libc" >/dev/null
+if [ $CAN_COMPILE_32 -ne 0 ]; then
+    # only build the 64-bit archive when 32-bit compilation is unavailable
+    make -s -C "$DIR/../libc" libc64 >/dev/null
+else
+    make -s -C "$DIR/../libc" >/dev/null
+fi
 
 fail=0
 for src in "$EX_DIR"/*.c; do


### PR DESCRIPTION
## Summary
- avoid building `libc32.a` in run_examples when the host can't compile 32-bit code

## Testing
- `tests/run_examples.sh`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877102ad6608324b7301c3aa01b89fb