### PR TITLE
Improve run_tests.sh to rebuild missing compiler

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,6 +3,12 @@ set -e
 DIR=$(dirname "$0")
 BINARY="$DIR/../vc"
 
+# build the compiler if it's missing
+if [ ! -x "$BINARY" ]; then
+    echo "Compiler not found, running make"
+    (cd "$DIR/.." && make >/dev/null)
+fi
+
 # check if the host compiler supports 32-bit builds
 set +e
 gcc -m32 -xc /dev/null -o /dev/null 2>/dev/null


### PR DESCRIPTION
## Summary
- in tests, rebuild compiler when missing before running

## Testing
- `tests/run_tests.sh` (confirmed compiler rebuilt when not found)


------
https://chatgpt.com/codex/tasks/task_e_687714a41788832489c315fd3e20275e