### PR TITLE
Check snprintf truncation in cli_opts

### DIFF
--- a/src/cli_opts.c
+++ b/src/cli_opts.c
@@ -398,7 +398,12 @@ int finalize_options(int argc, char **argv, const char *prog,
     if (opts->internal_libc) {
         if (!opts->vc_sysinclude || !*opts->vc_sysinclude) {
             char tmp[PATH_MAX];
-            snprintf(tmp, sizeof(tmp), "%s", prog);
+            int len = snprintf(tmp, sizeof(tmp), "%s", prog);
+            if (len < 0 || len >= (int)sizeof(tmp)) {
+                fprintf(stderr, "Error: internal libc path too long.\n");
+                cli_free_opts(opts);
+                return 1;
+            }
             char *slash = strrchr(tmp, '/');
             if (slash)
                 *slash = '\0';


### PR DESCRIPTION
## Summary
- validate `snprintf` when determining internal libc directory

## Testing
- `make test` *(fails: Makefile:47: test Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_687714c0d2348324bb0d1893fbaefe9a