### PR TITLE
Fix strcpy usage and add long filename tests

### DIFF
--- a/src/compile_link.c
+++ b/src/compile_link.c
@@ -38,12 +38,16 @@ vc_obj_name(const char *source)
         return NULL;
 
     memcpy(obj, base, len);
-    strcpy(obj + len, ".o");
+    memcpy(obj + len, ".o", 3);
     return obj;
 }
 
 /* Return a dependency file name derived from TARGET */
+#ifdef UNIT_TESTING
+char *vc_dep_name(const char *target)
+#else
 static char *vc_dep_name(const char *target)
+#endif
 {
     const char *base = strrchr(target, '/');
     base = base ? base + 1 : target;
@@ -53,7 +57,7 @@ static char *vc_dep_name(const char *target)
     if (!dep)
         return NULL;
     memcpy(dep, base, len);
-    strcpy(dep + len, ".d");
+    memcpy(dep + len, ".d", 3);
     return dep;
 }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -454,6 +454,11 @@ cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -Dcompile_unit=test_compile_u
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_compile_obj_fail.c" -o "$DIR/test_compile_obj_fail.o"
 cc -Wl,--gc-sections -o "$DIR/compile_obj_fail" compile_obj_fail.o compile_link_obj_fail.o "$DIR/test_compile_obj_fail.o"
 rm -f compile_obj_fail.o compile_link_obj_fail.o "$DIR/test_compile_obj_fail.o"
+# build object/dependency name long filename test
+cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile_link.c -o compile_link_names.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_vc_names.c" -o "$DIR/test_vc_names.o"
+cc -Wl,--gc-sections -o "$DIR/vc_names_tests" compile_link_names.o "$DIR/test_vc_names.o"
+rm -f compile_link_names.o "$DIR/test_vc_names.o"
 # build constant folding tests
 cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Dfree=test_free -c src/ir_core.c -o ir_fold.o
 cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Dfree=test_free -c src/util.c -o util_fold.o
@@ -523,6 +528,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/append_env_paths_semicolon"
 "$DIR/temp_file_tests"
 "$DIR/compile_obj_fail"
+"$DIR/vc_names_tests"
 "$DIR/preproc_alloc_tests"
 "$DIR/add_macro_fail_tests"
 "$DIR/text_line_fail"

--- a/tests/unit/test_vc_names.c
+++ b/tests/unit/test_vc_names.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "compile_helpers.h"
+
+/* vc_dep_name is exposed when UNIT_TESTING is defined */
+char *vc_dep_name(const char *target);
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void test_long_names(void)
+{
+    const char *prefix = "dir/subdir/";
+    size_t base_len = 5000;
+    size_t prefix_len = strlen(prefix);
+    char *src = malloc(prefix_len + base_len + 3);
+    memcpy(src, prefix, prefix_len);
+    memset(src + prefix_len, 'x', base_len);
+    memcpy(src + prefix_len + base_len, ".c", 3);
+
+    char *obj = vc_obj_name(src);
+    ASSERT(obj != NULL);
+    if (obj) {
+        ASSERT(strlen(obj) == base_len + 2);
+        ASSERT(strncmp(obj, src + prefix_len, base_len) == 0);
+        ASSERT(strcmp(obj + base_len, ".o") == 0);
+        free(obj);
+    }
+
+    char *dep = vc_dep_name(src);
+    ASSERT(dep != NULL);
+    if (dep) {
+        ASSERT(strlen(dep) == base_len + 2);
+        ASSERT(strncmp(dep, src + prefix_len, base_len) == 0);
+        ASSERT(strcmp(dep + base_len, ".d") == 0);
+        free(dep);
+    }
+
+    free(src);
+}
+
+int main(void)
+{
+    test_long_names();
+    if (failures == 0)
+        printf("All vc_names tests passed\n");
+    else
+        printf("%d vc_names test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- use memcpy instead of strcpy in vc_obj_name and vc_dep_name
- expose vc_dep_name for unit testing
- add regression tests for very long filenames
- build and run the new tests in `run.sh`

## Testing
- `tests/vc_names_tests`

------
https://chatgpt.com/codex/tasks/task_e_687714c914e48324a59ed045aa92eddc