### PR TITLE
Add stub file for CLI tests

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -33,8 +33,9 @@ cc -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push -c src/cli_op
 cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_cli.c" -o "$DIR/test_cli.o"
 cc -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_test.o
 cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -DNO_VECTOR_FREE_STUB -c src/util.c -o util_test.o
-cc -o "$DIR/cli_tests" cli_test.o cli_env_test.o cli_opts_test.o "$DIR/test_cli.o" vector_test.o util_test.o
-rm -f cli_test.o cli_env_test.o cli_opts_test.o "$DIR/test_cli.o" vector_test.o util_test.o
+cc -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_cli_stubs.c" -o "$DIR/test_cli_stubs.o"
+cc -o "$DIR/cli_tests" cli_test.o cli_env_test.o cli_opts_test.o "$DIR/test_cli.o" vector_test.o util_test.o "$DIR/test_cli_stubs.o"
+rm -f cli_test.o cli_env_test.o cli_opts_test.o "$DIR/test_cli.o" vector_test.o util_test.o "$DIR/test_cli_stubs.o"
 # build parser alloc failure unit test with vector_push wrapper
 cc -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push -c src/parser_core.c -o parser_core_fail.o
 cc -Iinclude -Wall -Wextra -std=c99 -c src/parser_init.c -o parser_init_fail.o

--- a/tests/unit/test_cli_stubs.c
+++ b/tests/unit/test_cli_stubs.c
@@ -1,0 +1,6 @@
+#include "ast_stmt.h"
+#include "preproc_path.h"
+
+void ast_free_func(func_t *func) { (void)func; }
+void ast_free_stmt(stmt_t *stmt) { (void)stmt; }
+void preproc_set_internal_libc_dir(const char *path) { (void)path; }


### PR DESCRIPTION
## Summary
- stub out `ast_free_func`, `ast_free_stmt` and `preproc_set_internal_libc_dir` for CLI unit tests
- compile the new stub when building CLI unit tests

## Testing
- `make test` *(fails: fixture compilation diff)*

------
https://chatgpt.com/codex/tasks/task_e_687717bf80148324a64ed30fd0486b1c