### PR TITLE
Add short write handling in libc

### DIFF
--- a/tests/fixtures/libc_short_write.c
+++ b/tests/fixtures/libc_short_write.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void) {
+    if (puts("hello") < 0)
+        return 1;
+    return 0;
+}

--- a/tests/unit/fail_vcwrite.c
+++ b/tests/unit/fail_vcwrite.c
@@ -1,0 +1,6 @@
+#include <errno.h>
+long _vc_write(int fd, const void *buf, unsigned long count) {
+    (void)fd; (void)buf;
+    errno = ENOSPC;
+    return (count > 0) ? (long)(count - 1) : 0;
+}


### PR DESCRIPTION
## Summary
- check `_vc_write` return value in `puts` and `printf`
- report failure via `perror` when short writes occur
- skip `libc_short_write` fixture in assembly tests
- simulate a short `_vc_write` in tests using LD_PRELOAD

## Testing
- `./tests/run_tests.sh` *(fails: No space left on device)*

------
https://chatgpt.com/codex/tasks/task_e_687721cf4af88324aae574b7b2daa1c7