### PR TITLE
Use proper file open flags

### DIFF
--- a/libc/src/file.c
+++ b/libc/src/file.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <string.h>
+#include <fcntl.h>
 #include "stdio.h"
 #include "stdlib.h"
 #include "../internal/_vc_syscalls.h"
@@ -12,7 +13,7 @@ FILE *fopen(const char *path, const char *mode)
     if (mode && mode[0] == 'r') {
         flags = 0; /* O_RDONLY */
     } else if (mode && mode[0] == 'w') {
-        flags = 1 | 64 | 512; /* O_WRONLY | O_CREAT | O_TRUNC */
+        flags = O_WRONLY | O_CREAT | O_TRUNC;
         perm = 0666;
     } else {
         return NULL;


### PR DESCRIPTION
## Summary
- include `<fcntl.h>` in vc's libc
- use `O_WRONLY`, `O_CREAT`, and `O_TRUNC` instead of numeric values
- build libc in both 32‑bit and 64‑bit modes

## Testing
- `make -C libc CAN_COMPILE_32=yes libc32 libc64`
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68772b0e884083249dae076408f753e3