### PR TITLE
Fix memory leak on struct declaration failure

### DIFF
--- a/src/parser_decl_struct.c
+++ b/src/parser_decl_struct.c
@@ -333,6 +333,13 @@ fail:
     }
     struct_member_t *members = (struct_member_t *)members_v.data;
     size_t count = members_v.count;
-    return ast_make_struct_decl(tag, members, count, kw->line, kw->column);
+    stmt_t *res = ast_make_struct_decl(tag, members, count,
+                                       kw->line, kw->column);
+    if (!res) {
+        for (size_t i = 0; i < count; i++)
+            free(members[i].name);
+        free(members);
+    }
+    return res;
 }
 


### PR DESCRIPTION
## Summary
- free struct member names when `ast_make_struct_decl` fails

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877ad1b5f288324bb9b1aa5e686d9a5