### PR TITLE
Fix cap overflow during file read

### DIFF
--- a/src/preproc_file_io.c
+++ b/src/preproc_file_io.c
@@ -132,11 +132,20 @@ static char *read_file_lines_internal(const char *path, char ***out_lines)
             continue;
         }
 
+        if (len == SIZE_MAX) {
+            fprintf(stderr, "vc: file too large\n");
+            fclose(f);
+            free(text);
+            return NULL;
+        }
         if (len + 1 >= cap) {
-            if (cap > SIZE_MAX / 2)
-                cap = cap + 1;
-            else
-                cap *= 2;
+            if (cap > SIZE_MAX / 2) {
+                fprintf(stderr, "vc: file too large\n");
+                fclose(f);
+                free(text);
+                return NULL;
+            }
+            cap *= 2;
             text = vc_realloc_or_exit(text, cap);
         }
         text[len++] = (char)c;


### PR DESCRIPTION
## Summary
- avoid overflowing `cap` in the preprocessor file reader
- abort with a clear error when a file is too large

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877caefc1908324b2edac153506b44f