### PR TITLE
Mark _vc_exit as noreturn

### DIFF
--- a/libc/internal/_vc_syscalls.h
+++ b/libc/internal/_vc_syscalls.h
@@ -31,7 +31,7 @@ long _vc_write(int, const void *, unsigned long);
 long _vc_read(int, void *, unsigned long);
 long _vc_open(const char *, int, int);
 long _vc_close(int);
-void _vc_exit(int);
+__attribute__((noreturn)) void _vc_exit(int);
 void *_vc_malloc(unsigned long);
 void _vc_free(void *);
 


### PR DESCRIPTION
## Summary
- mark `_vc_exit` as `noreturn`

## Testing
- `make -C libc`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877ef94f46c8324ac8820605fb77583