### PR TITLE
Handle short writes in libc

### DIFF
--- a/libc/src/file.c
+++ b/libc/src/file.c
@@ -45,7 +45,7 @@ static int flush_buf_fd(int fd, const char *buf, size_t *pos, int *total)
 {
     if (*pos > 0) {
         long ret = _vc_write(fd, buf, *pos);
-        if (ret < 0)
+        if (ret < (long)(*pos))
             return -1;
         if (total)
             *total += (int)(*pos);


### PR DESCRIPTION
## Summary
- detect short writes when flushing FILE buffers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877ef8b95608324877a4a5bf32faee0