### PR TITLE
Check overflow before allocating members array

### DIFF
--- a/src/ast_clone.c
+++ b/src/ast_clone.c
@@ -12,6 +12,7 @@
  */
 
 #include <stdlib.h>
+#include <stdint.h>
 #include "ast_clone.h"
 #include "ast_expr.h"
 #include "util.h"
@@ -187,6 +188,8 @@ static expr_t *clone_offsetof(const expr_t *expr)
     size_t n = expr->data.offsetof_expr.member_count;
     char **members = NULL;
     if (n) {
+        if (n > SIZE_MAX / sizeof(char *))
+            return NULL;
         members = malloc(n * sizeof(char *));
         if (!members)
             return NULL;


### PR DESCRIPTION
## Summary
- guard `malloc` call in `clone_offsetof`
- add `<stdint.h>` include for `SIZE_MAX`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877f36366d083248e9f14cd5300e706