### PR TITLE
Add quoted VCFLAGS parsing

### DIFF
--- a/src/cli_env.c
+++ b/src/cli_env.c
@@ -25,8 +25,24 @@ int load_vcflags(int *argc, char ***argv, char ***out_argv,
             free(vcbuf);
             return 1;
         }
-        for (char *t = strtok(tmp, " "); t; t = strtok(NULL, " "))
+        char *p = tmp;
+        while (*p) {
+            while (*p == ' ')
+                p++;
+            if (!*p)
+                break;
             vcargc++;
+            if (*p == '\'' || *p == '"') {
+                char q = *p++;
+                while (*p && *p != q)
+                    p++;
+                if (*p)
+                    p++;
+            } else {
+                while (*p && *p != ' ')
+                    p++;
+            }
+        }
         free(tmp);
 
         size_t new_count = (size_t)*argc + vcargc + 1;
@@ -46,8 +62,29 @@ int load_vcflags(int *argc, char ***argv, char ***out_argv,
 
         vcargv[0] = (*argv)[0];
         size_t idx = 1;
-        for (char *t = strtok(vcbuf, " "); t; t = strtok(NULL, " "))
-            vcargv[idx++] = t;
+        char *p2 = vcbuf;
+        while (*p2) {
+            while (*p2 == ' ')
+                p2++;
+            if (!*p2)
+                break;
+            char *start;
+            if (*p2 == '\'' || *p2 == '"') {
+                char q = *p2++;
+                start = p2;
+                while (*p2 && *p2 != q)
+                    p2++;
+                if (*p2)
+                    *p2++ = '\0';
+            } else {
+                start = p2;
+                while (*p2 && *p2 != ' ')
+                    p2++;
+                if (*p2)
+                    *p2++ = '\0';
+            }
+            vcargv[idx++] = start;
+        }
         for (int i = 1; i < *argc; i++)
             vcargv[idx++] = (*argv)[i];
 

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -174,6 +174,20 @@ static void test_internal_libc_leak(void)
     ASSERT(allocs == 0);
 }
 
+static void test_vcflags_quotes(void)
+{
+    cli_options_t opts;
+    setenv("VCFLAGS", "--intel-syntax --output 'out file.s'", 1);
+    char *argv[] = {"vc", "file.c", NULL};
+    int ret = cli_parse_args(2, argv, &opts);
+    unsetenv("VCFLAGS");
+    ASSERT(ret == 0);
+    ASSERT(opts.asm_syntax == ASM_INTEL);
+    ASSERT(strcmp(opts.output, "out file.s") == 0);
+    cli_free_opts(&opts);
+    ASSERT(allocs == 0);
+}
+
 int main(void)
 {
     test_parse_success();
@@ -182,6 +196,7 @@ int main(void)
     test_dump_tokens_option();
     test_verbose_includes_option();
     test_internal_libc_leak();
+    test_vcflags_quotes();
     test_parse_failure();
     if (failures == 0)
         printf("All cli tests passed\n");


### PR DESCRIPTION
## Summary
- support quoted VCFLAGS parsing in `load_vcflags`
- strip surrounding quotes from each parsed option
- test quoted VCFLAGS handling via new unit test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877f8db0bb08324bc8a0f9cefdb7da4