### PR TITLE
Handle quoted dependency flags

### DIFF
--- a/src/cli_env.c
+++ b/src/cli_env.c
@@ -99,13 +99,32 @@ int load_vcflags(int *argc, char ***argv, char ***out_argv,
     return 0;
 }
 
+static int match_flag(const char *arg, const char *flag)
+{
+    if (strcmp(arg, flag) == 0)
+        return 1;
+
+    size_t len = strlen(arg);
+    if (len >= 2 && (arg[0] == '"' || arg[0] == '\'') && arg[len - 1] == arg[0]) {
+        char buf[8];
+        if (len - 2 < sizeof(buf)) {
+            memcpy(buf, arg + 1, len - 2);
+            buf[len - 2] = '\0';
+            if (strcmp(buf, flag) == 0)
+                return 1;
+        }
+    }
+
+    return 0;
+}
+
 void scan_shortcuts(int *argc, char **argv)
 {
     int new_argc = 1;
     for (int i = 1; i < *argc; i++) {
-        if (strcmp(argv[i], "-MD") == 0)
+        if (match_flag(argv[i], "-MD"))
             argv[new_argc++] = "--MD";
-        else if (strcmp(argv[i], "-M") == 0)
+        else if (match_flag(argv[i], "-M"))
             argv[new_argc++] = "--M";
         else
             argv[new_argc++] = argv[i];

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -188,6 +188,26 @@ static void test_vcflags_quotes(void)
     ASSERT(allocs == 0);
 }
 
+static void test_shortcut_quotes(void)
+{
+    cli_options_t opts;
+    char *argv1[] = {"vc", "\"-MD\"", "file.c", NULL};
+    int ret = cli_parse_args(3, argv1, &opts);
+    ASSERT(ret == 0);
+    ASSERT(opts.deps);
+    ASSERT(!opts.dep_only);
+    cli_free_opts(&opts);
+    ASSERT(allocs == 0);
+
+    char *argv2[] = {"vc", "'-M'", "file.c", NULL};
+    ret = cli_parse_args(3, argv2, &opts);
+    ASSERT(ret == 0);
+    ASSERT(opts.dep_only);
+    ASSERT(!opts.deps);
+    cli_free_opts(&opts);
+    ASSERT(allocs == 0);
+}
+
 int main(void)
 {
     test_parse_success();
@@ -197,6 +217,7 @@ int main(void)
     test_verbose_includes_option();
     test_internal_libc_leak();
     test_vcflags_quotes();
+    test_shortcut_quotes();
     test_parse_failure();
     if (failures == 0)
         printf("All cli tests passed\n");


### PR DESCRIPTION
## Summary
- expand -M and -MD even when quoted
- test quoting for shortcut dependency options

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687800aa74488324b43f66b443acabf7