### PR TITLE
Add docs for named locals flag

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -22,6 +22,7 @@ The compiler supports the following options:
 - `--no-inline` – disable inline expansion of small functions.
 - `--debug` – emit `.file` and `.loc` directives in the assembly output.
 - `--emit-dwarf` – include DWARF line and symbol data in the output.
+- `--named-locals` – emit named symbols for local variables.
 - `--no-color` – disable ANSI colors in diagnostics.
 - `--no-warn-unreachable` – disable warnings for unreachable statements.
 - `--x86-64` – generate 64‑bit x86 assembly.

--- a/man/vc.1
+++ b/man/vc.1
@@ -143,6 +143,9 @@ Emit .file and .loc directives for debugging.
 .B --emit-dwarf
 Include DWARF line and symbol information in object files.
 .TP
+.B --named-locals
+Emit named symbols for local variables instead of stack offsets.
+.TP
 .B --no-color
 Disable ANSI colors in diagnostic output.
 .TP


### PR DESCRIPTION
## Summary
- document `--named-locals` in command line docs
- add `--named-locals` option to the man page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68780216b564832491fc5a8a91485db2