### PR TITLE
Fix va_end on printf error paths

### DIFF
--- a/libc/src/stdio.c
+++ b/libc/src/stdio.c
@@ -47,8 +47,10 @@ int printf(const char *fmt, ...)
         if (*p != '%') {
             out[pos++] = *p;
             if (pos == sizeof(out)) {
-                if (flush_buf(out, &pos, &written) < 0)
+                if (flush_buf(out, &pos, &written) < 0) {
+                    va_end(ap);
                     return -1;
+                }
             }
             continue;
         }
@@ -58,14 +60,18 @@ int printf(const char *fmt, ...)
         if (*p == '%') {
             out[pos++] = '%';
             if (pos == sizeof(out)) {
-                if (flush_buf(out, &pos, &written) < 0)
+                if (flush_buf(out, &pos, &written) < 0) {
+                    va_end(ap);
                     return -1;
+                }
             }
             continue;
         }
 
-        if (flush_buf(out, &pos, &written) < 0)
+        if (flush_buf(out, &pos, &written) < 0) {
+            va_end(ap);
             return -1;
+        }
 
         if (*p == 's') {
             const char *s = va_arg(ap, const char *);


### PR DESCRIPTION
## Summary
- fix `printf` to always cleanup its `va_list` on early errors

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68780410ece083249d7c5efc59bc62c3