### PR TITLE
Fix build_examples redundant else

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -29,12 +29,7 @@ for src in "$DIR"/*.c; do
 
     echo "Building $exe"
 
-    opts="--link $ARCH_OPT"
-    if [ "$base" = "file_io" ]; then
-        opts="$opts --internal-libc"
-    else
-        opts="$opts --internal-libc"
-    fi
+    opts="--link $ARCH_OPT --internal-libc"
 
     "$VC" $opts -o "$exe" "$src" >"$exe.log" 2>&1
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary
- simplify example build script

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687803ff0e8483249f27d4e6231975b3