### PR TITLE
Fix VCFLAGS lifetime in CLI options

### DIFF
--- a/include/cli.h
+++ b/include/cli.h
@@ -93,6 +93,7 @@ typedef struct {
     vector_t lib_dirs;     /* additional library search paths */
     vector_t libs;         /* libraries to link against */
     size_t max_include_depth; /* maximum nested includes */
+    char *vcflags_buf;     /* buffer holding VCFLAGS contents */
 } cli_options_t;
 
 /* Parse command line arguments. Returns 0 on success, non-zero on error. */


### PR DESCRIPTION
## Summary
- keep VCFLAGS buffer in `cli_options_t`
- free VCFLAGS buffer when cleaning up options
- adjust CLI parsing cleanup paths

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782886ae50832491d1844db9b338f5