### PR TITLE
Fix vc_strndup overread

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -95,9 +95,7 @@ char *vc_strdup(const char *s)
 /* Duplicate at most "n" characters of a string. */
 char *vc_strndup(const char *s, size_t n)
 {
-    size_t len = strlen(s);
-    if (len > n)
-        len = n;
+    size_t len = strnlen(s, n);
     char *out = malloc(len + 1);
     if (!out)
         return NULL;


### PR DESCRIPTION
## Summary
- avoid reading past `n` in `vc_strndup` by using `strnlen`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782a7f1b708324bee61dffa14763a6