### PR TITLE
Fix append_env_paths cleanup

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -229,6 +229,7 @@ int append_env_paths(const char *env, vector_t *search_dirs)
     char *tmp = vc_strdup(env);
     if (!tmp)
         return 0;
+    size_t start = search_dirs->count;
     char *tok, *sp;
 #if defined(_WIN32)
     const char *sep = ";:";
@@ -241,6 +242,9 @@ int append_env_paths(const char *env, vector_t *search_dirs)
             char *dup = vc_strdup(tok);
             if (!dup || !vector_push(search_dirs, &dup)) {
                 free(dup);
+                for (size_t i = start; i < search_dirs->count; i++)
+                    free(((char **)search_dirs->data)[i]);
+                search_dirs->count = start;
                 free(tmp);
                 return 0;
             }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -176,6 +176,24 @@ $CC -Iinclude -Wall -Wextra -std=c99 \
 $CC -Iinclude -Wall -Wextra -std=c99 -D_WIN32 \
     -o "$DIR/append_env_paths_semicolon" "$DIR/unit/test_append_env_paths_semicolon.c" \
     src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
+# build append_env_paths failure test
+$CC -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push \
+    -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/preproc_path.c -o preproc_path_append_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/include_path_cache.c -o include_path_cache_append_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/vector.c -o vector_append_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -DNO_VECTOR_FREE_STUB \
+    -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/util.c -o util_append_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push \
+    -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c "$DIR/unit/test_append_env_paths_fail.c" -o "$DIR/test_append_env_paths_fail.o"
+$CC -o "$DIR/append_env_paths_fail" preproc_path_append_fail.o include_path_cache_append_fail.o \
+    vector_append_fail.o util_append_fail.o "$DIR/test_append_env_paths_fail.o"
+rm -f preproc_path_append_fail.o include_path_cache_append_fail.o vector_append_fail.o util_append_fail.o \
+      "$DIR/test_append_env_paths_fail.o"
 # build invalid macro parse test
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_invalid_macro.c" -o "$DIR/test_invalid_macro.o"
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_invalid.o
@@ -551,6 +569,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/waitpid_retry"
 "$DIR/append_env_paths_colon"
 "$DIR/append_env_paths_semicolon"
+"$DIR/append_env_paths_fail"
 "$DIR/temp_file_tests"
 "$DIR/compile_obj_fail"
 "$DIR/vc_names_tests"

--- a/tests/unit/test_append_env_paths_fail.c
+++ b/tests/unit/test_append_env_paths_fail.c
@@ -1,0 +1,88 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_path.h"
+#include "util.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+extern int vector_push(vector_t *vec, const void *elem); /* real impl */
+static int fail_at = 0;
+static int call_count = 0;
+int test_vector_push(vector_t *vec, const void *elem)
+{
+    call_count++;
+    if (fail_at && call_count == fail_at)
+        return 0;
+    return vector_push(vec, elem);
+}
+
+extern void *malloc(size_t size); /* real malloc */
+extern void *calloc(size_t nmemb, size_t size); /* real calloc */
+extern void *realloc(void *ptr, size_t size); /* real realloc */
+extern void free(void *ptr); /* real free */
+static int allocs = 0;
+
+void *test_malloc(size_t size)
+{
+    void *p = malloc(size);
+    if (p)
+        allocs++;
+    return p;
+}
+
+void *test_calloc(size_t nmemb, size_t size)
+{
+    if (size && nmemb > SIZE_MAX / size)
+        return NULL;
+    void *p = calloc(nmemb, size);
+    if (p)
+        allocs++;
+    return p;
+}
+
+void *test_realloc(void *ptr, size_t size)
+{
+    if (!ptr)
+        return test_malloc(size);
+    void *p = realloc(ptr, size);
+    if (p && p != ptr) {
+        allocs++;
+        allocs--; /* previous ptr freed */
+    }
+    return p;
+}
+
+void test_free(void *ptr)
+{
+    if (ptr)
+        allocs--;
+    free(ptr);
+}
+
+static void test_fail_second(void)
+{
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    fail_at = 2; call_count = 0;
+    ASSERT(!append_env_paths("foo:bar", &dirs));
+    ASSERT(dirs.count == 0 && dirs.cap == 0);
+    ASSERT(allocs == 0);
+    vector_free(&dirs);
+}
+
+int main(void)
+{
+    test_fail_second();
+    if (failures == 0)
+        printf("All append_env_paths_fail tests passed\n");
+    else
+        printf("%d append_env_paths_fail test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- prevent leaks in `append_env_paths`
- add regression test for failure cleanup
- run new test in suite

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782bd95e5083249c24082fca9b4cd4