### PR TITLE
Add backslash escape handling in VCFLAGS

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -69,7 +69,8 @@ Additional options may be supplied in the `VCFLAGS` environment variable.
 Its contents are split on spaces and prepended to the argument vector so
 flags provided directly on the command line override those from
 `VCFLAGS`. Values containing spaces may be quoted with single or double
-quotes which will be removed during parsing.
+quotes which will be removed during parsing. Spaces and quote characters
+can also be escaped with a backslash.
 
 Use `vc -o out.s source.c` to compile a file, `vc -c -o out.o source.c` to
 produce an object, `vc --link -o prog main.c util.c` to build an executable

--- a/man/vc.1
+++ b/man/vc.1
@@ -238,7 +238,9 @@ paths are processed.
 .TP
 .B VCFLAGS
 Space separated list of additional command line options prepended before
-parsing. Flags given directly on the command line override these.
+parsing. Flags given directly on the command line override these. Spaces
+or quotes may be escaped with a backslash or an argument may be quoted
+with single or double quotes.
 .TP
 .B AS
 Assembler program to invoke instead of the default.

--- a/tests/unit/test_cli.c
+++ b/tests/unit/test_cli.c
@@ -188,6 +188,20 @@ static void test_vcflags_quotes(void)
     ASSERT(allocs == 0);
 }
 
+static void test_vcflags_backslash(void)
+{
+    cli_options_t opts;
+    setenv("VCFLAGS", "--intel-syntax --output out\\ file.s", 1);
+    char *argv[] = {"vc", "file.c", NULL};
+    int ret = cli_parse_args(2, argv, &opts);
+    unsetenv("VCFLAGS");
+    ASSERT(ret == 0);
+    ASSERT(opts.asm_syntax == ASM_INTEL);
+    ASSERT(strcmp(opts.output, "out file.s") == 0);
+    cli_free_opts(&opts);
+    ASSERT(allocs == 0);
+}
+
 static void test_shortcut_quotes(void)
 {
     cli_options_t opts;
@@ -217,6 +231,7 @@ int main(void)
     test_verbose_includes_option();
     test_internal_libc_leak();
     test_vcflags_quotes();
+    test_vcflags_backslash();
     test_shortcut_quotes();
     test_parse_failure();
     if (failures == 0)


### PR DESCRIPTION
## Summary
- handle backslash-escaped spaces and quotes when loading `VCFLAGS`
- document backslash escapes in the manual and command-line docs
- test VCFLAGS escape handling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782bd244c48324a24f0f2426b79d2c