### PR TITLE
Ensure plist freed on macro param parse fail

### DIFF
--- a/src/preproc_table.c
+++ b/src/preproc_table.c
@@ -130,12 +130,14 @@ static char *parse_macro_params(char *p, vector_t *out, int *variadic)
             p++;
         if (*p == ')') {
             char *plist = vc_strndup(start, (size_t)(p - start));
-            if (!tokenize_param_list(plist, out)) {
-                free(plist);
+            if (!plist)
+                return NULL;
+            int ok = tokenize_param_list(plist, out);
+            free(plist);
+            if (!ok) {
                 free_param_vector(out);
                 return NULL;
             }
-            free(plist);
             p++;
         } else {
             p = start - 1;


### PR DESCRIPTION
## Summary
- avoid leaking plist when tokenize_param_list fails in parse_macro_params

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782e3eede48324a1954f3e3f8a8ce1