### PR TITLE
Fix match_flag truncation

### DIFF
--- a/src/cli_env.c
+++ b/src/cli_env.c
@@ -136,11 +136,11 @@ static int match_flag(const char *arg, const char *flag)
 
     size_t len = strlen(arg);
     if (len >= 2 && (arg[0] == '"' || arg[0] == '\'') && arg[len - 1] == arg[0]) {
-        char buf[8];
-        if (len - 2 < sizeof(buf)) {
-            memcpy(buf, arg + 1, len - 2);
-            buf[len - 2] = '\0';
-            if (strcmp(buf, flag) == 0)
+        char *buf = vc_strndup(arg + 1, len - 2);
+        if (buf) {
+            int match = strcmp(buf, flag) == 0;
+            free(buf);
+            if (match)
                 return 1;
         }
     }


### PR DESCRIPTION
## Summary
- allocate memory for match_flag's quoted flag comparison

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782e5b741c832498e4c400934ebbbd