### PR TITLE
Propagate errno in create_temp_file

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -73,8 +73,10 @@ int create_temp_file(const cli_options_t *cli, const char *prefix,
 
     int fd = open_temp_file(tmpl);
     if (fd < 0) {
+        int err = errno;
         free(tmpl);
         *out_path = NULL;
+        errno = err;
         return -1;
     }
 


### PR DESCRIPTION
## Summary
- preserve errno when `open_temp_file` fails in `create_temp_file`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782e4824948324853fdc7e45267f69