### PR TITLE
Handle failing _vc_exit gracefully

### DIFF
--- a/libc/internal/_vc_syscalls.h
+++ b/libc/internal/_vc_syscalls.h
@@ -31,7 +31,7 @@ long _vc_write(int, const void *, unsigned long);
 long _vc_read(int, void *, unsigned long);
 long _vc_open(const char *, int, int);
 long _vc_close(int);
-__attribute__((noreturn)) void _vc_exit(int);
+long _vc_exit(int);
 void *_vc_malloc(unsigned long);
 void _vc_free(void *);
 

--- a/libc/src/pthread.c
+++ b/libc/src/pthread.c
@@ -1,5 +1,6 @@
 #include "pthread.h"
 #include "../internal/_vc_syscalls.h"
+void _exit(int);
 
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
                    void *(*start_routine)(void *), void *arg)
@@ -11,8 +12,13 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
     const char msg[] =
         "vc libc is single-threaded; pthread_create unsupported\n";
     _vc_write(2, msg, sizeof(msg) - 1);
-    _vc_exit(1);
-    for (;;)
-        ;
+    long ret = _vc_exit(1);
+    if (ret < 0) {
+        const char fail[] = "vc libc: exit syscall failed\n";
+        _vc_write(2, fail, sizeof(fail) - 1);
+        ret = _vc_exit(1);
+        if (ret < 0)
+            _exit(1);
+    }
 }
 

--- a/libc/src/stdlib.c
+++ b/libc/src/stdlib.c
@@ -1,12 +1,18 @@
 #include <stddef.h>
 #include "stdlib.h"
 #include "../internal/_vc_syscalls.h"
+void _exit(int);
 
 void exit(int status)
 {
-    _vc_exit(status);
-    for (;;)
-        ;
+    long ret = _vc_exit(status);
+    if (ret < 0) {
+        const char msg[] = "vc libc: exit syscall failed\n";
+        _vc_write(2, msg, sizeof(msg) - 1);
+        ret = _vc_exit(1);
+        if (ret < 0)
+            _exit(1);
+    }
 }
 
 void *malloc(size_t size)

--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -39,21 +39,22 @@ long _vc_close(int fd)
     SYSCALL_INVOKE(VC_SYS_CLOSE, fd, 0, 0);
 }
 
-__attribute__((noreturn, naked)) void _vc_exit(int status)
+long _vc_exit(int status)
 {
-    (void)status;
 #ifdef __x86_64__
-    __asm__ volatile(
-        "mov $60, %rax\n"
-        "syscall\n"
-        "hlt\n"
-    );
+    long ret;
+    __asm__ volatile ("syscall"
+                      : "=a"(ret)
+                      : "a"(VC_SYS_EXIT), "D"(status)
+                      : "rcx", "r11", "memory");
+    return ret;
 #elif defined(__i386__)
-    __asm__ volatile(
-        "mov $1, %eax\n"
-        "int $0x80\n"
-        "hlt\n"
-    );
+    long ret;
+    __asm__ volatile ("int $0x80"
+                      : "=a"(ret)
+                      : "a"(VC_SYS_EXIT), "b"(status)
+                      : "memory");
+    return ret;
 #endif
 }
 

--- a/tests/fixtures/libc_exit_fail.c
+++ b/tests/fixtures/libc_exit_fail.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+int main(void) {
+    exit(0);
+    return 1;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -34,7 +34,7 @@ for cfile in "$DIR"/fixtures/*.c; do
     base=$(basename "$cfile" .c)
 
     case "$base" in
-        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio|libc_puts|libc_printf|local_program|local_assign|libc_fileio|libc_short_write|libc_write_fail)
+        *_x86-64|struct_*|bitfield_rw|include_search|include_angle|include_env|macro_bad_define|preproc_blank|macro_cli|macro_cli_quote|include_once|include_once_link|include_next|include_next_quote|libm_program|union_example|varargs_double|include_stdio|libc_puts|libc_printf|local_program|local_assign|libc_fileio|libc_short_write|libc_write_fail|libc_exit_fail)
             continue;;
     esac
     compile_fixture "$cfile" "$DIR/fixtures/$base.s"
@@ -968,6 +968,27 @@ if [ $ret -eq 0 ]; then
     fail=1
 fi
 rm -f "$prog" "$failwrite" "$libvclib"
+
+# simulate failing exit syscall inside internal libc
+libvclib="$DIR/libvclib.so"
+cc -shared -fPIC -I "$DIR/../libc/include" \
+    "$DIR/../libc/src/stdio.c" "$DIR/../libc/src/stdlib.c" \
+    "$DIR/../libc/src/string.c" "$DIR/../libc/src/syscalls.c" \
+    "$DIR/../libc/src/file.c" -o "$libvclib"
+prog=$(mktemp)
+cc -I "$DIR/../libc/include" "$DIR/fixtures/libc_exit_fail.c" \
+    -L"$DIR" -Wl,-rpath="$DIR" -lvclib -o "$prog"
+failexit="$DIR/libfail_vcexit.so"
+cc -shared -fPIC -o "$failexit" "$DIR/unit/fail_vcexit.c"
+set +e
+LD_PRELOAD="$failexit" "$prog" >/dev/null 2>&1
+ret=$?
+set -e
+if [ $ret -ne 1 ]; then
+    echo "Test exit_fail_fallback failed"
+    fail=1
+fi
+rm -f "$prog" "$failexit" "$libvclib"
 
 # regression test for long command error message
 long_tmpdir=$(mktemp -d)

--- a/tests/unit/fail_vcexit.c
+++ b/tests/unit/fail_vcexit.c
@@ -1,0 +1,4 @@
+long _vc_exit(int status) {
+    (void)status;
+    return -1;
+}


### PR DESCRIPTION
## Summary
- expose `_vc_exit` as returning `long`
- implement a return path in `_vc_exit` when the syscall fails
- update `exit` and pthread stubs to retry `_vc_exit` and then `_exit`
- add failing exit stub for unit testing
- extend test suite to ensure exit fallback works

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68782fce74348324ba98f5bac212ef4e