### PR TITLE
Fix pthread_create missing return

### DIFF
--- a/libc/src/pthread.c
+++ b/libc/src/pthread.c
@@ -20,5 +20,7 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
         if (ret < 0)
             _exit(1);
     }
+
+    return -1;
 }
 


### PR DESCRIPTION
## Summary
- ensure pthread_create returns a failure code

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687835dffe5c83249398b281efd2b8c4