### PR TITLE
Handle snprintf error in temp file helper

### DIFF
--- a/include/compile_helpers.h
+++ b/include/compile_helpers.h
@@ -3,8 +3,12 @@
 
 #include "cli.h"
 
-/* Create a temporary file and return its descriptor. On success the path is
- * stored in *out_path. Returns -1 on failure. */
+/*
+ * Create a temporary file and return its descriptor.  On success the path
+ * is stored in *out_path.  Returns -1 on failure with errno set to one of:
+ *   ENAMETOOLONG - path would exceed PATH_MAX or snprintf truncated
+ *   others       - from malloc, mkstemp or fcntl
+ */
 int create_temp_file(const cli_options_t *cli, const char *prefix,
                      char **out_path);
 

--- a/include/util.h
+++ b/include/util.h
@@ -52,7 +52,14 @@ void free_func_list_vector(vector_t *v);
 /* Release a vector of stmt_t* elements */
 void free_glob_list_vector(vector_t *v);
 
-/* Assemble an mkstemp template path using cli->obj_dir */
+/*
+ * Assemble an mkstemp template path using cli->obj_dir or TMPDIR.
+ * Returns a newly allocated string on success or NULL on failure.
+ *
+ * Possible errno values:
+ *   ENAMETOOLONG - resulting path would exceed PATH_MAX or snprintf truncated
+ *   others       - from malloc or snprintf
+ */
 char *create_temp_template(const cli_options_t *cli, const char *prefix);
 
 /* Create and open the temporary file described by tmpl */

--- a/src/util.c
+++ b/src/util.c
@@ -272,10 +272,9 @@ create_temp_template(const cli_options_t *cli, const char *prefix)
     if (!tmpl)
         return NULL;
 
-    errno = 0;
     int n = snprintf(tmpl, len + 1, "%s/%sXXXXXX", dir, prefix);
-    int err = errno;
     if (n < 0) {
+        int err = errno;
         free(tmpl);
         errno = err;
         return NULL;

--- a/tests/unit/test_temp_file.c
+++ b/tests/unit/test_temp_file.c
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include "cli.h"
+#include "util.h"
 
 int create_temp_file(const cli_options_t *cli, const char *prefix, char **out_path);
 
@@ -38,6 +39,8 @@ int snprintf(char *str, size_t size, const char *fmt, ...)
     va_end(ap);
     return rc;
 }
+
+#include "../../src/util.c"
 
 static int failures = 0;
 #define ASSERT(cond) do { \
@@ -121,6 +124,19 @@ static void test_snprintf_error(void)
     force_snprintf_error = 0;
 }
 
+static void test_template_snprintf_error(void)
+{
+    force_snprintf_error = 1;
+    cli_options_t cli;
+    memset(&cli, 0, sizeof(cli));
+    const char *prefix = "vc";
+    errno = 0;
+    char *tmpl = create_temp_template(&cli, prefix);
+    ASSERT(tmpl == NULL);
+    ASSERT(errno == ENOSYS);
+    force_snprintf_error = 0;
+}
+
 static void test_tmpdir(void)
 {
     const char *tmpdir = "./tmp_test_dir";
@@ -168,6 +184,7 @@ int main(void)
     test_reject_pathmax_dir();
     test_snprintf_overflow();
     test_snprintf_error();
+    test_template_snprintf_error();
     test_tmpdir();
     test_tmpdir_mkdtemp();
     if (failures == 0)


### PR DESCRIPTION
## Summary
- preserve errno when snprintf fails in `create_temp_template`
- document errno values in headers
- test direct failure path in `create_temp_template`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687836728a1c8324b36b06578b771c84