### PR TITLE
Refactor linker args

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -196,5 +196,9 @@ most work to helper routines:
   `--link`.
 - `finalize_options` – validates the parsed state and gathers source files.
 
+`build_linker_args` constructs the final `cc` command for linking using an array
+of fixed arguments. The array size drives the allocation of the argument vector
+so adding new options only requires appending to the list.
+
 Splitting the logic keeps `cli_parse_args` short and makes each option group
 easier to maintain.


### PR DESCRIPTION
## Summary
- track linker arguments using a fixed array in `compile_link.c`
- mention the new approach in developer docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687836657a8c8324af913fb6ea517212