### PR TITLE
Handle append_token allocation failure

### DIFF
--- a/include/lexer_internal.h
+++ b/include/lexer_internal.h
@@ -5,8 +5,8 @@
 #include "token.h"
 #include "vector.h"
 
-void append_token(vector_t *vec, token_type_t type, const char *lexeme,
-                  size_t len, size_t line, size_t column);
+int append_token(vector_t *vec, token_type_t type, const char *lexeme,
+                 size_t len, size_t line, size_t column);
 
 int scan_identifier(const char *src, size_t *i, size_t *col,
                     vector_t *tokens, size_t line);

--- a/src/lexer_ident.c
+++ b/src/lexer_ident.c
@@ -63,8 +63,8 @@ static token_type_t lookup_keyword(const char *str, size_t len)
     return TOK_IDENT;
 }
 
-static void read_identifier(const char *src, size_t *i, size_t *col,
-                            vector_t *tokens, size_t line)
+static int read_identifier(const char *src, size_t *i, size_t *col,
+                           vector_t *tokens, size_t line)
 {
     size_t start = *i;
     while (isalnum((unsigned char)src[*i]) || src[*i] == '_')
@@ -73,13 +73,16 @@ static void read_identifier(const char *src, size_t *i, size_t *col,
     token_type_t type = TOK_IDENT;
     if (src[*i] == ':') {
         (*i)++; /* consume ':' */
-        append_token(tokens, TOK_LABEL, src + start, len, line, *col);
+        if (!append_token(tokens, TOK_LABEL, src + start, len, line, *col))
+            return 0;
         *col += len + 1;
-        return;
+        return 1;
     }
     type = lookup_keyword(src + start, len);
-    append_token(tokens, type, src + start, len, line, *col);
+    if (!append_token(tokens, type, src + start, len, line, *col))
+        return 0;
     *col += len;
+    return 1;
 }
 
 int scan_identifier(const char *src, size_t *i, size_t *col,
@@ -88,6 +91,7 @@ int scan_identifier(const char *src, size_t *i, size_t *col,
     char c = src[*i];
     if (!isalpha((unsigned char)c) && c != '_')
         return 0;
-    read_identifier(src, i, col, tokens, line);
+    if (!read_identifier(src, i, col, tokens, line))
+        return -1;
     return 1;
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -71,7 +71,8 @@ $CC -Iinclude -Wall -Wextra -std=c99 -c src/ast_clone.c -o ast_clone_fail.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/ast_expr.c -o ast_expr_fail.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/ast_stmt_create.c -o ast_stmt_create_fail.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/ast_stmt_free.c -o ast_stmt_free_fail.o
-$CC -Iinclude -Wall -Wextra -std=c99 -c src/lexer.c -o lexer_alloc.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push \
+    -c src/lexer.c -o lexer_alloc.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_alloc.o
 $CC -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -c src/util.c -o util_alloc.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_alloc.o

--- a/tests/unit/test_parser_alloc_fail.c
+++ b/tests/unit/test_parser_alloc_fail.c
@@ -34,9 +34,20 @@ static void test_param_alloc_fail(void)
     lexer_free_tokens(toks, count);
 }
 
+static void test_token_alloc_fail(void)
+{
+    const char *src = "int x;";
+    size_t count = 0;
+    fail_push = 1;
+    token_t *toks = lexer_tokenize(src, &count);
+    ASSERT(toks == NULL);
+    fail_push = 0;
+}
+
 int main(void)
 {
     test_param_alloc_fail();
+    test_token_alloc_fail();
     if (failures == 0)
         printf("All parser alloc tests passed\n");
     else


### PR DESCRIPTION
## Summary
- return an error from `append_token` instead of exiting
- propagate failures through lexing helpers and `lexer_tokenize`
- test token allocation failure via `parser_alloc_tests`
- compile lexer with allocation hook in tests

## Testing
- `tests/run.sh` *(fails: multiple definition of `ast_free_func`)*

------
https://chatgpt.com/codex/tasks/task_e_6878364c142c8324a1e9e16cadb7cf99