### PR TITLE
Refactor libc include/archive setup

### DIFF
--- a/include/cli_opts.h
+++ b/include/cli_opts.h
@@ -7,5 +7,7 @@ int parse_optimization_opts(int opt, const char *arg, cli_options_t *opts);
 int parse_io_paths(int opt, const char *arg, cli_options_t *opts);
 int parse_misc_opts(int opt, const char *arg, const char *prog, cli_options_t *opts);
 int finalize_options(int argc, char **argv, const char *prog, cli_options_t *opts);
+int setup_internal_libc_paths(cli_options_t *opts, const char *prog,
+                              char *archive_out, size_t out_len);
 
 #endif /* VC_CLI_OPTS_H */

--- a/src/cli_opts.c
+++ b/src/cli_opts.c
@@ -369,6 +369,75 @@ int parse_misc_opts(int opt, const char *arg, const char *prog,
     }
 }
 
+int setup_internal_libc_paths(cli_options_t *opts, const char *prog,
+                              char *archive_out, size_t out_len)
+{
+    if (!opts)
+        return 1;
+
+    if ((!opts->vc_sysinclude || !*opts->vc_sysinclude)) {
+        if (!prog)
+            return 1;
+        char tmp[PATH_MAX];
+        int len = snprintf(tmp, sizeof(tmp), "%s", prog);
+        if (len < 0 || len >= (int)sizeof(tmp)) {
+            fprintf(stderr, "Error: internal libc path too long.\n");
+            return 1;
+        }
+        char *slash = strrchr(tmp, '/');
+        if (slash)
+            *slash = '\0';
+        else
+            strcpy(tmp, ".");
+        size_t dirlen = strlen(tmp);
+        if (dirlen + strlen("/libc/include") >= PATH_MAX) {
+            fprintf(stderr, "Error: internal libc path too long.\n");
+            return 1;
+        }
+        strcat(tmp, "/libc/include");
+        opts->vc_sysinclude = vc_strdup(tmp);
+        if (!opts->vc_sysinclude) {
+            vc_oom();
+            return 1;
+        }
+        opts->free_vc_sysinclude = true;
+    }
+
+    preproc_set_internal_libc_dir(opts->vc_sysinclude);
+
+    const char *dir = opts->vc_sysinclude;
+    int ret;
+    char hdr[PATH_MAX];
+    ret = snprintf(hdr, sizeof(hdr), "%s/stdio.h", dir);
+    if (ret < 0 || ret >= (int)sizeof(hdr) || access(hdr, F_OK) != 0) {
+        fprintf(stderr, "Error: internal libc header '%s' not found.\n", hdr);
+        return 1;
+    }
+
+    char libdir[PATH_MAX];
+    ret = snprintf(libdir, sizeof(libdir), "%s", dir);
+    if (ret < 0 || ret >= (int)sizeof(libdir)) {
+        fprintf(stderr, "Error: internal libc archive path too long.\n");
+        return 1;
+    }
+    char *slash = strrchr(libdir, '/');
+    if (slash)
+        *slash = '\0';
+    const char *libname = opts->use_x86_64 ? "libc64.a" : "libc32.a";
+    if (snprintf(archive_out, out_len, "%s/%s", libdir, libname) >=
+        (int)out_len) {
+        fprintf(stderr, "Error: internal libc archive path too long.\n");
+        return 1;
+    }
+    if (access(archive_out, F_OK) != 0) {
+        fprintf(stderr, "Error: internal libc archive '%s' not found.\n",
+                archive_out);
+        return 1;
+    }
+
+    return 0;
+}
+
 int finalize_options(int argc, char **argv, const char *prog,
                      cli_options_t *opts)
 {
@@ -396,69 +465,8 @@ int finalize_options(int argc, char **argv, const char *prog,
     }
 
     if (opts->internal_libc) {
-        if (!opts->vc_sysinclude || !*opts->vc_sysinclude) {
-            char tmp[PATH_MAX];
-            int len = snprintf(tmp, sizeof(tmp), "%s", prog);
-            if (len < 0 || len >= (int)sizeof(tmp)) {
-                fprintf(stderr, "Error: internal libc path too long.\n");
-                cli_free_opts(opts);
-                return 1;
-            }
-            char *slash = strrchr(tmp, '/');
-            if (slash)
-                *slash = '\0';
-            else
-                strcpy(tmp, ".");
-            size_t dirlen = strlen(tmp);
-            if (dirlen + strlen("/libc/include") >= PATH_MAX) {
-                fprintf(stderr, "Error: internal libc path too long.\n");
-                cli_free_opts(opts);
-                return 1;
-            }
-            strcat(tmp, "/libc/include");
-            opts->vc_sysinclude = vc_strdup(tmp);
-            if (!opts->vc_sysinclude) {
-                vc_oom();
-                cli_free_opts(opts);
-                return 1;
-            }
-            opts->free_vc_sysinclude = true;
-        }
-        preproc_set_internal_libc_dir(opts->vc_sysinclude);
-
-        const char *dir = opts->vc_sysinclude;
-        int ret;
-        char hdr[PATH_MAX];
-        ret = snprintf(hdr, sizeof(hdr), "%s/stdio.h", dir);
-        if (ret < 0 || ret >= (int)sizeof(hdr) || access(hdr, F_OK) != 0) {
-            fprintf(stderr,
-                    "Error: internal libc header '%s' not found.\n",
-                    hdr);
-            cli_free_opts(opts);
-            return 1;
-        }
-
-        char libdir[PATH_MAX];
-        ret = snprintf(libdir, sizeof(libdir), "%s", dir);
-        if (ret < 0 || ret >= (int)sizeof(libdir)) {
-            fprintf(stderr, "Error: internal libc archive path too long.\n");
-            cli_free_opts(opts);
-            return 1;
-        }
-        char *slash = strrchr(libdir, '/');
-        if (slash)
-            *slash = '\0';
-        const char *libname = opts->use_x86_64 ? "libc64.a" : "libc32.a";
         char archive[PATH_MAX];
-        if (snprintf(archive, sizeof(archive), "%s/%s", libdir, libname) >= (int)sizeof(archive)) {
-            fprintf(stderr, "Error: internal libc archive path too long.\n");
-            cli_free_opts(opts);
-            return 1;
-        }
-        if (access(archive, F_OK) != 0) {
-            fprintf(stderr,
-                    "Error: internal libc archive '%s' not found.\n",
-                    archive);
+        if (setup_internal_libc_paths(opts, prog, archive, sizeof(archive)) != 0) {
             cli_free_opts(opts);
             return 1;
         }


### PR DESCRIPTION
## Summary
- centralize internal libc path logic in `setup_internal_libc_paths`
- use helper in `finalize_options` and linker code

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687835fc82748324a1696133f16af018