### PR TITLE
Fix preproc context leak on preprocessing failure

### DIFF
--- a/src/compile_tokenize.c
+++ b/src/compile_tokenize.c
@@ -243,6 +243,7 @@ int compile_tokenize_impl(const char *source, const cli_options_t *cli,
                            cli->internal_libc, cli->use_x86_64);
         if (!text) {
             perror("preproc_run");
+            preproc_context_free(&ctx);
             return 0;
         }
         if (deps) {


### PR DESCRIPTION
## Summary
- free preprocessor context when `preproc_run` fails inside `compile_tokenize_impl`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783d0ab5988324b810d17b759d3483