### PR TITLE
Fix internal libc path truncation

### DIFF
--- a/src/cli_opts.c
+++ b/src/cli_opts.c
@@ -398,12 +398,13 @@ int finalize_options(int argc, char **argv, const char *prog,
     if (opts->internal_libc) {
         if (!opts->vc_sysinclude || !*opts->vc_sysinclude) {
             char tmp[PATH_MAX];
-            int len = snprintf(tmp, sizeof(tmp), "%s", prog);
-            if (len < 0 || len >= (int)sizeof(tmp)) {
+            size_t prog_len = strlen(prog);
+            if (prog_len >= sizeof(tmp)) {
                 fprintf(stderr, "Error: internal libc path too long.\n");
                 cli_free_opts(opts);
                 return 1;
             }
+            memcpy(tmp, prog, prog_len + 1);
             char *slash = strrchr(tmp, '/');
             if (slash)
                 *slash = '\0';

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -514,6 +514,17 @@ $CC -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING \
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_vc_sysinclude_long.c" -o "$DIR/test_vc_sysinclude_long.o"
 $CC -Wl,--gc-sections -o "$DIR/vc_sysinclude_long" compile_link_vc_sysinclude_long.o src/vector.c src/util.c src/error.c "$DIR/test_vc_sysinclude_long.o"
 rm -f compile_link_vc_sysinclude_long.o "$DIR/test_vc_sysinclude_long.o"
+# build overlong program path regression test
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/cli.c -o cli_prog_path_long.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/cli_env.c -o cli_env_prog_path_long.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/cli_opts.c -o cli_opts_prog_path_long.o
+$CC -Iinclude -Wall -Wextra -std=c99 -DPROJECT_ROOT="$(pwd)" -c src/preproc_path.c -o preproc_path_prog_path_long.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/include_path_cache.c -o include_path_cache_prog_path_long.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_prog_path_long.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_prog_path_long.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_prog_path_long.c" -o "$DIR/test_prog_path_long.o"
+$CC -o "$DIR/prog_path_long" cli_prog_path_long.o cli_env_prog_path_long.o cli_opts_prog_path_long.o preproc_path_prog_path_long.o include_path_cache_prog_path_long.o vector_prog_path_long.o util_prog_path_long.o "$DIR/test_prog_path_long.o"
+rm -f cli_prog_path_long.o cli_env_prog_path_long.o cli_opts_prog_path_long.o preproc_path_prog_path_long.o include_path_cache_prog_path_long.o vector_prog_path_long.o util_prog_path_long.o "$DIR/test_prog_path_long.o"
 # build object/dependency name long filename test
 $CC -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile_link.c -o compile_link_names.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_vc_names.c" -o "$DIR/test_vc_names.o"
@@ -634,6 +645,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/vc_sysinclude"
 "$DIR/vc_sysinclude_win"
 "$DIR/vc_sysinclude_long"
+"$DIR/prog_path_long"
 "$DIR/preproc_sysheaders_fail"
 "$DIR/preproc_popen_fail"
 "$DIR/invalid_macro_tests"

--- a/tests/unit/test_prog_path_long.c
+++ b/tests/unit/test_prog_path_long.c
@@ -1,0 +1,65 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#ifndef PATH_MAX
+# include <sys/param.h>
+#endif
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
+#include "cli.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    size_t len = PATH_MAX + 10;
+    char *prog = malloc(len + 1);
+    memset(prog, 'a', len);
+    prog[len] = '\0';
+
+    char *argv[] = { prog, "--internal-libc", "-o", "out.o", "file.c", NULL };
+    int argc = 5;
+
+    FILE *tmp = tmpfile();
+    if (!tmp) {
+        perror("tmpfile");
+        exit(1);
+    }
+    int saved = dup(fileno(stderr));
+    dup2(fileno(tmp), fileno(stderr));
+
+    cli_options_t opts;
+    int ret = cli_parse_args(argc, argv, &opts);
+
+    fflush(stderr);
+    fseek(tmp, 0, SEEK_SET);
+    char buf[256];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    buf[n] = '\0';
+
+    dup2(saved, fileno(stderr));
+    close(saved);
+    fclose(tmp);
+
+    if (ret == 0)
+        cli_free_opts(&opts);
+    free(prog);
+
+    ASSERT(ret != 0);
+    ASSERT(strstr(buf, "internal libc path too long") != NULL);
+
+    if (failures == 0)
+        printf("All prog_path_long tests passed\n");
+    else
+        printf("%d prog_path_long test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- check `prog` length before formatting the default internal libc path
- handle overlong executable paths in `cli_opts.c`
- add regression test for extremely long program name

## Testing
- `bash -x tests/run.sh` *(fails: multiple definition of `ast_free_func`)*

------
https://chatgpt.com/codex/tasks/task_e_68783cf2f2a4832493d1e2f06238120c