### PR TITLE
Clamp puts return

### DIFF
--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -10,6 +10,8 @@
 
 #include <stdarg.h>
 
+/* Returns the number of characters written including the newline. If the
+ * length would overflow an int, INT_MAX is returned instead. */
 int puts(const char *s);
 int printf(const char *format, ...);
 

--- a/libc/src/stdio.c
+++ b/libc/src/stdio.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <stdarg.h>
+#include <limits.h>
 #include "stdio.h"
 #include "../internal/_vc_syscalls.h"
 
@@ -17,6 +18,8 @@ int puts(const char *s)
         perror("write");
         return -1;
     }
+    if (len + 1 > (size_t)INT_MAX)
+        return INT_MAX;
     return (int)(len + 1);
 }
 

--- a/tests/fixtures/libc_puts_large.c
+++ b/tests/fixtures/libc_puts_large.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <limits.h>
+int main(void)
+{
+    int ret = puts("a");
+    return (ret == INT_MAX) ? 0 : 1;
+}

--- a/tests/unit/large_strlen.c
+++ b/tests/unit/large_strlen.c
@@ -1,0 +1,14 @@
+#include <limits.h>
+#include <stddef.h>
+
+size_t strlen(const char *s)
+{
+    (void)s;
+    return (size_t)INT_MAX + 10;
+}
+
+long _vc_write(int fd, const void *buf, unsigned long count)
+{
+    (void)fd; (void)buf;
+    return (long)count;
+}


### PR DESCRIPTION
## Summary
- clamp return value of puts at INT_MAX
- document puts return clamping
- test puts with artificially huge string

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68783d6d4f388324b187fe537404a984