### PR TITLE
Remove dead null check in init_std_include_dirs

### DIFF
--- a/src/include_path_cache.c
+++ b/src/include_path_cache.c
@@ -142,18 +142,16 @@ static void init_std_include_dirs(void)
     }
     size_t len = strlen("/usr/include/") + strlen(multi);
     char *path = vc_alloc_or_exit(len + 1);
-    if (!path)
-        return;
     snprintf(path, len + 1, "/usr/include/%s", multi);
     std_include_dirs[0] = path;
     const char *gccdir = get_gcc_include_dir();
+#if !defined(GCC_INCLUDE_DIR)
     char *fallback = NULL;
+#endif
     if (!gccdir) {
 #if !defined(GCC_INCLUDE_DIR)
         len = strlen("/usr/lib/gcc/") + strlen(multi) + strlen("/include");
         fallback = vc_alloc_or_exit(len + 1);
-        if (!fallback)
-            goto fail;
         snprintf(fallback, len + 1, "/usr/lib/gcc/%s/include", multi);
         gcc_include_cached = fallback;
         gccdir = fallback;
@@ -163,16 +161,6 @@ static void init_std_include_dirs(void)
     }
     std_include_dirs[1] = gccdir;
     std_dirs_initialized = 1;
-    return;
-fail:
-    free(path);
-    std_include_dirs[0] = NULL;
-#ifndef GCC_INCLUDE_DIR
-    free(fallback);
-    if (fallback && gcc_include_cached == fallback)
-        gcc_include_cached = NULL;
-#endif
-    std_include_dirs[1] = NULL;
     return;
 #elif defined(__NetBSD__) || defined(__FreeBSD__)
     const char *gccdir = get_gcc_include_dir();


### PR DESCRIPTION
## Summary
- remove unreachable null checks after `vc_alloc_or_exit`
- delete `fail:` cleanup block and limit `fallback` scope

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783fa0b7508324b3df569e0f2bebfe