### PR TITLE
Handle __has_include allocation failure

### DIFF
--- a/src/preproc_expr_parse.c
+++ b/src/preproc_expr_parse.c
@@ -26,6 +26,11 @@ static long long parse_has_include(expr_ctx_t *ctx, int is_next)
         ctx->s++;
     size_t len = (size_t)(ctx->s - start);
     char *tok = vc_strndup(start, len);
+    if (!tok) {
+        ctx->error = 1;
+        vc_oom();
+        return 0;
+    }
     ctx->s = skip_ws((char *)ctx->s);
     if (*ctx->s == ')')
         ctx->s++;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -288,6 +288,8 @@ $CC -Iinclude -Wall -Wextra -std=c99 \
     src/preproc_include.c src/preproc_includes.c src/include_path_cache.c src/preproc_path.c \
     src/vector.c src/strbuf.c src/util.c src/error.c
 $CC -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/preproc_has_include_alloc_fail" "$DIR/unit/test_preproc_has_include_alloc_fail.c"
+$CC -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/preproc_include_comment" "$DIR/unit/test_preproc_include_comment.c" \
     src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c \
     src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c \
@@ -604,6 +606,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/preproc_multi_stdheaders"
 "$DIR/preproc_has_include"
 "$DIR/preproc_has_include_macro"
+"$DIR/preproc_has_include_alloc_fail"
 "$DIR/preproc_include_comment"
 "$DIR/preproc_ifmacro"
 "$DIR/preproc_line"

--- a/tests/unit/test_preproc_has_include_alloc_fail.c
+++ b/tests/unit/test_preproc_has_include_alloc_fail.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include "preproc_expr_parse.h"
+#include "preproc_macros.h"
+#include "strbuf.h"
+#include "vector.h"
+#include "util.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static char *test_vc_strndup(const char *s, size_t n) { (void)s; (void)n; return NULL; }
+static int test_expand_line(const char *l, vector_t *m, strbuf_t *o, size_t c, int d, preproc_context_t *ctx) { (void)l;(void)m;(void)o;(void)c;(void)d;(void)ctx; return 1; }
+static char *test_expr_parse_header_name(expr_ctx_t *ctx, char *endc) { (void)ctx;(void)endc; return NULL; }
+static char *test_find_include_path(const char *f, char e, const char *d, const vector_t *i, size_t s, size_t *o) { (void)f;(void)e;(void)d;(void)i;(void)s;(void)o; return NULL; }
+void vc_oom(void) { }
+static void test_strbuf_init(strbuf_t *b) { (void)b; }
+static void test_strbuf_free(strbuf_t *b) { (void)b; }
+static char *test_expr_parse_ident(expr_ctx_t *ctx) { (void)ctx; return NULL; }
+static int test_expr_parse_char_escape(const char **p) { (void)p; return 0; }
+static int test_is_macro_defined(vector_t *m, const char *n) { (void)m;(void)n; return 0; }
+
+#define vc_strndup test_vc_strndup
+#define expand_line test_expand_line
+#define expr_parse_header_name test_expr_parse_header_name
+#define find_include_path test_find_include_path
+#define strbuf_init test_strbuf_init
+#define strbuf_free test_strbuf_free
+#define expr_parse_ident test_expr_parse_ident
+#define expr_parse_char_escape test_expr_parse_char_escape
+#define is_macro_defined test_is_macro_defined
+#include "../../src/preproc_expr_parse.c"
+
+int main(void) {
+    expr_ctx_t ctx = { "__has_include(foo)", NULL, NULL, NULL, NULL, 0 };
+    long long val = parse_has_include(&ctx, 0);
+    ASSERT(val == 0);
+    ASSERT(ctx.error);
+    if (failures == 0)
+        printf("All preproc_has_include_alloc_fail tests passed\n");
+    else
+        printf("%d preproc_has_include_alloc_fail test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- detect failed vc_strndup in `parse_has_include`
- add regression test for `__has_include` allocation failure

## Testing
- `gcc -Iinclude -Wall -Wextra -std=c99 tests/unit/test_preproc_has_include_alloc_fail.c -o /tmp/t`
- `/tmp/t`

------
https://chatgpt.com/codex/tasks/task_e_68783d41e5248324a7f7c341ddd5eeb5