### PR TITLE
Handle unexpected _vc_exit return

### DIFF
--- a/libc/internal/_vc_syscalls.h
+++ b/libc/internal/_vc_syscalls.h
@@ -31,7 +31,7 @@ long _vc_write(int, const void *, unsigned long);
 long _vc_read(int, void *, unsigned long);
 long _vc_open(const char *, int, int);
 long _vc_close(int);
-long _vc_exit(int);
+void _vc_exit(int) __attribute__((noreturn));
 void *_vc_malloc(unsigned long);
 void _vc_free(void *);
 

--- a/libc/src/pthread.c
+++ b/libc/src/pthread.c
@@ -1,6 +1,6 @@
 #include "pthread.h"
 #include "../internal/_vc_syscalls.h"
-void _exit(int);
+void _exit(int) __attribute__((noreturn));
 
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
                    void *(*start_routine)(void *), void *arg)
@@ -12,14 +12,12 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
     const char msg[] =
         "vc libc is single-threaded; pthread_create unsupported\n";
     _vc_write(2, msg, sizeof(msg) - 1);
-    long ret = _vc_exit(1);
-    if (ret < 0) {
-        const char fail[] = "vc libc: exit syscall failed\n";
-        _vc_write(2, fail, sizeof(fail) - 1);
-        ret = _vc_exit(1);
-        if (ret < 0)
-            _exit(1);
-    }
+    void (*exit_ptr)(int) = _vc_exit;
+    exit_ptr(1);
+    const char fail[] = "vc libc: exit syscall failed\n";
+    _vc_write(2, fail, sizeof(fail) - 1);
+    exit_ptr(1);
+    _exit(1);
 
     return -1;
 }

--- a/libc/src/stdlib.c
+++ b/libc/src/stdlib.c
@@ -1,18 +1,17 @@
 #include <stddef.h>
 #include "stdlib.h"
 #include "../internal/_vc_syscalls.h"
-void _exit(int);
+void _exit(int) __attribute__((noreturn));
 
+void exit(int status) __attribute__((noreturn));
 void exit(int status)
 {
-    long ret = _vc_exit(status);
-    if (ret < 0) {
-        const char msg[] = "vc libc: exit syscall failed\n";
-        _vc_write(2, msg, sizeof(msg) - 1);
-        ret = _vc_exit(1);
-        if (ret < 0)
-            _exit(1);
-    }
+    void (*vc_exit_ptr)(int) = _vc_exit;
+    vc_exit_ptr(status);
+    const char msg[] = "vc libc: exit syscall failed\n";
+    _vc_write(2, msg, sizeof(msg) - 1);
+    vc_exit_ptr(1);
+    _exit(1);
 }
 
 void *malloc(size_t size)

--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -39,23 +39,20 @@ long _vc_close(int fd)
     SYSCALL_INVOKE(VC_SYS_CLOSE, fd, 0, 0);
 }
 
-long _vc_exit(int status)
+void _vc_exit(int status)
 {
 #ifdef __x86_64__
-    long ret;
     __asm__ volatile ("syscall"
-                      : "=a"(ret)
+                      :
                       : "a"(VC_SYS_EXIT), "D"(status)
                       : "rcx", "r11", "memory");
-    return ret;
 #elif defined(__i386__)
-    long ret;
     __asm__ volatile ("int $0x80"
-                      : "=a"(ret)
+                      :
                       : "a"(VC_SYS_EXIT), "b"(status)
                       : "memory");
-    return ret;
 #endif
+    __builtin_unreachable();
 }
 
 void *_vc_malloc(unsigned long size)

--- a/tests/unit/fail_vcexit.c
+++ b/tests/unit/fail_vcexit.c
@@ -1,4 +1,3 @@
-long _vc_exit(int status) {
+void _vc_exit(int status) {
     (void)status;
-    return -1;
 }


### PR DESCRIPTION
## Summary
- mark `_vc_exit` as a `noreturn` syscall wrapper
- mark `exit` as `noreturn` and fall back to `_exit` if `_vc_exit` returns
- update `pthread_create` to handle unexpected `_vc_exit` return
- adjust failing exit test stub

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783f7efa80832488cf653fdd668392