### PR TITLE
Ensure multiarch cache freed on error

### DIFF
--- a/src/include_path_cache.c
+++ b/src/include_path_cache.c
@@ -48,12 +48,13 @@ static const char *get_multiarch_dir(void)
             gcc_query_failed = 1;
         } else {
             char buf[256];
+            char *tmp = NULL;
             if (fgets(buf, sizeof(buf), fp)) {
                 size_t len = strlen(buf);
                 while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
                     buf[--len] = '\0';
                 if (len)
-                    multiarch_cached = vc_strndup(buf, len);
+                    tmp = vc_strndup(buf, len);
             } else {
                 perror("fgets");
                 gcc_query_failed = 1;
@@ -61,8 +62,10 @@ static const char *get_multiarch_dir(void)
             if (pclose(fp) == -1) {
                 perror("pclose");
                 gcc_query_failed = 1;
+                free(tmp);
                 return NULL;
             }
+            multiarch_cached = tmp;
         }
         if (!multiarch_cached) {
 #ifdef MULTIARCH


### PR DESCRIPTION
## Summary
- store the gcc multiarch output in a temporary variable
- free the temporary buffer if `pclose` fails so the global cache stays `NULL`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6878400d2bc483249dea2778b2c37e51