### PR TITLE
Support %u, %c and width in printf

### DIFF
--- a/libc/src/stdio.c
+++ b/libc/src/stdio.c
@@ -71,14 +71,70 @@ int printf(const char *fmt, ...)
             continue;
         }
 
+        int width = 0;
+        const char *start = p;
+        while (*p >= '0' && *p <= '9') {
+            width = width * 10 + (*p - '0');
+            p++;
+        }
+
         if (flush_buf(out, &pos, &written) < 0) {
             va_end(ap);
             return -1;
         }
 
-        if (*p == 's') {
-            const char *s = va_arg(ap, const char *);
-            size_t len = strlen(s);
+        if (*p == 's' || *p == 'c' || *p == 'd' || *p == 'u') {
+            char num[32];
+            const char *s = NULL;
+            size_t len = 0;
+
+            if (*p == 's') {
+                s = va_arg(ap, const char *);
+                len = strlen(s);
+            } else if (*p == 'c') {
+                num[0] = (char)va_arg(ap, int);
+                s = num;
+                len = 1;
+            } else if (*p == 'd' || *p == 'u') {
+                unsigned int u;
+                int neg = 0;
+                if (*p == 'd') {
+                    int n = va_arg(ap, int);
+                    if (n < 0) {
+                        neg = 1;
+                        u = (unsigned int)(-n);
+                    } else {
+                        u = (unsigned int)n;
+                    }
+                } else {
+                    u = va_arg(ap, unsigned int);
+                }
+
+                char *q = num + sizeof(num);
+                if (u == 0) {
+                    *--q = '0';
+                } else {
+                    while (u) {
+                        *--q = (char)('0' + (u % 10));
+                        u /= 10;
+                    }
+                }
+                if (neg)
+                    *--q = '-';
+                len = num + sizeof(num) - q;
+                s = q;
+            }
+
+            int pad = width > (int)len ? width - (int)len : 0;
+            while (pad-- > 0) {
+                if (_vc_write(1, " ", 1) < 1) {
+                    perror("write");
+                    va_end(ap);
+                    return -1;
+                }
+                written += 1;
+            }
+
             long ret = _vc_write(1, s, len);
             if (ret < (long)len) {
                 perror("write");
@@ -86,45 +142,33 @@ int printf(const char *fmt, ...)
                 return -1;
             }
             written += (int)len;
-        } else if (*p == 'd') {
-            int n = va_arg(ap, int);
-            char num[32];
-            char *q = num + sizeof(num);
-            unsigned int u = (n < 0) ? (unsigned int)(-n) : (unsigned int)n;
-            if (n == 0) {
-                *--q = '0';
-            } else {
-                while (u) {
-                    *--q = (char)('0' + (u % 10));
-                    u /= 10;
-                }
-                if (n < 0)
-                    *--q = '-';
-            }
-            size_t len = num + sizeof(num) - q;
-            long ret2 = _vc_write(1, q, len);
-            if (ret2 < (long)len) {
+        } else {
+            /* unsupported specifier, print literally */
+            long ret = _vc_write(1, "%", 1);
+            if (ret < 1) {
                 perror("write");
                 va_end(ap);
                 return -1;
             }
-            written += (int)len;
-        } else {
-            /* unsupported specifier, print it literally */
-            out[pos++] = '%';
-            if (pos == sizeof(out)) {
-                if (flush_buf(out, &pos, &written) < 0) {
+            written += 1;
+            if (width) {
+                const char *q = start;
+                size_t l = (size_t)(p - start);
+                ret = _vc_write(1, q, l);
+                if (ret < (long)l) {
+                    perror("write");
                     va_end(ap);
                     return -1;
                 }
+                written += (int)l;
             }
-            out[pos++] = *p;
-            if (pos == sizeof(out)) {
-                if (flush_buf(out, &pos, &written) < 0) {
-                    va_end(ap);
-                    return -1;
-                }
+            ret = _vc_write(1, p, 1);
+            if (ret < 1) {
+                perror("write");
+                va_end(ap);
+                return -1;
             }
+            written += 1;
         }
     }
 

--- a/tests/fixtures/libc_printf.c
+++ b/tests/fixtures/libc_printf.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
 int main(void) {
-    printf("hi\n");
+    printf("hi %c %u %5d\n", 'A', 3u, 7);
     return 0;
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -730,7 +730,7 @@ if [ $SKIP_LIBC_TESTS -eq 0 ]; then
         libc_printf32=$(mktemp)
         rm -f "${libc_printf32}"
         "$BINARY" --link --internal-libc -o "${libc_printf32}" "$DIR/fixtures/libc_printf.c"
-        if [ "$("${libc_printf32}")" != "hi" ]; then
+        if [ "$("${libc_printf32}")" != "hi A 3     7" ]; then
             echo "Test libc_printf_32 failed"
             fail=1
         fi
@@ -740,7 +740,7 @@ if [ $SKIP_LIBC_TESTS -eq 0 ]; then
     libc_printf64=$(mktemp)
     rm -f "${libc_printf64}"
     "$BINARY" --x86-64 --link --internal-libc -o "${libc_printf64}" "$DIR/fixtures/libc_printf.c"
-    if [ "$("${libc_printf64}")" != "hi" ]; then
+    if [ "$("${libc_printf64}")" != "hi A 3     7" ]; then
         echo "Test libc_printf_64 failed"
         fail=1
     fi


### PR DESCRIPTION
## Summary
- improve `printf` and `fprintf` in the internal libc
- allow `%u`, `%c` and field widths
- adjust libc test fixture and expectations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783fc87c8483249c864c56d2e970d4