### PR TITLE
Make eval_expr internal

### DIFF
--- a/include/preproc_expr.h
+++ b/include/preproc_expr.h
@@ -1,9 +1,9 @@
 /*
  * Expression evaluation used by the preprocessor.
  *
- * Provides `eval_expr` which parses and evaluates the limited boolean
- * expressions permitted in conditional directives.  Evaluation uses the
- * currently defined macros to resolve the `defined` operator.
+ * Provides helpers to parse and evaluate the limited boolean expressions
+ * permitted in conditional directives.  Evaluation uses the currently
+ * defined macros to resolve the `defined` operator.
  *
  * Part of vc under the BSD 2-Clause license.
  * See LICENSE for details.
@@ -14,9 +14,6 @@
 
 #include "vector.h"
 #include "preproc_macros.h"
-
-/* Evaluate a conditional expression */
-long long eval_expr(const char *s, vector_t *macros);
 
 /* Evaluate an expression with include lookup support */
 long long eval_expr_full(const char *s, vector_t *macros,

--- a/src/preproc_expr_eval.c
+++ b/src/preproc_expr_eval.c
@@ -26,8 +26,3 @@ long long eval_expr_full(const char *s, vector_t *macros,
     return eval_internal(s, macros, dir, incdirs, stack);
 }
 
-long long eval_expr(const char *s, vector_t *macros)
-{
-    return eval_internal(s, macros, NULL, NULL, NULL);
-}
-

--- a/tests/unit/test_preproc_expr.c
+++ b/tests/unit/test_preproc_expr.c
@@ -34,11 +34,12 @@ static void test_features_expr(void)
 {
     vector_t macros; vector_init(&macros, sizeof(macro_t));
 
-    ASSERT(eval_expr("defined FOO", &macros) == 0);
-    ASSERT(eval_expr("(11 << 16) + 1 >= (10 << 16) + 1", &macros));
-    ASSERT(eval_expr("199309L >= 2 || 0", &macros));
-    ASSERT(eval_expr("1 ? 2 : 3", &macros));
-    ASSERT(eval_expr("0 ? 2 : 3", &macros));
+    ASSERT(eval_expr_full("defined FOO", &macros, NULL, NULL, NULL) == 0);
+    ASSERT(eval_expr_full("(11 << 16) + 1 >= (10 << 16) + 1", &macros,
+                         NULL, NULL, NULL));
+    ASSERT(eval_expr_full("199309L >= 2 || 0", &macros, NULL, NULL, NULL));
+    ASSERT(eval_expr_full("1 ? 2 : 3", &macros, NULL, NULL, NULL));
+    ASSERT(eval_expr_full("0 ? 2 : 3", &macros, NULL, NULL, NULL));
 
     vector_free(&macros);
 }
@@ -47,9 +48,9 @@ static void test_large_constants(void)
 {
     vector_t macros; vector_init(&macros, sizeof(macro_t));
 
-    ASSERT(eval_expr("4294967296", &macros) == 4294967296LL);
-    ASSERT(eval_expr("9223372036854775807", &macros) == 9223372036854775807LL);
-    ASSERT(eval_expr("-9223372036854775807 - 1", &macros) == (-9223372036854775807LL - 1LL));
+    ASSERT(eval_expr_full("4294967296", &macros, NULL, NULL, NULL) == 4294967296LL);
+    ASSERT(eval_expr_full("9223372036854775807", &macros, NULL, NULL, NULL) == 9223372036854775807LL);
+    ASSERT(eval_expr_full("-9223372036854775807 - 1", &macros, NULL, NULL, NULL) == (-9223372036854775807LL - 1LL));
 
     vector_free(&macros);
 }
@@ -58,10 +59,10 @@ static void test_shift_clamp(void)
 {
     vector_t macros; vector_init(&macros, sizeof(macro_t));
 
-    ASSERT(eval_expr("1 << 70", &macros) == (long long)(1ULL << 63));
-    ASSERT(eval_expr("8 >> 70", &macros) == 0);
-    ASSERT(eval_expr("1 << -1", &macros) == 1);
-    ASSERT(eval_expr("8 >> -2", &macros) == 8);
+    ASSERT(eval_expr_full("1 << 70", &macros, NULL, NULL, NULL) == (long long)(1ULL << 63));
+    ASSERT(eval_expr_full("8 >> 70", &macros, NULL, NULL, NULL) == 0);
+    ASSERT(eval_expr_full("1 << -1", &macros, NULL, NULL, NULL) == 1);
+    ASSERT(eval_expr_full("8 >> -2", &macros, NULL, NULL, NULL) == 8);
 
     vector_free(&macros);
 }


### PR DESCRIPTION
## Summary
- remove `eval_expr` prototype from public header
- delete unused helper in implementation
- update unit test to use `eval_expr_full`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687841a0e4f08324b13347d9736d0408