### PR TITLE
Fix alias entry string management

### DIFF
--- a/src/ir_builder.c
+++ b/src/ir_builder.c
@@ -3,6 +3,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include "ir_builder.h"
+#include "util.h"
 
 /* Allocate and append a blank instruction */
 ir_instr_t *append_instr(ir_builder_t *b)
@@ -72,7 +73,11 @@ int get_alias(ir_builder_t *b, const char *name)
     e = malloc(sizeof(*e));
     if (!e)
         return 0;
-    e->name = name;
+    e->name = vc_strdup(name);
+    if (!e->name) {
+        free(e);
+        return 0;
+    }
     e->set = b->next_alias_id++;
     e->next = b->aliases;
     b->aliases = e;

--- a/src/ir_core.c
+++ b/src/ir_core.c
@@ -61,6 +61,7 @@ void ir_builder_free(ir_builder_t *b)
     b->next_value_id = 0;
     while (b->aliases) {
         alias_ent_t *n = b->aliases->next;
+        free((char *)b->aliases->name);
         free(b->aliases);
         b->aliases = n;
     }

--- a/src/opt_alias.c
+++ b/src/opt_alias.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include "opt.h"
 #include "ir_core.h"
+#include "util.h"
 
 static int lookup_alias(alias_ent_t **list, const char *name, int *next_id)
 {
@@ -22,7 +23,12 @@ static int lookup_alias(alias_ent_t **list, const char *name, int *next_id)
         opt_error("out of memory");
         return 0;
     }
-    e->name = name;
+    e->name = vc_strdup(name);
+    if (!e->name) {
+        opt_error("out of memory");
+        free(e);
+        return 0;
+    }
     e->set = (*next_id)++;
     e->next = *list;
     *list = e;
@@ -65,6 +71,7 @@ void compute_alias_sets(ir_builder_t *ir)
 
     while (vars) {
         alias_ent_t *n = vars->next;
+        free((char *)vars->name);
         free(vars);
         vars = n;
     }


### PR DESCRIPTION
## Summary
- duplicate alias variable names when creating alias entries
- release alias names in `ir_builder_free` and alias analysis cleanup

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68784577eda88324916d816cbf8c67ef