### PR TITLE
Remove unreachable return from pthread stub

### DIFF
--- a/libc/src/pthread.c
+++ b/libc/src/pthread.c
@@ -2,6 +2,10 @@
 #include "../internal/_vc_syscalls.h"
 void _exit(int) __attribute__((noreturn));
 
+/*
+ * Stub implementation for pthread_create in the single-threaded libc.
+ * Prints an error message and exits; this function never returns.
+ */
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
                    void *(*start_routine)(void *), void *arg)
 {
@@ -18,7 +22,5 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
     _vc_write(2, fail, sizeof(fail) - 1);
     exit_ptr(1);
     _exit(1);
-
-    return -1;
 }
 


### PR DESCRIPTION
## Summary
- explain that `pthread_create` stub never returns
- remove the unreachable `return -1`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68784517ae288324b1630ceab4605acf