### PR TITLE
Fix allocation failure handling

### DIFF
--- a/src/preproc_expr_parse.c
+++ b/src/preproc_expr_parse.c
@@ -27,8 +27,8 @@ static long long parse_has_include(expr_ctx_t *ctx, int is_next)
     size_t len = (size_t)(ctx->s - start);
     char *tok = vc_strndup(start, len);
     if (!tok) {
-        ctx->error = 1;
         vc_oom();
+        ctx->error = 1;
         return 0;
     }
     ctx->s = skip_ws((char *)ctx->s);


### PR DESCRIPTION
## Summary
- fix parse_has_include to call `vc_oom()` before setting the error flag

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687847b7b9588324bb8f40b3198a8342