### PR TITLE
Fix duplicate comment in strbuf.c

### DIFF
--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -28,13 +28,12 @@ void strbuf_init(strbuf_t *sb)
     sb->data[0] = '\0';
 }
 
-/* Ensure the buffer can hold at least "extra" additional bytes. */
 /*
  * Ensure the buffer can hold at least "extra" additional bytes.
  * Returns 0 on success and -1 on failure.  On failure an error message
  * is printed and no reallocation is performed.  Memory allocation
  * failures are fatal and terminate the process.
- */
+*/
 static int sb_ensure(strbuf_t *sb, size_t extra)
 {
     if (!sb)


### PR DESCRIPTION
## Summary
- deduplicate the sb_ensure comment in `src/strbuf.c`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6878522a88a8832489e3761ddfa7a864