### PR TITLE
Fix vc_strtoul_size to reject negatives and add test

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -30,7 +30,11 @@ void *vc_realloc_or_exit(void *ptr, size_t size);
 /* Read entire file into a NUL-terminated buffer */
 char *vc_read_file(const char *path);
 
-/* Convert string to size_t, returning 1 on success */
+/*
+ * Convert string to size_t, returning 1 on success.
+ *
+ * Negative values are rejected.
+ */
 int vc_strtoul_size(const char *s, size_t *out);
 
 /*

--- a/src/util.c
+++ b/src/util.c
@@ -156,6 +156,8 @@ char *vc_read_file(const char *path)
  */
 int vc_strtoul_size(const char *s, size_t *out)
 {
+    if (s[0] == '-')
+        return 0;
     errno = 0;
     char *end;
     unsigned long val = strtoul(s, &end, 10);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -155,6 +155,11 @@ $CC -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strtoul_unsigned.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_vc_strtoul_unsigned.c" -o "$DIR/test_vc_strtoul_unsigned.o"
 $CC -o "$DIR/vc_strtoul_unsigned" util_strtoul_unsigned.o "$DIR/test_vc_strtoul_unsigned.o"
 rm -f util_strtoul_unsigned.o "$DIR/test_vc_strtoul_unsigned.o"
+# build vc_strtoul_size negative value rejection test
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strtoul_size.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_vc_strtoul_size.c" -o "$DIR/test_vc_strtoul_size.o"
+$CC -o "$DIR/vc_strtoul_size" util_strtoul_size.o "$DIR/test_vc_strtoul_size.o"
+rm -f util_strtoul_size.o "$DIR/test_vc_strtoul_size.o"
 # build builtin counter wraparound regression test
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/preproc_builtin.c -o preproc_builtin_wrap.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_wrap.o
@@ -712,6 +717,17 @@ if [ $ret -ne 0 ]; then
     fail=1
 fi
 rm -f "$err" "$DIR/vc_strtoul_unsigned"
+# regression test for vc_strtoul_size handling
+err=$(safe_mktemp)
+set +e
+"$DIR/vc_strtoul_size" > /dev/null 2> "$err"
+ret=$?
+set -e
+if [ $ret -ne 0 ]; then
+    echo "Test vc_strtoul_size failed"
+    fail=1
+fi
+rm -f "$err" "$DIR/vc_strtoul_size"
 # regression test for collect_funcs overflow handling
 err=$(safe_mktemp)
 set +e

--- a/tests/unit/test_vc_strtoul_size.c
+++ b/tests/unit/test_vc_strtoul_size.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include "util.h"
+
+int main(void)
+{
+    size_t val = 0;
+    if (vc_strtoul_size("-1", &val)) {
+        printf("negative accepted\n");
+        return 1;
+    }
+    if (!vc_strtoul_size("123", &val) || val != (size_t)123u) {
+        printf("parse failed\n");
+        return 1;
+    }
+    printf("All vc_strtoul_size tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- reject negative inputs in `vc_strtoul_size`
- document negative rejection in `util.h`
- add a regression test verifying behaviour
- hook the new test into the test driver

## Testing
- `cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -c src/util.c -o util_test.o`
- `cc -Iinclude -Wall -Wextra -std=c99 tests/unit/test_vc_strtoul_size.c util_test.o -o vc_strtoul_size`
- `./vc_strtoul_size`

------
https://chatgpt.com/codex/tasks/task_e_687852a8b4e083249987e6630238aae5