### PR TITLE
Fix include path cleanup on push failure

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -335,9 +335,11 @@ int collect_include_dirs(vector_t *search_dirs,
             size_t len = root_len + strlen(base);
             char *dup = malloc(len + 1);
             if (!dup) {
-                free_string_vector(search_dirs);
-                if (dest == &extra_sys_dirs)
+                free_string_vector(dest);
+                if (dest == search_dirs)
                     free_string_vector(&extra_sys_dirs);
+                else
+                    free_string_vector(search_dirs);
                 return 0;
             }
             memcpy(dup, sysroot, root_len);
@@ -345,9 +347,11 @@ int collect_include_dirs(vector_t *search_dirs,
             strcat(dup, base);
             if (!vector_push(dest, &dup)) {
                 free(dup);
-                free_string_vector(search_dirs);
-                if (dest == &extra_sys_dirs)
+                free_string_vector(dest);
+                if (dest == search_dirs)
                     free_string_vector(&extra_sys_dirs);
+                else
+                    free_string_vector(search_dirs);
                 return 0;
             }
         }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -214,6 +214,24 @@ $CC -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push -c "$DIR/uni
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_addmacro.o
 $CC -o "$DIR/add_macro_fail_tests" "$DIR/test_add_macro_fail.o" vector_addmacro.o
 rm -f "$DIR/test_add_macro_fail.o" vector_addmacro.o
+# build collect_include_dirs failure test
+$CC -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push \
+    -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/preproc_path.c -o preproc_path_collect_dest_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/include_path_cache.c -o include_path_cache_collect_dest_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/vector.c -o vector_collect_dest_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -DNO_VECTOR_FREE_STUB \
+    -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c src/util.c -o util_collect_dest_fail.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push \
+    -Dmalloc=test_malloc -Dcalloc=test_calloc -Drealloc=test_realloc -Dfree=test_free \
+    -c "$DIR/unit/test_collect_include_dest_fail.c" -o "$DIR/test_collect_include_dest_fail.o"
+$CC -o "$DIR/collect_include_dest_fail" preproc_path_collect_dest_fail.o include_path_cache_collect_dest_fail.o \
+    vector_collect_dest_fail.o util_collect_dest_fail.o "$DIR/test_collect_include_dest_fail.o"
+rm -f preproc_path_collect_dest_fail.o include_path_cache_collect_dest_fail.o vector_collect_dest_fail.o util_collect_dest_fail.o \
+      "$DIR/test_collect_include_dest_fail.o"
 # build variadic macro tests
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/preproc_expand.c -o preproc_expand.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/preproc_table.c -o preproc_table.o
@@ -609,6 +627,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/std_dirs_alloc_fail"
 "$DIR/preproc_alloc_tests"
 "$DIR/add_macro_fail_tests"
+"$DIR/collect_include_dest_fail"
 "$DIR/text_line_fail"
 "$DIR/variadic_macro_tests"
 "$DIR/macro_stringize_escape"

--- a/tests/unit/test_collect_include_dest_fail.c
+++ b/tests/unit/test_collect_include_dest_fail.c
@@ -1,0 +1,93 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include "preproc_path.h"
+#include "vector.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+extern int vector_push(vector_t *vec, const void *elem); /* real impl */
+static int fail_at = 0;
+static int call_count = 0;
+int test_vector_push(vector_t *vec, const void *elem)
+{
+    call_count++;
+    if (fail_at && call_count == fail_at)
+        return 0;
+    return vector_push(vec, elem);
+}
+
+extern void *malloc(size_t size); /* real malloc */
+extern void *calloc(size_t nmemb, size_t size); /* real calloc */
+extern void *realloc(void *ptr, size_t size); /* real realloc */
+extern void free(void *ptr); /* real free */
+static int allocs = 0;
+
+void *test_malloc(size_t size)
+{
+    void *p = malloc(size);
+    if (p)
+        allocs++;
+    return p;
+}
+
+void *test_calloc(size_t nmemb, size_t size)
+{
+    if (size && nmemb > SIZE_MAX / size)
+        return NULL;
+    void *p = calloc(nmemb, size);
+    if (p)
+        allocs++;
+    return p;
+}
+
+void *test_realloc(void *ptr, size_t size)
+{
+    if (!ptr)
+        return test_malloc(size);
+    void *p = realloc(ptr, size);
+    if (p && p != ptr) {
+        allocs++;
+        allocs--; /* previous ptr freed */
+    }
+    return p;
+}
+
+void test_free(void *ptr)
+{
+    if (ptr)
+        allocs--;
+    free(ptr);
+}
+
+int main(void)
+{
+    unsetenv("VCPATH");
+    unsetenv("VCINC");
+    unsetenv("CPATH");
+    unsetenv("C_INCLUDE_PATH");
+    unsetenv("VC_SYSINCLUDE");
+
+    vector_t empty; vector_init(&empty, sizeof(char *));
+    vector_t dirs;
+
+    fail_at = 1; call_count = 0;
+    ASSERT(!collect_include_dirs(&dirs, &empty, "/tmp/sysroot", NULL, false));
+    ASSERT(dirs.count == 0 && dirs.cap == 0);
+    ASSERT(allocs == 0);
+    vector_free(&dirs);
+    vector_free(&empty);
+    preproc_path_cleanup();
+
+    if (failures == 0)
+        printf("All collect_include_dest_fail tests passed\n");
+    else
+        printf("%d collect_include_dest_fail test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- ensure collect_include_dirs frees partially added paths when push fails
- test collect_include_dirs cleanly handles push failure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6878521b6c98832499511b114b7c7201