### PR TITLE
Add AST allocation failure test

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -87,6 +87,12 @@ $CC -Iinclude -Wall -Wextra -std=c99 -c src/error.c -o error_ircore.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_ir_core.c" -o "$DIR/test_ir_core.o"
 $CC -o "$DIR/ir_core_tests" ir_core_test.o util_ircore.o error_ircore.o label_ircore.o "$DIR/test_ir_core.o"
 rm -f ir_core_test.o util_ircore.o error_ircore.o label_ircore.o "$DIR/test_ir_core.o"
+# build AST allocation failure test
+$CC -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c src/ast_expr_literal.c -o ast_expr_literal_alloc.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c src/util.c -o util_ast_alloc.o
+$CC -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -c "$DIR/unit/test_ast_alloc_fail.c" -o "$DIR/test_ast_alloc_fail.o"
+$CC -o "$DIR/ast_alloc_fail" ast_expr_literal_alloc.o util_ast_alloc.o "$DIR/test_ast_alloc_fail.o"
+rm -f ast_expr_literal_alloc.o util_ast_alloc.o "$DIR/test_ast_alloc_fail.o"
 # build conditional expression regression test
 $CC -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/cond_expr_tests" "$DIR/unit/test_cond_expr.c" \
@@ -588,6 +594,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/cli_tests"
 "$DIR/parser_alloc_tests"
 "$DIR/ir_core_tests"
+"$DIR/ast_alloc_fail"
 "$DIR/opt_fold_tests"
 "$DIR/opt_unreachable_tests"
 "$DIR/opt_licm_tests"

--- a/tests/unit/test_ast_alloc_fail.c
+++ b/tests/unit/test_ast_alloc_fail.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "ast_expr.h"
+#include "ast_stmt.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+extern void *malloc(size_t size); /* real malloc */
+static int fail_malloc = 0;
+static int fail_after = 0;
+void *test_malloc(size_t size)
+{
+    if (fail_malloc) {
+        if (fail_after-- <= 0)
+            return NULL;
+    }
+    return malloc(size);
+}
+
+static void test_number_expr_alloc(void)
+{
+    fail_malloc = 1; fail_after = 0; /* fail in vc_strndup */
+    expr_t *e = ast_make_number("123", 1, 1);
+    ASSERT(e == NULL);
+    fail_malloc = 0;
+}
+
+static void test_new_expr_alloc(void)
+{
+    fail_malloc = 1; fail_after = 1; /* fail in new_expr after strip_suffix */
+    expr_t *e = ast_make_number("123", 1, 1);
+    ASSERT(e == NULL);
+    fail_malloc = 0;
+}
+
+int main(void)
+{
+    test_number_expr_alloc();
+    test_new_expr_alloc();
+    if (failures == 0)
+        printf("All ast_alloc_fail tests passed\n");
+    else
+        printf("%d ast_alloc_fail test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- add unit tests for AST allocation failures
- build and run new test in test harness

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687851f3608c83249244fecbcc9077c3