### PR TITLE
Use POSIX seq for long path test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1013,7 +1013,7 @@ rm -f "$prog" "$clamp" "$libvclib"
 
 # regression test for long command error message
 long_tmpdir=$(safe_mktemp -d)
-long_out="$long_tmpdir/$(printf 'a%.0s' {1..50})/$(printf 'b%.0s' {1..50})/$(printf 'c%.0s' {1..50})/$(printf 'd%.0s' {1..50})/$(printf 'e%.0s' {1..50})/out.o"
+long_out="$long_tmpdir/$(printf 'a%.0s' $(seq 1 50))/$(printf 'b%.0s' $(seq 1 50))/$(printf 'c%.0s' $(seq 1 50))/$(printf 'd%.0s' $(seq 1 50))/$(printf 'e%.0s' $(seq 1 50))/out.o"
 mkdir -p "$(dirname "$long_out")"
 err=$(safe_mktemp)
 set +e


### PR DESCRIPTION
## Summary
- generate long path segments using `seq` for POSIX compatibility

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687854a78d548324b84f105b1234c8e1