### PR TITLE
Fix optional args for safe_mktemp

### DIFF
--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -25,7 +25,7 @@ check_can_compile_32() {
 
 # Create a temporary file or directory safely
 safe_mktemp() {
-    tmp=$(mktemp "$@") || {
+    tmp=$(mktemp ${1:+"$@"}) || {
         echo "mktemp failed" >&2
         return 1
     }


### PR DESCRIPTION
## Summary
- improve `safe_mktemp` so `mktemp` is not called with empty args
- run shellcheck and unit tests

## Testing
- `shellcheck tests/helpers.sh tests/run_tests.sh tests/run.sh start.sh`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687854c57e888324a957c8e027e5e587