### PR TITLE
Limit b2 buffer scope

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -127,7 +127,6 @@ void emit_div(strbuf_t *sb, ir_instr_t *ins,
               asm_syntax_t syntax)
 {
     char b1[32];
-    char b2[32];
     const char *sfx = x64 ? "q" : "l";
     const char *ax = x86_fmt_reg(x64 ? "%rax" : "%eax", syntax);
     x86_emit_mov(sb, sfx,
@@ -138,6 +137,7 @@ void emit_div(strbuf_t *sb, ir_instr_t *ins,
                    x86_loc_str(b1, ra, ins->src2, x64, syntax));
     if (ra && ra->loc[ins->dest] >= 0 &&
         strcmp(regalloc_reg_name(ra->loc[ins->dest]), ax) != 0) {
+        char b2[32];
         x86_emit_mov(sb, sfx, ax,
                      x86_loc_str(b2, ra, ins->dest, x64, syntax),
                      syntax);
@@ -149,7 +149,6 @@ void emit_mod(strbuf_t *sb, ir_instr_t *ins,
               asm_syntax_t syntax)
 {
     char b1[32];
-    char b2[32];
     const char *sfx = x64 ? "q" : "l";
     const char *ax = x86_fmt_reg(x64 ? "%rax" : "%eax", syntax);
     x86_emit_mov(sb, sfx,
@@ -161,6 +160,7 @@ void emit_mod(strbuf_t *sb, ir_instr_t *ins,
     if (ra && ra->loc[ins->dest] >= 0 &&
         strcmp(regalloc_reg_name(ra->loc[ins->dest]),
                x64 ? "%rdx" : "%edx") != 0) {
+        char b2[32];
         x86_emit_mov(sb, sfx,
                      x86_fmt_reg(x64 ? "%rdx" : "%edx", syntax),
                      x86_loc_str(b2, ra, ins->dest, x64, syntax),

--- a/src/codegen_float.c
+++ b/src/codegen_float.c
@@ -46,7 +46,6 @@ void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
                       asm_syntax_t syntax)
 {
     char b1[32];
-    char b2[32];
     int r0 = regalloc_xmm_acquire();
     int r1 = regalloc_xmm_acquire();
     const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
@@ -57,24 +56,30 @@ void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
         strbuf_appendf(sb, "    movd %s, %s\n", reg1,
                        loc_str(b1, ra, ins->src2, x64, syntax));
         strbuf_appendf(sb, "    %s %s, %s\n", op, reg0, reg1);
-        if (ra && ra->loc[ins->dest] >= 0)
+        if (ra && ra->loc[ins->dest] >= 0) {
+            char b2[32];
             strbuf_appendf(sb, "    movd %s, %s\n",
                            loc_str(b2, ra, ins->dest, x64, syntax), reg0);
-        else
+        } else {
+            char b2[32];
             strbuf_appendf(sb, "    movss %s, %s\n",
                            loc_str(b2, ra, ins->dest, x64, syntax), reg0);
+        }
     } else {
         strbuf_appendf(sb, "    movd %s, %s\n",
                        loc_str(b1, ra, ins->src1, x64, syntax), reg0);
         strbuf_appendf(sb, "    movd %s, %s\n",
                        loc_str(b1, ra, ins->src2, x64, syntax), reg1);
         strbuf_appendf(sb, "    %s %s, %s\n", op, reg1, reg0);
-        if (ra && ra->loc[ins->dest] >= 0)
+        if (ra && ra->loc[ins->dest] >= 0) {
+            char b2[32];
             strbuf_appendf(sb, "    movd %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
-        else
+        } else {
+            char b2[32];
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
+        }
     }
     regalloc_xmm_release(r1);
     regalloc_xmm_release(r0);

--- a/src/codegen_store.c
+++ b/src/codegen_store.c
@@ -109,16 +109,18 @@ void emit_store_ptr(strbuf_t *sb, ir_instr_t *ins,
                     asm_syntax_t syntax)
 {
     char b1[32];
-    char b2[32];
     const char *sfx = x64 ? "q" : "l";
-    if (syntax == ASM_INTEL)
+    if (syntax == ASM_INTEL) {
+        char b2[32];
         strbuf_appendf(sb, "    mov%s [%s], %s\n", sfx,
                        loc_str(b2, ra, ins->src1, x64, syntax),
                        loc_str(b1, ra, ins->src2, x64, syntax));
-    else
+    } else {
+        char b2[32];
         strbuf_appendf(sb, "    mov%s %s, (%s)\n", sfx,
                        loc_str(b1, ra, ins->src2, x64, syntax),
                        loc_str(b2, ra, ins->src1, x64, syntax));
+    }
 }
 
 /*
@@ -133,18 +135,20 @@ void emit_store_idx(strbuf_t *sb, ir_instr_t *ins,
                     asm_syntax_t syntax)
 {
     char b1[32];
-    char b2[32];
     const char *sfx = x64 ? "q" : "l";
     char basebuf[32];
     const char *base = fmt_stack(basebuf, ins->name, x64, syntax);
-    if (syntax == ASM_INTEL)
+    if (syntax == ASM_INTEL) {
+        char b2[32];
         strbuf_appendf(sb, "    mov%s %s(,%s,4), %s\n", sfx, base,
                        loc_str(b2, ra, ins->src1, x64, syntax),
                        loc_str(b1, ra, ins->src2, x64, syntax));
-    else
+    } else {
+        char b2[32];
         strbuf_appendf(sb, "    mov%s %s, %s(,%s,4)\n", sfx,
                        loc_str(b1, ra, ins->src2, x64, syntax),
                        base,
                        loc_str(b2, ra, ins->src1, x64, syntax));
+    }
 }
 


### PR DESCRIPTION
## Summary
- limit the scope of temporary `b2` buffers to the conditional blocks that use them
- repeat for similar patterns in store and float helpers

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_687854e5f1848324bf30123ecfd78246