### PR TITLE
Fix missing vc_strdup checks

### DIFF
--- a/src/include_path_cache.c
+++ b/src/include_path_cache.c
@@ -73,6 +73,8 @@ static const char *get_multiarch_dir(void)
 #else
             multiarch_cached = vc_strdup(MULTIARCH_FALLBACK);
 #endif
+            if (!multiarch_cached)
+                return NULL;
         }
     }
     return multiarch_cached;
@@ -118,6 +120,8 @@ static const char *get_gcc_include_dir(void)
             snprintf(gcc_include_cached, len + 1, "/usr/lib/gcc/%s/include", multi);
 #else
             gcc_include_cached = vc_strdup("/usr/lib/gcc/include");
+            if (!gcc_include_cached)
+                return NULL;
 #endif
         }
         if (gcc_query_failed && !sys_header_warned) {

--- a/src/parser_expr_primary.c
+++ b/src/parser_expr_primary.c
@@ -131,8 +131,11 @@ static int parse_struct_union_tag(parser_t *p, type_kind_t *out_type,
     p->pos++;
     if (out_type)
         *out_type = t;
-    if (out_tag)
+    if (out_tag) {
         *out_tag = vc_strdup(id->lexeme);
+        if (!*out_tag)
+            return 0;
+    }
     return 1;
 }
 

--- a/src/semantic_inline.c
+++ b/src/semantic_inline.c
@@ -33,7 +33,10 @@ static int mark_inline_emitted(const char *name)
     if (!tmp)
         return 0;
     inline_emitted = tmp;
-    inline_emitted[inline_emitted_count++] = vc_strdup(name ? name : "");
+    inline_emitted[inline_emitted_count] = vc_strdup(name ? name : "");
+    if (!inline_emitted[inline_emitted_count])
+        return 0;
+    inline_emitted_count++;
     return 1;
 }
 

--- a/src/semantic_layout.c
+++ b/src/semantic_layout.c
@@ -133,6 +133,14 @@ int copy_union_metadata(symbol_t *sym, union_member_t *members,
     for (size_t i = 0; i < count; i++) {
         union_member_t *m = &members[i];
         sym->members[i].name = vc_strdup(m->name);
+        if (!sym->members[i].name) {
+            for (size_t j = 0; j < i; j++)
+                free(sym->members[j].name);
+            free(sym->members);
+            sym->members = NULL;
+            sym->member_count = 0;
+            return 0;
+        }
         sym->members[i].type = m->type;
         sym->members[i].elem_size = m->elem_size;
         sym->members[i].offset = m->offset;
@@ -157,6 +165,14 @@ int copy_struct_metadata(symbol_t *sym, struct_member_t *members,
     for (size_t i = 0; i < count; i++) {
         struct_member_t *m = &members[i];
         sym->struct_members[i].name = vc_strdup(m->name);
+        if (!sym->struct_members[i].name) {
+            for (size_t j = 0; j < i; j++)
+                free(sym->struct_members[j].name);
+            free(sym->struct_members);
+            sym->struct_members = NULL;
+            sym->struct_member_count = 0;
+            return 0;
+        }
         sym->struct_members[i].type = m->type;
         sym->struct_members[i].elem_size = m->elem_size;
         sym->struct_members[i].offset = m->offset;

--- a/src/symtable_struct.c
+++ b/src/symtable_struct.c
@@ -101,6 +101,15 @@ int symtable_add_union(symtable_t *table, const char *tag,
         }
         for (size_t i = 0; i < member_count; i++) {
             sym->members[i].name = vc_strdup(members[i].name);
+            if (!sym->members[i].name) {
+                for (size_t j = 0; j < i; j++)
+                    free(sym->members[j].name);
+                free(sym->members);
+                free(sym->name);
+                free(sym->ir_name);
+                free(sym);
+                return 0;
+            }
             sym->members[i].type = members[i].type;
             sym->members[i].elem_size = members[i].elem_size;
             sym->members[i].offset = members[i].offset;
@@ -148,6 +157,15 @@ int symtable_add_union_global(symtable_t *table, const char *tag,
         }
         for (size_t i = 0; i < member_count; i++) {
             sym->members[i].name = vc_strdup(members[i].name);
+            if (!sym->members[i].name) {
+                for (size_t j = 0; j < i; j++)
+                    free(sym->members[j].name);
+                free(sym->members);
+                free(sym->name);
+                free(sym->ir_name);
+                free(sym);
+                return 0;
+            }
             sym->members[i].type = members[i].type;
             sym->members[i].elem_size = members[i].elem_size;
             sym->members[i].offset = members[i].offset;
@@ -212,6 +230,15 @@ int symtable_add_struct(symtable_t *table, const char *tag,
         }
         for (size_t i = 0; i < member_count; i++) {
             sym->struct_members[i].name = vc_strdup(members[i].name);
+            if (!sym->struct_members[i].name) {
+                for (size_t j = 0; j < i; j++)
+                    free(sym->struct_members[j].name);
+                free(sym->struct_members);
+                free(sym->name);
+                free(sym->ir_name);
+                free(sym);
+                return 0;
+            }
             sym->struct_members[i].type = members[i].type;
             sym->struct_members[i].elem_size = members[i].elem_size;
             sym->struct_members[i].offset = members[i].offset;
@@ -268,6 +295,15 @@ int symtable_add_struct_global(symtable_t *table, const char *tag,
         }
         for (size_t i = 0; i < member_count; i++) {
             sym->struct_members[i].name = vc_strdup(members[i].name);
+            if (!sym->struct_members[i].name) {
+                for (size_t j = 0; j < i; j++)
+                    free(sym->struct_members[j].name);
+                free(sym->struct_members);
+                free(sym->name);
+                free(sym->ir_name);
+                free(sym);
+                return 0;
+            }
             sym->struct_members[i].type = members[i].type;
             sym->struct_members[i].elem_size = members[i].elem_size;
             sym->struct_members[i].offset = members[i].offset;


### PR DESCRIPTION
## Summary
- validate results from `vc_strdup` in several helpers
- propagate allocation failures instead of assuming success

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68785dc4feb88324be38b3a05f87f784