### PR TITLE
Handle vc_strndup allocation failure

### DIFF
--- a/src/include_path_cache.c
+++ b/src/include_path_cache.c
@@ -53,8 +53,17 @@ static const char *get_multiarch_dir(void)
                 size_t len = strlen(buf);
                 while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
                     buf[--len] = '\0';
-                if (len)
+                if (len) {
                     tmp = vc_strndup(buf, len);
+                    if (!tmp) {
+                        gcc_query_failed = 1;
+                        if (pclose(fp) == -1) {
+                            perror("pclose");
+                            gcc_query_failed = 1;
+                        }
+                        return NULL;
+                    }
+                }
             } else {
                 perror("fgets");
                 gcc_query_failed = 1;
@@ -98,8 +107,17 @@ static const char *get_gcc_include_dir(void)
                 size_t len = strlen(buf);
                 while (len && (buf[len-1] == '\n' || buf[len-1] == '\r'))
                     buf[--len] = '\0';
-                if (len)
+                if (len) {
                     gcc_include_cached = vc_strndup(buf, len);
+                    if (!gcc_include_cached) {
+                        gcc_query_failed = 1;
+                        if (pclose(fp) == -1) {
+                            perror("pclose");
+                            gcc_query_failed = 1;
+                        }
+                        return NULL;
+                    }
+                }
             } else {
                 perror("fgets");
                 gcc_query_failed = 1;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -528,6 +528,10 @@ $CC -Iinclude -Wall -Wextra -std=c99 -Dvc_alloc_or_exit=test_alloc_or_exit \
 $CC -o "$DIR/std_dirs_alloc_fail" include_path_cache_fail_impl.o util_std_dirs_fail.o \
     "$DIR/test_std_dirs_alloc_fail.o"
 rm -f include_path_cache_fail_impl.o util_std_dirs_fail.o "$DIR/test_std_dirs_alloc_fail.o"
+# build gcc include dir strndup failure test
+$CC -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/gcc_dir_strndup_fail" "$DIR/unit/test_gcc_dir_strndup_fail.c" \
+    src/util.c
 # build create_temp_file path length regression test
 $CC -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -ffunction-sections -fdata-sections -c src/compile.c -o compile_temp.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_temp_file.c" -o "$DIR/test_temp_file.o"
@@ -637,6 +641,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/compile_obj_fail"
 "$DIR/vc_names_tests"
 "$DIR/std_dirs_alloc_fail"
+"$DIR/gcc_dir_strndup_fail"
 "$DIR/preproc_alloc_tests"
 "$DIR/add_macro_fail_tests"
 "$DIR/collect_include_dest_fail"

--- a/tests/unit/test_gcc_dir_strndup_fail.c
+++ b/tests/unit/test_gcc_dir_strndup_fail.c
@@ -1,0 +1,31 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include "include_path_cache.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static char *test_vc_strndup(const char *s, size_t n) { (void)s; (void)n; return NULL; }
+#define vc_strndup test_vc_strndup
+#include "../../src/include_path_cache.c"
+
+int main(void)
+{
+    include_path_cache_init();
+    ASSERT(gcc_query_failed);
+    const char *dir = include_path_cache_gcc_dir();
+    ASSERT(dir != NULL);
+    include_path_cache_cleanup();
+    ASSERT(gcc_query_failed == 0);
+
+    if (failures == 0)
+        printf("All gcc_dir_strndup_fail tests passed\n");
+    else
+        printf("%d gcc_dir_strndup_fail test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- validate return value of `vc_strndup` when querying gcc
- set `gcc_query_failed` and clean up if allocation fails
- add unit test for `vc_strndup` failure

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68785dd854288324a12b7e066d321c1e