### PR TITLE
Deduplicate fmt_stack

### DIFF
--- a/include/codegen_mem.h
+++ b/include/codegen_mem.h
@@ -40,4 +40,7 @@ void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
 extern size_t arg_stack_bytes;
 extern int arg_reg_idx;
 
+const char *fmt_stack(char buf[32], const char *name, int x64,
+                      asm_syntax_t syntax);
+
 #endif /* VC_CODEGEN_MEM_H */

--- a/src/codegen_load.c
+++ b/src/codegen_load.c
@@ -12,33 +12,9 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#include "codegen_mem.h"
 #include "codegen_loadstore.h"
 #include "regalloc_x86.h"
-
-/* Convert "stack:offset" names to frame-pointer relative operands */
-static const char *fmt_stack(char buf[32], const char *name, int x64,
-                             asm_syntax_t syntax)
-{
-    if (strncmp(name, "stack:", 6) != 0)
-        return name;
-    char *end;
-    errno = 0;
-    long off = strtol(name + 6, &end, 10);
-    if (errno || *end != '\0')
-        off = 0;
-    if (x64) {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[rbp-%d]", (int)off);
-        else
-            snprintf(buf, 32, "-%d(%%rbp)", (int)off);
-    } else {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[ebp-%d]", (int)off);
-        else
-            snprintf(buf, 32, "-%d(%%ebp)", (int)off);
-    }
-    return buf;
-}
 
 #define SCRATCH_REG 0
 

--- a/src/codegen_mem_common.c
+++ b/src/codegen_mem_common.c
@@ -1,4 +1,8 @@
 #include "codegen_mem.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
 
 /* Current argument stack size for the active call. */
 size_t arg_stack_bytes = 0;
@@ -23,4 +27,29 @@ void emit_memory_instr(strbuf_t *sb, ir_instr_t *ins,
     mem_emit_fn fn = mem_emitters[ins->op];
     if (fn)
         fn(sb, ins, ra, x64, syntax);
+}
+
+/* Convert "stack:offset" names to frame-pointer relative operands. */
+const char *fmt_stack(char buf[32], const char *name, int x64,
+                      asm_syntax_t syntax)
+{
+    if (strncmp(name, "stack:", 6) != 0)
+        return name;
+    char *end;
+    errno = 0;
+    long off = strtol(name + 6, &end, 10);
+    if (errno || *end != '\0')
+        off = 0;
+    if (x64) {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[rbp-%d]", (int)off);
+        else
+            snprintf(buf, 32, "-%d(%%rbp)", (int)off);
+    } else {
+        if (syntax == ASM_INTEL)
+            snprintf(buf, 32, "[ebp-%d]", (int)off);
+        else
+            snprintf(buf, 32, "-%d(%%ebp)", (int)off);
+    }
+    return buf;
 }

--- a/src/codegen_mem_x86.c
+++ b/src/codegen_mem_x86.c
@@ -20,30 +20,6 @@
 #include "regalloc_x86.h"
 #include "ast.h"
 
-static const char *fmt_stack(char buf[32], const char *name, int x64,
-                             asm_syntax_t syntax)
-{
-    if (strncmp(name, "stack:", 6) != 0)
-        return name;
-    char *end;
-    errno = 0;
-    long off = strtol(name + 6, &end, 10);
-    if (errno || *end != '\0')
-        off = 0;
-    if (x64) {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[rbp-%d]", (int)off);
-        else
-            snprintf(buf, 32, "-%d(%%rbp)", (int)off);
-    } else {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[ebp-%d]", (int)off);
-        else
-            snprintf(buf, 32, "-%d(%%ebp)", (int)off);
-    }
-    return buf;
-}
-
 #define SCRATCH_REG 0
 
 /* The table `mem_emitters` maps IR opcodes to the helpers below. */

--- a/src/codegen_store.c
+++ b/src/codegen_store.c
@@ -12,32 +12,10 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#include "codegen_mem.h"
 #include "codegen_loadstore.h"
 #include "regalloc_x86.h"
 
-static const char *fmt_stack(char buf[32], const char *name, int x64,
-                             asm_syntax_t syntax)
-{
-    if (strncmp(name, "stack:", 6) != 0)
-        return name;
-    char *end;
-    errno = 0;
-    long off = strtol(name + 6, &end, 10);
-    if (errno || *end != '\0')
-        off = 0;
-    if (x64) {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[rbp-%d]", (int)off);
-        else
-            snprintf(buf, 32, "-%d(%%rbp)", (int)off);
-    } else {
-        if (syntax == ASM_INTEL)
-            snprintf(buf, 32, "[ebp-%d]", (int)off);
-        else
-            snprintf(buf, 32, "-%d(%%ebp)", (int)off);
-    }
-    return buf;
-}
 
 #define SCRATCH_REG 0
 


### PR DESCRIPTION
## Summary
- centralize `fmt_stack` in codegen_mem_common.c
- expose `fmt_stack` via codegen_mem.h
- include the header and drop local copies in load/store and mem_x86

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68786960f1548324980cbf218cc11f3d