### PR TITLE
Add errno support to internal libc

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -9,9 +9,9 @@ CAN_COMPILE_32 := $(shell $(CC) -m32 -xc /dev/null -o /dev/null \
     >/dev/null 2>&1 && echo yes || echo no)
 
 SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c src/file.c \
-       src/pthread.c src/_exit.c
+       src/pthread.c src/_exit.c src/errno.c
 HDR := include/stdarg.h include/stddef.h include/stdio.h \
-       include/stdlib.h include/string.h include/pthread.h
+       include/stdlib.h include/string.h include/pthread.h include/errno.h
 OBJ32 := $(SRC:src/%.c=src/%.32.o)
 OBJ64 := $(SRC:src/%.c=src/%.64.o)
 

--- a/libc/include/errno.h
+++ b/libc/include/errno.h
@@ -1,0 +1,30 @@
+/*
+ * Minimal errno declarations for vc's internal libc.
+ *
+ * Part of vc under the BSD 2-Clause license.
+ * See LICENSE for details.
+ */
+
+#ifndef VC_ERRNO_H
+#define VC_ERRNO_H
+
+/* Global errno variable accessible through _errno_location(). */
+extern int errno;
+
+/* Return address of thread-local errno. In this libc it is a single
+ * static variable, so the function simply returns its address.
+ */
+int *_errno_location(void);
+
+/* Map errno to the function above. */
+#define errno (*_errno_location())
+
+/* Minimal set of error codes used by the library and tests. */
+#define ENOENT        2
+#define EINTR         4
+#define ENOMEM       12
+#define ENAMETOOLONG 36
+#define ENOSYS       38
+#define ENOSPC       28
+
+#endif /* VC_ERRNO_H */

--- a/libc/src/errno.c
+++ b/libc/src/errno.c
@@ -1,0 +1,12 @@
+#include "errno.h"
+
+/*
+ * Provide storage for errno and a helper returning its address.
+ * In this simple libc there is only one global instance.
+ */
+static int errno_value;
+
+int *_errno_location(void)
+{
+    return &errno_value;
+}

--- a/libc/src/file.c
+++ b/libc/src/file.c
@@ -2,7 +2,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <fcntl.h>
-#include <errno.h>
+#include "errno.h"
 #include "stdio.h"
 #include <limits.h>
 #include "stdlib.h"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -932,7 +932,7 @@ libvclib="$DIR/libvclib.so"
 cc -shared -fPIC -I "$DIR/../libc/include" \
     "$DIR/../libc/src/stdio.c" "$DIR/../libc/src/stdlib.c" \
     "$DIR/../libc/src/string.c" "$DIR/../libc/src/syscalls.c" \
-    "$DIR/../libc/src/file.c" -o "$libvclib"
+    "$DIR/../libc/src/file.c" "$DIR/../libc/src/errno.c" -o "$libvclib"
 prog=$(safe_mktemp)
 cc -I "$DIR/../libc/include" "$DIR/fixtures/libc_short_write.c" \
     -L"$DIR" -Wl,-rpath="$DIR" -lvclib -o "$prog"
@@ -953,7 +953,7 @@ libvclib="$DIR/libvclib.so"
 cc -shared -fPIC -I "$DIR/../libc/include" \
     "$DIR/../libc/src/stdio.c" "$DIR/../libc/src/stdlib.c" \
     "$DIR/../libc/src/string.c" "$DIR/../libc/src/syscalls.c" \
-    "$DIR/../libc/src/file.c" -o "$libvclib"
+    "$DIR/../libc/src/file.c" "$DIR/../libc/src/errno.c" -o "$libvclib"
 prog=$(safe_mktemp)
 cc -I "$DIR/../libc/include" "$DIR/fixtures/libc_write_fail.c" \
     -L"$DIR" -Wl,-rpath="$DIR" -lvclib -o "$prog"
@@ -974,7 +974,7 @@ libvclib="$DIR/libvclib.so"
 cc -shared -fPIC -I "$DIR/../libc/include" \
     "$DIR/../libc/src/stdio.c" "$DIR/../libc/src/stdlib.c" \
     "$DIR/../libc/src/string.c" "$DIR/../libc/src/syscalls.c" \
-    "$DIR/../libc/src/file.c" -o "$libvclib"
+    "$DIR/../libc/src/file.c" "$DIR/../libc/src/errno.c" -o "$libvclib"
 prog=$(safe_mktemp)
 cc -I "$DIR/../libc/include" "$DIR/fixtures/libc_exit_fail.c" \
     -L"$DIR" -Wl,-rpath="$DIR" -lvclib -o "$prog"
@@ -995,7 +995,7 @@ libvclib="$DIR/libvclib.so"
 cc -shared -fPIC -I "$DIR/../libc/include" \
     "$DIR/../libc/src/stdio.c" "$DIR/../libc/src/stdlib.c" \
     "$DIR/../libc/src/string.c" "$DIR/../libc/src/syscalls.c" \
-    "$DIR/../libc/src/file.c" -o "$libvclib"
+    "$DIR/../libc/src/file.c" "$DIR/../libc/src/errno.c" -o "$libvclib"
 prog=$(safe_mktemp)
 cc -I "$DIR/../libc/include" "$DIR/fixtures/libc_puts_large.c" \
     -L"$DIR" -Wl,-rpath="$DIR" -lvclib -o "$prog"


### PR DESCRIPTION
## Summary
- provide minimal errno.h header and errno storage
- build errno.c in libc archive
- switch file.c to use the new header
- adjust tests to link errno.c when building the helper libc

## Testing
- `make -C libc`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687874f8c68c8324a00847abe47ed149