### PR TITLE
Add GNU-stack note to startup stub

### DIFF
--- a/src/startup.c
+++ b/src/startup.c
@@ -111,6 +111,8 @@ int write_startup_asm(int use_x86_64, asm_syntax_t syntax,
                 stub);
         }
     }
+    if (rc != EOF)
+        rc = fputs(".section .note.GNU-stack,\"\",@progbits\n", stub);
     if (rc == EOF) {
         perror("fputs");
         fclose(stub);


### PR DESCRIPTION
## Summary
- append `.section .note.GNU-stack,"",@progbits` when generating the
  startup assembly so the object is marked as not requiring an executable
  stack

## Testing
- `make -j$(nproc)`
- `./examples/build_examples.sh` *(fails: missing __errno_location)*

------
https://chatgpt.com/codex/tasks/task_e_6878757204fc8324b62a765efa70ddc4