### PR TITLE
Add float token type and parsing support

### DIFF
--- a/include/token.h
+++ b/include/token.h
@@ -15,6 +15,7 @@ typedef enum {
     TOK_EOF = 0,
     TOK_IDENT,
     TOK_NUMBER,
+    TOK_FLOAT,
     TOK_IMAG_NUMBER,
     TOK_STRING,
     TOK_CHAR,

--- a/src/compile_tokenize.c
+++ b/src/compile_tokenize.c
@@ -29,6 +29,7 @@ static const char *tok_names[] = {
     [TOK_EOF] = "end of file",
     [TOK_IDENT] = "identifier",
     [TOK_NUMBER] = "number",
+    [TOK_FLOAT] = "float number",
     [TOK_STRING] = "string",
     [TOK_CHAR] = "character",
     [TOK_WIDE_STRING] = "L\"string\"",

--- a/src/lexer_scan_numeric.c
+++ b/src/lexer_scan_numeric.c
@@ -48,14 +48,13 @@ static int read_number(const char *src, size_t *i, size_t *col,
            src[*i] == 'l' || src[*i] == 'L')
         (*i)++;
 
-    token_type_t type = TOK_NUMBER;
+    token_type_t type = is_float ? TOK_FLOAT : TOK_NUMBER;
     if (src[*i] == 'i' || src[*i] == 'I') {
         (*i)++;
         type = TOK_IMAG_NUMBER;
     }
 
     size_t len = *i - start;
-    (void)is_float;
     if (!append_token(tokens, type, src + start, len, line, *col))
         return 0;
     *col += len;

--- a/src/parser_expr_literal.c
+++ b/src/parser_expr_literal.c
@@ -46,7 +46,7 @@ expr_t *parse_literal(parser_t *p)
     token_t *tok = peek(p);
     if (!tok)
         return NULL;
-    if (tok->type == TOK_NUMBER) {
+    if (tok->type == TOK_NUMBER || tok->type == TOK_FLOAT) {
         size_t save = p->pos;
         token_t *num_tok = tok;
         p->pos++; /* consume number */
@@ -70,6 +70,8 @@ expr_t *parse_literal(parser_t *p)
         double imag = strtod(tok->lexeme, NULL);
         return ast_make_complex_literal(0.0, imag, tok->line, tok->column);
     }
+    if (match(p, TOK_FLOAT))
+        return ast_make_number(tok->lexeme, tok->line, tok->column);
     if (match(p, TOK_NUMBER))
         return ast_make_number(tok->lexeme, tok->line, tok->column);
     expr_t *s = parse_string_literal(p);

--- a/src/token_names.c
+++ b/src/token_names.c
@@ -15,6 +15,7 @@ static const char *token_names[] = {
     [TOK_EOF] = "end of file",
     [TOK_IDENT] = "identifier",
     [TOK_NUMBER] = "number",
+    [TOK_FLOAT] = "float number",
     [TOK_IMAG_NUMBER] = "imaginary number",
     [TOK_STRING] = "string",
     [TOK_CHAR] = "character",

--- a/tests/unit/test_lexer_parser.c
+++ b/tests/unit/test_lexer_parser.c
@@ -124,6 +124,17 @@ static void test_lexer_imag_number(void)
     lexer_free_tokens(toks, count);
 }
 
+/* Lexing of a floating point constant. */
+static void test_lexer_float_number(void)
+{
+    const char *src = "1.0";
+    size_t count = 0;
+    token_t *toks = lexer_tokenize(src, &count);
+    ASSERT(toks[0].type == TOK_FLOAT);
+    ASSERT(strcmp(toks[0].lexeme, "1.0") == 0);
+    lexer_free_tokens(toks, count);
+}
+
 /* Parsing of an imaginary constant as a complex literal. */
 static void test_parser_imag_literal(void)
 {
@@ -511,8 +522,7 @@ static void test_parser_sizeof(void)
 /* Parse a simple variadic call expression. */
 static void test_parser_variadic_call(void)
 {
-    /* floating point literals are not yet recognized, so use integers */
-    const char *src = "foo(1, 2)";
+    const char *src = "foo(1.0, 2.0)";
     size_t count = 0;
     token_t *toks = lexer_tokenize(src, &count);
     ASSERT(count >= 6);
@@ -777,6 +787,7 @@ int main(void)
     test_lexer_new_types();
     test_lexer_complex_kw();
     test_lexer_imag_number();
+    test_lexer_float_number();
     test_parser_imag_literal();
     test_parser_complex_literal();
     test_parser_expr();


### PR DESCRIPTION
## Summary
- recognize floating point literals with new `TOK_FLOAT` token
- handle `TOK_FLOAT` in literal parsing and name tables
- add tests for float lexing and update variadic call to use floats

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689622f1e9c483248b39299d62b561f2