### PR TITLE
Handle EOF separately in vc_read_file

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -144,8 +144,12 @@ char *vc_read_file(const char *path)
     }
     size_t len = (size_t)len_off;
     char *buf = vc_alloc_or_exit(len + 1);
+    errno = 0;
     if (fread(buf, 1, len, f) != len) {
-        perror("fread");
+        if (errno != 0 || ferror(f))
+            perror("fread");
+        else
+            fprintf(stderr, "%s: unexpected EOF\n", path);
         fclose(f);
         free(buf);
         return NULL;


### PR DESCRIPTION
## Summary
- reset `errno` before `fread` in `vc_read_file`
- distinguish I/O errors from unexpected EOF and report accordingly

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689628ebb89883248fac43ab301da971