### PR TITLE
Remove redundant null check in strbuf_append

### DIFF
--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -74,8 +74,6 @@ int strbuf_append(strbuf_t *sb, const char *text)
     size_t l = strlen(text);
     if (sb_ensure(sb, l + 1) < 0)
         return -1;
-    if (!sb->data)
-        return -1;
     memcpy(sb->data + sb->len, text, l + 1);
     sb->len += l;
     return 0;


### PR DESCRIPTION
## Summary
- remove obsolete NULL check in strbuf_append after ensuring buffer allocation

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689628f724208324bf983286a3930e3f