### PR TITLE
Handle snprintf errors when defining __BASE_FILE__

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -319,7 +319,18 @@ static int define_default_macros(vector_t *macros, const char *base_file,
             return 0;
         }
         char quoted[PATH_MAX + 2];
-        snprintf(quoted, sizeof(quoted), "\"%s\"", canon);
+        int n = snprintf(quoted, sizeof(quoted), "\"%s\"", canon);
+        if (n < 0) {
+            int err = errno;
+            free(canon);
+            errno = err;
+            return 0;
+        }
+        if ((size_t)n >= sizeof(quoted)) {
+            free(canon);
+            errno = ENAMETOOLONG;
+            return 0;
+        }
         define_simple_macro(macros, "__BASE_FILE__", quoted);
         free(canon);
     } else {


### PR DESCRIPTION
## Summary
- validate snprintf when populating __BASE_FILE__ macro
- return error on truncation or formatting issues to prevent ENAMETOOLONG

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68962a525c2c8324b02d05bbf8f70dee