### PR TITLE
Fix strbuf capacity check

### DIFF
--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -72,7 +72,7 @@ int strbuf_append(strbuf_t *sb, const char *text)
     if (!sb || !text)
         return -1;
     size_t l = strlen(text);
-    if (sb_ensure(sb, l + 1) < 0)
+    if (sb_ensure(sb, l) < 0)
         return -1;
     memcpy(sb->data + sb->len, text, l + 1);
     sb->len += l;


### PR DESCRIPTION
## Summary
- ensure `strbuf_append` requests exactly the required capacity

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68962a24ba6c8324830751dbeb28c667