### PR TITLE
Handle missing GCC include directory

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -263,6 +263,11 @@ int collect_include_dirs(vector_t *search_dirs,
 {
     include_path_cache_init();
     const char *gcc_dir = include_path_cache_gcc_dir();
+    if (!gcc_dir) {
+        fprintf(stderr,
+                "vc: system headers could not be located. Use --vc-sysinclude=<dir> or VC_SYSINCLUDE\n");
+        return 0;
+    }
     const char * const *std_include_dirs = include_path_cache_std_dirs();
     assert(strcspn(gcc_dir, " \t\n") == strlen(gcc_dir));
     vector_init(search_dirs, sizeof(char *));


### PR DESCRIPTION
## Summary
- check for a NULL result from `include_path_cache_gcc_dir`
- emit an error and abort include path collection if system headers can't be located

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68963df706f4832492beec3b17c9a752