### PR TITLE
Check include path snprintf truncation

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -121,7 +121,12 @@ char *find_include_path(const char *fname, char endc, const char *dir,
     max_len += 1;
     char *out_path = vc_alloc_or_exit(max_len);
     if (endc == '"' && dir && start == 0) {
-        snprintf(out_path, max_len, "%s%s", dir, fname);
+        int n = snprintf(out_path, max_len, "%s%s", dir, fname);
+        if (n < 0 || (size_t)n >= max_len) {
+            fprintf(stderr, "vc: include path too long\n");
+            free(out_path);
+            return NULL;
+        }
         if (verbose_includes)
             fprintf(stderr, "checking %s%s\n", dir, fname);
         if (access(out_path, R_OK) == 0) {
@@ -134,7 +139,12 @@ char *find_include_path(const char *fname, char endc, const char *dir,
     }
     for (size_t i = start; i < incdirs->count; i++) {
         const char *base = ((const char **)incdirs->data)[i];
-        snprintf(out_path, max_len, "%s/%s", base, fname);
+        int n = snprintf(out_path, max_len, "%s/%s", base, fname);
+        if (n < 0 || (size_t)n >= max_len) {
+            fprintf(stderr, "vc: include path too long\n");
+            free(out_path);
+            return NULL;
+        }
         if (verbose_includes)
             fprintf(stderr, "checking %s/%s\n", base, fname);
         if (access(out_path, R_OK) == 0) {
@@ -151,7 +161,12 @@ char *find_include_path(const char *fname, char endc, const char *dir,
     if (endc == '<') {
         for (size_t i = builtin_start; i < extra_sys_dirs.count; i++) {
             const char *base = ((const char **)extra_sys_dirs.data)[i];
-            snprintf(out_path, max_len, "%s/%s", base, fname);
+            int n = snprintf(out_path, max_len, "%s/%s", base, fname);
+            if (n < 0 || (size_t)n >= max_len) {
+                fprintf(stderr, "vc: include path too long\n");
+                free(out_path);
+                return NULL;
+            }
             if (verbose_includes)
                 fprintf(stderr, "checking %s/%s\n", base, fname);
             if (access(out_path, R_OK) == 0) {
@@ -165,7 +180,12 @@ char *find_include_path(const char *fname, char endc, const char *dir,
         size_t off = builtin_start > extra_sys_dirs.count ?
                       builtin_start - extra_sys_dirs.count : 0;
         for (size_t i = off; std_include_dirs[i]; i++) {
-            snprintf(out_path, max_len, "%s/%s", std_include_dirs[i], fname);
+            int n = snprintf(out_path, max_len, "%s/%s", std_include_dirs[i], fname);
+            if (n < 0 || (size_t)n >= max_len) {
+                fprintf(stderr, "vc: include path too long\n");
+                free(out_path);
+                return NULL;
+            }
             if (verbose_includes)
                 fprintf(stderr, "checking %s/%s\n", std_include_dirs[i], fname);
             if (access(out_path, R_OK) == 0) {
@@ -179,7 +199,12 @@ char *find_include_path(const char *fname, char endc, const char *dir,
         free(out_path);
         return NULL;
     }
-    snprintf(out_path, max_len, "%s", fname);
+    int n = snprintf(out_path, max_len, "%s", fname);
+    if (n < 0 || (size_t)n >= max_len) {
+        fprintf(stderr, "vc: include path too long\n");
+        free(out_path);
+        return NULL;
+    }
     if (verbose_includes)
         fprintf(stderr, "checking %s\n", out_path);
     if (access(out_path, R_OK) == 0) {
@@ -191,7 +216,12 @@ char *find_include_path(const char *fname, char endc, const char *dir,
     }
     for (size_t i = builtin_start; i < extra_sys_dirs.count; i++) {
         const char *base = ((const char **)extra_sys_dirs.data)[i];
-        snprintf(out_path, max_len, "%s/%s", base, fname);
+        int n = snprintf(out_path, max_len, "%s/%s", base, fname);
+        if (n < 0 || (size_t)n >= max_len) {
+            fprintf(stderr, "vc: include path too long\n");
+            free(out_path);
+            return NULL;
+        }
         if (verbose_includes)
             fprintf(stderr, "checking %s/%s\n", base, fname);
         if (access(out_path, R_OK) == 0) {
@@ -205,7 +235,12 @@ char *find_include_path(const char *fname, char endc, const char *dir,
     size_t off = builtin_start > extra_sys_dirs.count ?
                   builtin_start - extra_sys_dirs.count : 0;
     for (size_t i = off; std_include_dirs[i]; i++) {
-        snprintf(out_path, max_len, "%s/%s", std_include_dirs[i], fname);
+        int n = snprintf(out_path, max_len, "%s/%s", std_include_dirs[i], fname);
+        if (n < 0 || (size_t)n >= max_len) {
+            fprintf(stderr, "vc: include path too long\n");
+            free(out_path);
+            return NULL;
+        }
         if (verbose_includes)
             fprintf(stderr, "checking %s/%s\n", std_include_dirs[i], fname);
         if (access(out_path, R_OK) == 0) {


### PR DESCRIPTION
## Summary
- validate `snprintf` return values when constructing include paths
- abort with diagnostic if any path would be truncated

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68963e63afa483249b76bc9ea7e00ee6