### PR TITLE
Handle long base file paths in __BASE_FILE__

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -320,13 +320,7 @@ static int define_default_macros(vector_t *macros, const char *base_file,
         }
         char quoted[PATH_MAX + 2];
         int n = snprintf(quoted, sizeof(quoted), "\"%s\"", canon);
-        if (n < 0) {
-            int err = errno;
-            free(canon);
-            errno = err;
-            return 0;
-        }
-        if ((size_t)n >= sizeof(quoted)) {
+        if (n < 0 || (size_t)n >= sizeof(quoted)) {
             free(canon);
             errno = ENAMETOOLONG;
             return 0;


### PR DESCRIPTION
## Summary
- detect snprintf truncation when quoting canonical base file path
- abort __BASE_FILE__ macro definition with ENAMETOOLONG on error

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6896429a12908324bcad130bbedad624