### PR TITLE
Check readlink length in fd_realpath

### DIFF
--- a/src/preproc_include.c
+++ b/src/preproc_include.c
@@ -74,6 +74,10 @@ static char *fd_realpath(int fd, const char *fallback)
     snprintf(proc, sizeof(proc), "/proc/self/fd/%d", fd);
     ssize_t len = readlink(proc, path, sizeof(path) - 1);
     if (len >= 0) {
+        if (len == (ssize_t)sizeof(path) - 1) {
+            errno = ENAMETOOLONG;
+            return NULL;
+        }
         path[len] = '\0';
         char *canon = realpath(path, NULL);
         if (!canon)


### PR DESCRIPTION
## Summary
- guard against truncated symlink targets in `fd_realpath` by failing when `readlink` fills the buffer

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689643c6389883249c43bc816be27fb5