### PR TITLE
Fix indexed load scaling for non-4-byte elements

### DIFF
--- a/src/codegen_load.c
+++ b/src/codegen_load.c
@@ -68,6 +68,32 @@ static const char *loc_str(char buf[32], regalloc_t *ra, int id, int x64,
     return buf;
 }
 
+/* Determine the element size for indexed loads. */
+static int load_scale(const ir_instr_t *ins, int x64)
+{
+    if (ins->imm)
+        return (int)ins->imm;
+    switch (ins->type) {
+    case TYPE_CHAR: case TYPE_UCHAR: case TYPE_BOOL:
+        return 1;
+    case TYPE_SHORT: case TYPE_USHORT:
+        return 2;
+    case TYPE_DOUBLE: case TYPE_LLONG: case TYPE_ULLONG:
+    case TYPE_FLOAT_COMPLEX:
+        return 8;
+    case TYPE_LDOUBLE:
+        return 10;
+    case TYPE_DOUBLE_COMPLEX:
+        return 16;
+    case TYPE_LDOUBLE_COMPLEX:
+        return 20;
+    case TYPE_PTR:
+        return x64 ? 8 : 4;
+    default:
+        return 4;
+    }
+}
+
 /*
  * Load a value from memory into the destination location (IR_LOAD).
  *
@@ -145,8 +171,9 @@ void emit_load_idx(strbuf_t *sb, ir_instr_t *ins,
     char srcbuf[64];
     char basebuf[32];
     const char *base = fmt_stack(basebuf, ins->name, x64, syntax);
-    snprintf(srcbuf, sizeof(srcbuf), "%s(,%s,4)",
-             base, loc_str(b1, ra, ins->src1, x64, syntax));
+    int scale = load_scale(ins, x64);
+    snprintf(srcbuf, sizeof(srcbuf), "%s(,%s,%d)",
+             base, loc_str(b1, ra, ins->src1, x64, syntax), scale);
     emit_move_with_spill(sb, sfx, srcbuf, dest, slot, spill, syntax);
 }
 

--- a/src/semantic_mem.c
+++ b/src/semantic_mem.c
@@ -105,6 +105,8 @@ type_kind_t check_index_expr(expr_t *expr, symtable_t *vars,
             *out = sym->is_volatile
                      ? ir_build_load_idx_vol(ir, sym->ir_name, idx_val, sym->type)
                      : ir_build_load_idx(ir, sym->ir_name, idx_val, sym->type);
+            if (ir && ir->tail && ir->tail->op == IR_LOAD_IDX)
+                ir->tail->imm = sym->elem_size ? (int)sym->elem_size : 4;
         }
     }
     return TYPE_INT;

--- a/tests/fixtures/array_index_scale.c
+++ b/tests/fixtures/array_index_scale.c
@@ -1,0 +1,10 @@
+unsigned char ca[4];
+double da[4];
+
+int get_uc(int i) {
+    return ca[i];
+}
+
+double get_d(int i) {
+    return da[i];
+}

--- a/tests/fixtures/array_index_scale.s
+++ b/tests/fixtures/array_index_scale.s
@@ -1,0 +1,32 @@
+.data
+ca:
+    .long 0
+    .long 0
+    .long 0
+    .long 0
+da:
+    .long 0
+    .long 0
+    .long 0
+    .long 0
+.text
+get_uc:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %eax
+    movl ca(,%eax,1), %ebx
+    movl %ebx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret
+get_d:
+    pushl %ebp
+    movl %esp, %ebp
+    movl 8(%ebp), %ebx
+    movl da(,%ebx,8), %eax
+    movl %eax, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret


### PR DESCRIPTION
## Summary
- derive indexed load address scaling from element size or operand type
- propagate element size info when building IR for array indexing
- add regression test for byte and double array indexing

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68964591a1188324b73bbf581bd90667