### PR TITLE
Handle spilled pointer operands

### DIFF
--- a/src/codegen_load.c
+++ b/src/codegen_load.c
@@ -113,14 +113,19 @@ void emit_load_ptr(strbuf_t *sb, ir_instr_t *ins,
     const char *dest = spill ? reg_str(SCRATCH_REG, syntax)
                              : loc_str(destb, ra, ins->dest, x64, syntax);
     const char *slot = loc_str(mem, ra, ins->dest, x64, syntax);
+    const char *addr = loc_str(b1, ra, ins->src1, x64, syntax);
     char srcbuf[32];
-    if (syntax == ASM_INTEL)
-        snprintf(srcbuf, sizeof(srcbuf), "[%s]",
-                 loc_str(b1, ra, ins->src1, x64, syntax));
-    else
-        snprintf(srcbuf, sizeof(srcbuf), "(%s)",
-                 loc_str(b1, ra, ins->src1, x64, syntax));
-    emit_move_with_spill(sb, sfx, srcbuf, dest, slot, spill, syntax);
+    const char *src;
+    if (ra && ins->src1 > 0 && ra->loc[ins->src1] >= 0) {
+        if (syntax == ASM_INTEL)
+            snprintf(srcbuf, sizeof(srcbuf), "[%s]", addr);
+        else
+            snprintf(srcbuf, sizeof(srcbuf), "(%s)", addr);
+        src = srcbuf;
+    } else {
+        src = addr;
+    }
+    emit_move_with_spill(sb, sfx, src, dest, slot, spill, syntax);
 }
 
 /*

--- a/src/codegen_store.c
+++ b/src/codegen_store.c
@@ -90,14 +90,26 @@ void emit_store_ptr(strbuf_t *sb, ir_instr_t *ins,
     const char *sfx = (x64 && ins->type != TYPE_INT) ? "q" : "l";
     if (syntax == ASM_INTEL) {
         char b2[32];
-        strbuf_appendf(sb, "    mov%s [%s], %s\n", sfx,
-                       loc_str(b2, ra, ins->src1, x64, syntax),
+        const char *addr = loc_str(b2, ra, ins->src1, x64, syntax);
+        char buf[32];
+        const char *dst = addr;
+        if (ra && ins->src1 > 0 && ra->loc[ins->src1] >= 0) {
+            snprintf(buf, sizeof(buf), "[%s]", addr);
+            dst = buf;
+        }
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dst,
                        loc_str(b1, ra, ins->src2, x64, syntax));
     } else {
         char b2[32];
-        strbuf_appendf(sb, "    mov%s %s, (%s)\n", sfx,
-                       loc_str(b1, ra, ins->src2, x64, syntax),
-                       loc_str(b2, ra, ins->src1, x64, syntax));
+        const char *addr = loc_str(b2, ra, ins->src1, x64, syntax);
+        char buf[32];
+        const char *dst = addr;
+        if (ra && ins->src1 > 0 && ra->loc[ins->src1] >= 0) {
+            snprintf(buf, sizeof(buf), "(%s)", addr);
+            dst = buf;
+        }
+        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
+                       loc_str(b1, ra, ins->src2, x64, syntax), dst);
     }
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -203,6 +203,17 @@ if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
 fi
 rm -f "${out}" "${err}"
 
+# verify pointer loads/stores from spilled addresses
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_load_store_spill.c" \
+    "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/load_store_spill"
+if ! "$DIR/load_store_spill" >/dev/null; then
+    echo "Test load_store_spill failed"
+    fail=1
+fi
+rm -f "$DIR/load_store_spill"
+
 # negative test for failing static assertion
 err=$(safe_mktemp)
 out=$(safe_mktemp)

--- a/tests/unit/test_load_store_spill.c
+++ b/tests/unit/test_load_store_spill.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "codegen_loadstore.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Provide minimal stubs to satisfy linker requirements. */
+const char *fmt_stack(char buf[32], const char *name, int x64,
+                      asm_syntax_t syntax) {
+    (void)buf; (void)x64; (void)syntax;
+    return name;
+}
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int has_invalid(const char *s) {
+    return strstr(s, "[[") || strstr(s, "((");
+}
+
+int main(void) {
+    int locs[3] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    /* Test load from spilled address */
+    ra.loc[1] = -1; /* address in stack slot */
+    ra.loc[2] = 0;  /* destination register */
+    ins.op = IR_LOAD_PTR;
+    ins.dest = 2;
+    ins.src1 = 1;
+    ins.type = TYPE_INT;
+
+    strbuf_init(&sb);
+    emit_load_ptr(&sb, &ins, &ra, 0, ASM_ATT);
+    if (has_invalid(sb.data)) {
+        printf("load ATT failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_load_ptr(&sb, &ins, &ra, 0, ASM_INTEL);
+    if (has_invalid(sb.data)) {
+        printf("load Intel failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Test store to spilled address */
+    ra.loc[1] = -1; /* address in stack slot */
+    ra.loc[2] = 0;  /* value register */
+    ins.op = IR_STORE_PTR;
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.type = TYPE_INT;
+
+    strbuf_init(&sb);
+    emit_store_ptr(&sb, &ins, &ra, 0, ASM_ATT);
+    if (has_invalid(sb.data)) {
+        printf("store ATT failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_store_ptr(&sb, &ins, &ra, 0, ASM_INTEL);
+    if (has_invalid(sb.data)) {
+        printf("store Intel failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("load/store spill tests passed\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Fix pointer load/store emitters to avoid wrapping stack operands with extra brackets
- Add unit test exercising pointer loads/stores from spilled addresses

## Testing
- `tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689645efe92c8324b10f1b0832040028