### PR TITLE
Use 16-byte stack slots for long double args on x64

### DIFF
--- a/src/codegen_mem_x86.c
+++ b/src/codegen_mem_x86.c
@@ -437,7 +437,7 @@ static void emit_arg(strbuf_t *sb, ir_instr_t *ins,
     else if (t == TYPE_DOUBLE)
         sz = 8;
     else if (t == TYPE_LDOUBLE)
-        sz = 10;
+        sz = x64 ? 16 : 10;
     static const char *arg_regs[6] = {"%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9"};
     if (x64 && arg_reg_idx < 6 && t != TYPE_FLOAT && t != TYPE_DOUBLE && t != TYPE_LDOUBLE) {
         const char *reg = fmt_reg(arg_regs[arg_reg_idx], syntax);
@@ -468,10 +468,11 @@ static void emit_arg(strbuf_t *sb, ir_instr_t *ins,
                        loc_str(b1, ra, ins->src1, x64, syntax));
         strbuf_appendf(sb, "    movsd %%xmm0, (%s)\n", sp);
     } else if (t == TYPE_LDOUBLE) {
+        size_t pad = x64 ? 16 : 10;
         if (syntax == ASM_INTEL)
-            strbuf_appendf(sb, "    sub %s, 10\n", sp);
+            strbuf_appendf(sb, "    sub %s, %zu\n", sp, pad);
         else
-            strbuf_appendf(sb, "    sub $10, %s\n", sp);
+            strbuf_appendf(sb, "    sub $%zu, %s\n", pad, sp);
         strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src1, x64, syntax));
         strbuf_appendf(sb, "    fstpt (%s)\n", sp);
     } else {

--- a/tests/fixtures/ldouble_arg.c
+++ b/tests/fixtures/ldouble_arg.c
@@ -1,0 +1,6 @@
+void sink(long double);
+int main() {
+    long double x = 1.0L;
+    sink(x);
+    return 0;
+}

--- a/tests/fixtures/ldouble_arg.s
+++ b/tests/fixtures/ldouble_arg.s
@@ -1,0 +1,18 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $1, %eax
+    movl %eax, -0(%ebp)
+    movl $1, %eax
+    sub $10, %esp
+    fldt %eax
+    fstpt (%esp)
+    call sink
+    addl $10, %esp
+    movl %eax, %eax
+    movl $0, %ebx
+    movl %ebx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/ldouble_arg_x86-64.s
+++ b/tests/fixtures/ldouble_arg_x86-64.s
@@ -1,0 +1,18 @@
+main:
+    pushq %rbp
+    movq %rsp, %rbp
+    movq $1, %rax
+    movq %rax, -0(%rbp)
+    movq $1, %rax
+    sub $16, %rsp
+    fldt %rax
+    fstpt (%rsp)
+    call sink
+    addq $16, %rsp
+    movq %rax, %rax
+    movq $0, %rbx
+    movq %rbx, %rax
+    ret
+    movq %rbp, %rsp
+    popq %rbp
+    ret


### PR DESCRIPTION
## Summary
- Reserve 16 bytes for long double arguments on x86-64 and track the stack usage
- Add fixtures testing long double argument passing in 32-bit and 64-bit modes

## Testing
- `tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896502a94c083249be509f1c4374607