### PR TITLE
Use CL for Intel shift counts and add tests

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -176,16 +176,17 @@ void emit_shift(strbuf_t *sb, ir_instr_t *ins,
     char b2[32];
     const char *sfx = (x64 && ins->type != TYPE_INT) ? "q" : "l";
     const char *cx = x86_fmt_reg(x64 ? "%rcx" : "%ecx", syntax);
+    const char *cl = x86_fmt_reg("%cl", syntax);
     x86_emit_mov(sb, sfx,
                  x86_loc_str(b1, ra, ins->src1, x64, syntax),
                  x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
     x86_emit_mov(sb, sfx,
                  x86_loc_str(b1, ra, ins->src2, x64, syntax), cx, syntax);
     if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, cx,
-                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+        strbuf_appendf(sb, "    %s %s, %s\n", op,
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax), cl);
     else
-        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, "%cl",
+        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, cl,
                        x86_loc_str(b2, ra, ins->dest, x64, syntax));
 }
 

--- a/tests/fixtures/shift_var.c
+++ b/tests/fixtures/shift_var.c
@@ -1,0 +1,7 @@
+int main(void) {
+    int a = 1;
+    int b;
+    int x = a << b;
+    int y = a >> b;
+    return x + y;
+}

--- a/tests/fixtures/shift_var.s
+++ b/tests/fixtures/shift_var.s
@@ -1,0 +1,27 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    subl $16, %esp
+    movl $1, %eax
+    movl %eax, -4(%ebp)
+    movl $1, %eax
+    movl -8(%ebp), %ebx
+    movl %eax, %ecx
+    movl %ebx, %ecx
+    sall %cl, %ecx
+    movl %ecx, -12(%ebp)
+    movl $1, %ecx
+    movl -8(%ebp), %ebx
+    movl %ecx, %eax
+    movl %ebx, %ecx
+    sarl %cl, %eax
+    movl %eax, -16(%ebp)
+    movl -12(%ebp), %eax
+    movl -16(%ebp), %ebx
+    movl %eax, %ecx
+    addl %ebx, %ecx
+    movl %ecx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/shift_var_intel.s
+++ b/tests/fixtures/shift_var_intel.s
@@ -1,0 +1,27 @@
+main:
+    pushl ebp
+    movl ebp, esp
+    subl esp, 16
+    movl eax, 1
+    movl [ebp-4], eax
+    movl eax, 1
+    movl ebx, [ebp-8]
+    movl ecx, eax
+    movl ecx, ebx
+    sal ecx, cl
+    movl [ebp-12], ecx
+    movl ecx, 1
+    movl ebx, [ebp-8]
+    movl eax, ecx
+    movl ecx, ebx
+    sar eax, cl
+    movl [ebp-16], eax
+    movl eax, [ebp-12]
+    movl ebx, [ebp-16]
+    movl ecx, eax
+    addl ecx, ebx
+    movl eax, ecx
+    ret
+    movl esp, ebp
+    popl ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -67,6 +67,7 @@ compile_fixture "$DIR/fixtures/simple_add.c" "$DIR/fixtures/simple_add_intel.s" 
 # additional Intel syntax fixtures
 compile_fixture "$DIR/fixtures/pointer_add.c" "$DIR/fixtures/pointer_add_intel.s" --intel-syntax
 compile_fixture "$DIR/fixtures/while_loop.c" "$DIR/fixtures/while_loop_intel.s" --intel-syntax
+compile_fixture "$DIR/fixtures/shift_var.c" "$DIR/fixtures/shift_var_intel.s" --intel-syntax
 
 # verify include search path option
 compile_fixture "$DIR/fixtures/include_search.c" "$DIR/fixtures/include_search.s" -I "$DIR/includes"
@@ -654,6 +655,17 @@ if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
 fi
 rm -f "${obj_out}"
 
+# test -c/--compile with shift operations
+obj_tmp=$(safe_mktemp tmp.XXXXXX)
+obj_out="${obj_tmp}.o"
+rm -f "${obj_tmp}"
+"$BINARY" -c -o "${obj_out}" "$DIR/fixtures/shift_var.c"
+if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
+    echo "Test compile_option_shift failed"
+    fail=1
+fi
+rm -f "${obj_out}"
+
 # test --intel-syntax --compile option (requires nasm)
 if command -v nasm >/dev/null; then
     obj_tmp=$(safe_mktemp tmp.XXXXXX)
@@ -667,6 +679,21 @@ if command -v nasm >/dev/null; then
     rm -f "${obj_out}"
 else
     echo "Skipping compile_option_intel (nasm not found)"
+fi
+
+# test --intel-syntax --compile with shift operations (requires nasm)
+if command -v nasm >/dev/null; then
+    obj_tmp=$(safe_mktemp tmp.XXXXXX)
+    obj_out="${obj_tmp}.o"
+    rm -f "${obj_tmp}"
+    "$BINARY" --intel-syntax -c -o "${obj_out}" "$DIR/fixtures/shift_var.c"
+    if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
+        echo "Test compile_option_shift_intel failed"
+        fail=1
+    fi
+    rm -f "${obj_out}"
+else
+    echo "Skipping compile_option_shift_intel (nasm not found)"
 fi
 
 # test --emit-dwarf option


### PR DESCRIPTION
## Summary
- use the `cl` register when emitting variable shifts in Intel syntax
- add fixture and regression tests ensuring shift instructions assemble

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896501de9b08324ad3847b960b98888