### PR TITLE
Handle zero-sized types in pointer diff

### DIFF
--- a/docs/language_features.md
+++ b/docs/language_features.md
@@ -318,7 +318,8 @@ vc -o ptr_arith.s ptr_arith.c
 Pointer subtraction of two pointers is also supported and returns the
 element distance between them.
 Pointer offsets are scaled by the size of the pointed-to type rather
-than the machine word size.
+than the machine word size. If the pointed-to type has size zero, the
+difference is defined to be zero.
 
 Pointer variables may also be incremented or decremented with `++` and
 `--`.  These operations are equivalent to adding or subtracting one

--- a/include/ir_memory.h
+++ b/include/ir_memory.h
@@ -50,7 +50,8 @@ void ir_build_store_ptr_res(ir_builder_t *b, ir_value_t addr, ir_value_t val);
 ir_value_t ir_build_ptr_add(ir_builder_t *b, ir_value_t ptr, ir_value_t idx,
                             int elem_size);
 
-/* Emit IR_PTR_DIFF computing `a - bptr` in elements of size `elem_size`. */
+/* Emit IR_PTR_DIFF computing `a - bptr` in elements of size `elem_size`.
+ * A zero `elem_size` yields a result of zero. */
 ir_value_t ir_build_ptr_diff(ir_builder_t *b, ir_value_t a, ir_value_t bptr,
                              int elem_size);
 

--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -57,6 +57,13 @@ void emit_ptr_diff(strbuf_t *sb, ir_instr_t *ins,
                                       : x86_loc_str(b2, ra, ins->dest, x64, syntax);
     const char *dest_mem = x86_loc_str(mem, ra, ins->dest, x64, syntax);
 
+    if (esz == 0) {
+        x86_emit_op(sb, "xor", sfx, dest_reg, dest_reg, syntax);
+        if (dest_spill)
+            x86_emit_mov(sb, sfx, dest_reg, dest_mem, syntax);
+        return;
+    }
+
     x86_emit_mov(sb, sfx,
                  x86_loc_str(b1, ra, ins->src1, x64, syntax), dest_reg, syntax);
     x86_emit_op(sb, "sub", sfx,

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -214,6 +214,17 @@ if ! "$DIR/load_store_spill" >/dev/null; then
 fi
 rm -f "$DIR/load_store_spill"
 
+# verify pointer difference with zero element size
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_ptr_diff_zero.c" \
+    "$DIR/../src/codegen_arith_int.c" "$DIR/../src/codegen_x86.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/ptr_diff_zero"
+if ! "$DIR/ptr_diff_zero" >/dev/null; then
+    echo "Test ptr_diff_zero failed"
+    fail=1
+fi
+rm -f "$DIR/ptr_diff_zero"
+
 # negative test for failing static assertion
 err=$(safe_mktemp)
 out=$(safe_mktemp)

--- a/tests/unit/test_ptr_diff_zero.c
+++ b/tests/unit/test_ptr_diff_zero.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_arith_int.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Minimal stubs to satisfy linker requirements. */
+const char *label_format_suffix(char buf[32], const char *prefix, int id,
+                                const char *suffix) {
+    (void)buf; (void)prefix; (void)id; (void)suffix; return "";
+}
+void emit_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                           int x64, asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax, const char *op) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; (void)op;
+}
+void emit_cplx_mul(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_cplx_div(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_cast(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+               asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+int label_next_id(void) { return 0; }
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+int main(void) {
+    int locs[4] = {0, 0, 1, 2};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    ins.op = IR_PTR_DIFF;
+    ins.dest = 3;
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.type = TYPE_INT;
+    ins.imm = 0; /* element size */
+
+    strbuf_init(&sb);
+    emit_ptr_diff(&sb, &ins, &ra, 0, ASM_ATT);
+    if (strstr(sb.data, "idiv") || strstr(sb.data, "sar") || !strstr(sb.data, "xor")) {
+        printf("ATT: unexpected output: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_ptr_diff(&sb, &ins, &ra, 0, ASM_INTEL);
+    if (strstr(sb.data, "idiv") || strstr(sb.data, "sar") || !strstr(sb.data, "xor")) {
+        printf("Intel: unexpected output: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("ptr diff zero tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Guard pointer difference emission against zero-sized elements by zeroing the result
- Document pointer subtraction behavior for zero-sized types
- Add regression test for pointer difference with element size zero

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68965294251c8324abbe4fc8cfeb92ef