### PR TITLE
Handle assembly syntax in emit_arg

### DIFF
--- a/src/codegen_mem_x86.c
+++ b/src/codegen_mem_x86.c
@@ -454,25 +454,46 @@ static void emit_arg(strbuf_t *sb, ir_instr_t *ins,
             strbuf_appendf(sb, "    sub %s, 4\n", sp);
         else
             strbuf_appendf(sb, "    sub $4, %s\n", sp);
-        strbuf_appendf(sb, "    movd %s, %%xmm0\n",
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    movss %%xmm0, (%s)\n", sp);
+        const char *src = loc_str(b1, ra, ins->src1, x64, syntax);
+        const char *x0 = fmt_reg("%xmm0", syntax);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movd %s, %s\n", x0, src);
+        else
+            strbuf_appendf(sb, "    movd %s, %s\n", src, x0);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movss [%s], %s\n", sp, x0);
+        else
+            strbuf_appendf(sb, "    movss %s, (%s)\n", x0, sp);
     } else if (t == TYPE_DOUBLE) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    sub %s, 8\n", sp);
         else
             strbuf_appendf(sb, "    sub $8, %s\n", sp);
-        strbuf_appendf(sb, "    movq %s, %%xmm0\n",
-                       loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    movsd %%xmm0, (%s)\n", sp);
+        const char *src = loc_str(b1, ra, ins->src1, x64, syntax);
+        const char *x0 = fmt_reg("%xmm0", syntax);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movq %s, %s\n", x0, src);
+        else
+            strbuf_appendf(sb, "    movq %s, %s\n", src, x0);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movsd [%s], %s\n", sp, x0);
+        else
+            strbuf_appendf(sb, "    movsd %s, (%s)\n", x0, sp);
     } else if (t == TYPE_LDOUBLE) {
         size_t pad = x64 ? 16 : 10;
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    sub %s, %zu\n", sp, pad);
         else
             strbuf_appendf(sb, "    sub $%zu, %s\n", pad, sp);
-        strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src1, x64, syntax));
-        strbuf_appendf(sb, "    fstpt (%s)\n", sp);
+        const char *src = loc_str(b1, ra, ins->src1, x64, syntax);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    fld tword ptr %s\n", src);
+        else
+            strbuf_appendf(sb, "    fldt %s\n", src);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    fstp tword ptr [%s]\n", sp);
+        else
+            strbuf_appendf(sb, "    fstpt (%s)\n", sp);
     } else {
         const char *sfx = x64 ? "q" : "l";
         strbuf_appendf(sb, "    push%s %s\n", sfx,

--- a/tests/fixtures/float_double_ldouble_args.c
+++ b/tests/fixtures/float_double_ldouble_args.c
@@ -1,0 +1,12 @@
+void sinkf(float);
+void sinkd(double);
+void sinkld(long double);
+int main() {
+    float a = 1;
+    double b = 2;
+    long double c = 3;
+    sinkf(a);
+    sinkd(b);
+    sinkld(c);
+    return 0;
+}

--- a/tests/fixtures/float_double_ldouble_args.s
+++ b/tests/fixtures/float_double_ldouble_args.s
@@ -1,0 +1,36 @@
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $1, %eax
+    movl %eax, -0(%ebp)
+    movl $2, %eax
+    movl %eax, -0(%ebp)
+    movl $3, %eax
+    movl %eax, -0(%ebp)
+    movl $3, %eax
+    sub $4, %esp
+    movd %eax, %xmm0
+    movss %xmm0, (%esp)
+    call sinkf
+    addl $4, %esp
+    movl %eax, %eax
+    movl -0(%ebp), %ebx
+    sub $8, %esp
+    movq %ebx, %xmm0
+    movsd %xmm0, (%esp)
+    call sinkd
+    addl $8, %esp
+    movl %eax, %ebx
+    movl -0(%ebp), %ecx
+    sub $10, %esp
+    fldt %ecx
+    fstpt (%esp)
+    call sinkld
+    addl $10, %esp
+    movl %eax, %ecx
+    movl $0, %edx
+    movl %edx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/fixtures/float_double_ldouble_args_intel.s
+++ b/tests/fixtures/float_double_ldouble_args_intel.s
@@ -1,0 +1,36 @@
+main:
+    pushl ebp
+    movl ebp, esp
+    movl eax, 1
+    movl [ebp-0], eax
+    movl eax, 2
+    movl [ebp-0], eax
+    movl eax, 3
+    movl [ebp-0], eax
+    movl eax, 3
+    sub esp, 4
+    movd xmm0, eax
+    movss [esp], xmm0
+    call sinkf
+    addl esp, 4
+    movl eax, eax
+    movl ebx, [ebp-0]
+    sub esp, 8
+    movq xmm0, ebx
+    movsd [esp], xmm0
+    call sinkd
+    addl esp, 8
+    movl ebx, eax
+    movl ecx, [ebp-0]
+    sub esp, 10
+    fld tword ptr ecx
+    fstp tword ptr [esp]
+    call sinkld
+    addl esp, 10
+    movl ecx, eax
+    movl edx, 0
+    movl eax, edx
+    ret
+    movl esp, ebp
+    popl ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -68,6 +68,7 @@ compile_fixture "$DIR/fixtures/simple_add.c" "$DIR/fixtures/simple_add_intel.s" 
 compile_fixture "$DIR/fixtures/pointer_add.c" "$DIR/fixtures/pointer_add_intel.s" --intel-syntax
 compile_fixture "$DIR/fixtures/while_loop.c" "$DIR/fixtures/while_loop_intel.s" --intel-syntax
 compile_fixture "$DIR/fixtures/shift_var.c" "$DIR/fixtures/shift_var_intel.s" --intel-syntax
+compile_fixture "$DIR/fixtures/float_double_ldouble_args.c" "$DIR/fixtures/float_double_ldouble_args_intel.s" --intel-syntax
 
 # verify include search path option
 compile_fixture "$DIR/fixtures/include_search.c" "$DIR/fixtures/include_search.s" -I "$DIR/includes"


### PR DESCRIPTION
## Summary
- Generate movd/movq/movss/movsd/fldt/fstpt with proper operand order based on Intel vs AT&T syntax
- Add fixture to verify float/double/long double argument passing in both AT&T and Intel syntaxes

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689654220a8083249d4e4651231ba1b4