### PR TITLE
Handle 64-bit int/float conversions

### DIFF
--- a/src/codegen_arith_float.c
+++ b/src/codegen_arith_float.c
@@ -53,17 +53,20 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     char b2[32];
     type_kind_t src = (type_kind_t)((unsigned long long)ins->imm >> 32);
     type_kind_t dst = (type_kind_t)(ins->imm & 0xffffffffu);
+    int src64 = (src == TYPE_LLONG || src == TYPE_ULLONG);
+    int dst64 = (dst == TYPE_LLONG || dst == TYPE_ULLONG);
 
     int r0 = regalloc_xmm_acquire();
     const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
     const char *sfx = x64 ? "q" : "l";
 
     if (is_intlike(src) && dst == TYPE_FLOAT) {
+        const char *op = src64 ? "cvtsi2ssq" : "cvtsi2ss";
         if (syntax == ASM_INTEL)
-            strbuf_appendf(sb, "    cvtsi2ss %s, %s\n", reg0,
+            strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
                            loc_str(b1, ra, ins->src1, x64, syntax));
         else
-            strbuf_appendf(sb, "    cvtsi2ss %s, %s\n",
+            strbuf_appendf(sb, "    %s %s, %s\n", op,
                            loc_str(b1, ra, ins->src1, x64, syntax), reg0);
         if (ra && ra->loc[ins->dest] >= 0)
             strbuf_appendf(sb, "    movd %s, %s\n", reg0,
@@ -76,11 +79,12 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     }
 
     if (is_intlike(src) && dst == TYPE_DOUBLE) {
+        const char *op = src64 ? "cvtsi2sdq" : "cvtsi2sd";
         if (syntax == ASM_INTEL)
-            strbuf_appendf(sb, "    cvtsi2sd %s, %s\n", reg0,
+            strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
                            loc_str(b1, ra, ins->src1, x64, syntax));
         else
-            strbuf_appendf(sb, "    cvtsi2sd %s, %s\n",
+            strbuf_appendf(sb, "    %s %s, %s\n", op,
                            loc_str(b1, ra, ins->src1, x64, syntax), reg0);
         if (ra && ra->loc[ins->dest] >= 0)
             strbuf_appendf(sb, "    movq %s, %s\n", reg0,
@@ -99,11 +103,12 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    movss %s, %s\n",
                            loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        const char *op = dst64 ? "cvttss2siq" : "cvttss2si";
         if (syntax == ASM_INTEL)
-            strbuf_appendf(sb, "    cvttss2si %s, %s\n", reg0,
+            strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
         else
-            strbuf_appendf(sb, "    cvttss2si %s, %s\n", reg0,
+            strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
         regalloc_xmm_release(r0);
         return;
@@ -116,11 +121,12 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         else
             strbuf_appendf(sb, "    movsd %s, %s\n",
                            loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+        const char *op = dst64 ? "cvttsd2siq" : "cvttsd2si";
         if (syntax == ASM_INTEL)
-            strbuf_appendf(sb, "    cvttsd2si %s, %s\n", reg0,
+            strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
         else
-            strbuf_appendf(sb, "    cvttsd2si %s, %s\n", reg0,
+            strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
                            loc_str(b2, ra, ins->dest, x64, syntax));
         regalloc_xmm_release(r0);
         return;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -226,6 +226,17 @@ if ! "$DIR/load_store_idx_scale" >/dev/null; then
 fi
 rm -f "$DIR/load_store_idx_scale"
 
+# verify 64-bit int/float cast emission
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_emit_cast_int64.c" \
+    "$DIR/../src/codegen_arith_float.c" "$DIR/../src/strbuf.c" \
+    "$DIR/../src/regalloc_x86.c" -o "$DIR/emit_cast_int64"
+if ! "$DIR/emit_cast_int64" >/dev/null; then
+    echo "Test emit_cast_int64 failed"
+    fail=1
+fi
+rm -f "$DIR/emit_cast_int64"
+
 # negative test for failing static assertion
 err=$(safe_mktemp)
 out=$(safe_mktemp)

--- a/tests/unit/test_emit_cast_int64.c
+++ b/tests/unit/test_emit_cast_int64.c
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "codegen_arith_float.h"
+#include "strbuf.h"
+#include "regalloc_x86.h"
+
+int is_intlike(type_kind_t t) {
+    switch (t) {
+    case TYPE_INT: case TYPE_UINT: case TYPE_CHAR: case TYPE_UCHAR:
+    case TYPE_SHORT: case TYPE_USHORT: case TYPE_LONG: case TYPE_ULONG:
+    case TYPE_LLONG: case TYPE_ULLONG: case TYPE_BOOL:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+int main(void) {
+    ir_instr_t ins = {0};
+    strbuf_t sb;
+    int fail = 0;
+
+    strbuf_init(&sb);
+
+    ins.imm = ((long long)TYPE_LLONG << 32) | TYPE_FLOAT;
+    emit_cast(&sb, &ins, NULL, 1, ASM_ATT);
+    if (!strstr(sb.data, "cvtsi2ssq")) {
+        printf("int64->float ATT failed: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+    emit_cast(&sb, &ins, NULL, 1, ASM_INTEL);
+    if (!strstr(sb.data, "cvtsi2ssq")) {
+        printf("int64->float Intel failed: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+
+    ins.imm = ((long long)TYPE_LLONG << 32) | TYPE_DOUBLE;
+    emit_cast(&sb, &ins, NULL, 1, ASM_ATT);
+    if (!strstr(sb.data, "cvtsi2sdq")) {
+        printf("int64->double ATT failed: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+    emit_cast(&sb, &ins, NULL, 1, ASM_INTEL);
+    if (!strstr(sb.data, "cvtsi2sdq")) {
+        printf("int64->double Intel failed: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+
+    ins.imm = ((long long)TYPE_FLOAT << 32) | TYPE_LLONG;
+    emit_cast(&sb, &ins, NULL, 1, ASM_ATT);
+    if (!strstr(sb.data, "cvttss2siq")) {
+        printf("float->int64 ATT failed: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+    emit_cast(&sb, &ins, NULL, 1, ASM_INTEL);
+    if (!strstr(sb.data, "cvttss2siq")) {
+        printf("float->int64 Intel failed: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+
+    ins.imm = ((long long)TYPE_DOUBLE << 32) | TYPE_LLONG;
+    emit_cast(&sb, &ins, NULL, 1, ASM_ATT);
+    if (!strstr(sb.data, "cvttsd2siq")) {
+        printf("double->int64 ATT failed: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+    emit_cast(&sb, &ins, NULL, 1, ASM_INTEL);
+    if (!strstr(sb.data, "cvttsd2siq")) {
+        printf("double->int64 Intel failed: %s\n", sb.data);
+        fail = 1;
+    }
+
+    strbuf_free(&sb);
+    if (fail)
+        return 1;
+    printf("emit_cast int64 tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- detect 64-bit operands and emit q-suffixed conversion opcodes
- add coverage for int64<->float/double casts in AT&T and Intel syntaxes

## Testing
- `tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68965469f67c8324a0d83dddeec2f5f7