### PR TITLE
Handle stack destinations in emit_cmp

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -226,6 +226,17 @@ if ! "$DIR/ptr_diff_zero" >/dev/null; then
 fi
 rm -f "$DIR/ptr_diff_zero"
 
+# verify compare emission for register and spilled destinations
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_cmp_spill.c" \
+    "$DIR/../src/codegen_arith_int.c" "$DIR/../src/codegen_x86.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/cmp_spill"
+if ! "$DIR/cmp_spill" >/dev/null; then
+    echo "Test cmp_spill failed"
+    fail=1
+fi
+rm -f "$DIR/cmp_spill"
+
 # verify indexed load/store scale handling
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_store_idx_scale.c" \

--- a/tests/unit/test_cmp_spill.c
+++ b/tests/unit/test_cmp_spill.c
@@ -1,0 +1,71 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_arith_int.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Stubs required by codegen_arith_int.c */
+const char *label_format_suffix(char buf[32], const char *prefix, int id,
+                                const char *suffix) { (void)buf; (void)prefix; (void)id; (void)suffix; return ""; }
+void emit_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                           int x64, asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax, const char *op) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; (void)op; }
+void emit_cplx_mul(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cplx_div(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cast(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+               asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+int label_next_id(void) { return 0; }
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int contains(const char *s, const char *sub) { return strstr(s, sub) != NULL; }
+
+int main(void) {
+    int locs[4] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    ins.op = IR_CMPEQ;
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.dest = 3;
+    ins.type = TYPE_INT;
+
+    /* Register destination */
+    ra.loc[1] = 0; /* %eax */
+    ra.loc[2] = 1; /* %ebx */
+    ra.loc[3] = 2; /* %ecx */
+
+    strbuf_init(&sb);
+    emit_cmp(&sb, &ins, &ra, 0, ASM_ATT);
+    if (!contains(sb.data, "movzbl %al, %ecx") || contains(sb.data, "movb")) {
+        printf("register ATT failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Spilled destination */
+    ra.loc[3] = -1; /* stack slot */
+
+    strbuf_init(&sb);
+    emit_cmp(&sb, &ins, &ra, 0, ASM_ATT);
+    const char *out = sb.data;
+    if (!contains(out, "movb %al, -4(%ebp)") ||
+        !contains(out, "movzbl %al, %eax") ||
+        !contains(out, "movl %eax, -4(%ebp)") ||
+        contains(out, "movzbl %al, -4(%ebp)")) {
+        printf("spill ATT failed: %s\n", out);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("emit_cmp tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- detect when compare results are spilled and write AL to the stack with `movb`
- zero-extend through a scratch register and only use `movzb*` when the destination is a register
- add unit test for register and spilled compare results and hook it into the test suite

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896550d3fd48324ad014b03e85ccb07