### PR TITLE
Fix complex add/sub register order and add tests

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -366,10 +366,10 @@ void emit_arith_instr(strbuf_t *sb, ir_instr_t *ins,
         emit_long_float_binop(sb, ins, ra, x64, "fdivp", syntax);
         break;
     case IR_CPLX_ADD:
-        emit_cplx_addsub(sb, ins, ra, x64, "addsd", syntax);
+        emit_cplx_addsub(sb, ins, ra, x64, "add", syntax);
         break;
     case IR_CPLX_SUB:
-        emit_cplx_addsub(sb, ins, ra, x64, "subsd", syntax);
+        emit_cplx_addsub(sb, ins, ra, x64, "sub", syntax);
         break;
     case IR_CPLX_MUL:
         emit_cplx_mul(sb, ins, ra, x64, syntax);

--- a/src/codegen_complex.c
+++ b/src/codegen_complex.c
@@ -64,38 +64,22 @@ void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
     const char *reg1 = fmt_reg(regalloc_xmm_name(r1), syntax);
 
     /* real part */
-    if (syntax == ASM_INTEL) {
-        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                       loc_str_off(b1, ra, ins->src1, 0, x64, syntax));
-        strbuf_appendf(sb, "    movsd %s, %s\n", reg1,
-                       loc_str_off(b2, ra, ins->src2, 0, x64, syntax));
-        strbuf_appendf(sb, "    %s %s, %s\n", op, reg0, reg1);
-        strbuf_appendf(sb, "    movsd %s, %s\n",
-                       loc_str_off(b3, ra, ins->dest, 0, x64, syntax), reg0);
-        /* imag part */
-        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                       loc_str_off(b1, ra, ins->src1, 8, x64, syntax));
-        strbuf_appendf(sb, "    movsd %s, %s\n", reg1,
-                       loc_str_off(b2, ra, ins->src2, 8, x64, syntax));
-        strbuf_appendf(sb, "    %s %s, %s\n", op, reg0, reg1);
-        strbuf_appendf(sb, "    movsd %s, %s\n",
-                       loc_str_off(b3, ra, ins->dest, 8, x64, syntax), reg0);
-    } else {
-        strbuf_appendf(sb, "    movsd %s, %s\n",
-                       loc_str_off(b1, ra, ins->src1, 0, x64, syntax), reg0);
-        strbuf_appendf(sb, "    movsd %s, %s\n",
-                       loc_str_off(b2, ra, ins->src2, 0, x64, syntax), reg1);
-        strbuf_appendf(sb, "    %s %s, %s\n", op, reg1, reg0);
-        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                       loc_str_off(b3, ra, ins->dest, 0, x64, syntax));
-        strbuf_appendf(sb, "    movsd %s, %s\n",
-                       loc_str_off(b1, ra, ins->src1, 8, x64, syntax), reg0);
-        strbuf_appendf(sb, "    movsd %s, %s\n",
-                       loc_str_off(b2, ra, ins->src2, 8, x64, syntax), reg1);
-        strbuf_appendf(sb, "    %s %s, %s\n", op, reg1, reg0);
-        strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                       loc_str_off(b3, ra, ins->dest, 8, x64, syntax));
-    }
+    emit_movsd(sb, loc_str_off(b1, ra, ins->src1, 0, x64, syntax), reg0,
+               syntax);
+    emit_movsd(sb, loc_str_off(b2, ra, ins->src2, 0, x64, syntax), reg1,
+               syntax);
+    emit_op_sd(sb, op, reg1, reg0, syntax);
+    emit_movsd(sb, reg0, loc_str_off(b3, ra, ins->dest, 0, x64, syntax),
+               syntax);
+
+    /* imag part */
+    emit_movsd(sb, loc_str_off(b1, ra, ins->src1, 8, x64, syntax), reg0,
+               syntax);
+    emit_movsd(sb, loc_str_off(b2, ra, ins->src2, 8, x64, syntax), reg1,
+               syntax);
+    emit_op_sd(sb, op, reg1, reg0, syntax);
+    emit_movsd(sb, reg0, loc_str_off(b3, ra, ins->dest, 8, x64, syntax),
+               syntax);
     regalloc_xmm_release(r1);
     regalloc_xmm_release(r0);
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -271,6 +271,17 @@ if ! "$DIR/emit_cast_int64" >/dev/null; then
 fi
 rm -f "$DIR/emit_cast_int64"
 
+# verify complex addition emission
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_emit_cplx_add.c" \
+    "$DIR/../src/codegen_complex.c" "$DIR/../src/codegen_x86.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/emit_cplx_add"
+if ! "$DIR/emit_cplx_add" >/dev/null; then
+    echo "Test emit_cplx_add failed"
+    fail=1
+fi
+rm -f "$DIR/emit_cplx_add"
+
 # verify shifts with destination in %ecx/%rcx
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_shift_rcx.c" \

--- a/tests/unit/test_emit_cplx_add.c
+++ b/tests/unit/test_emit_cplx_add.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_float.h"
+#include "strbuf.h"
+#include "regalloc_x86.h"
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+int main(void) {
+    ir_instr_t ins = {0};
+    strbuf_t sb;
+    int fail = 0;
+    int locs[4] = {0, -1, -2, -3};
+    regalloc_t ra = { .loc = locs };
+
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.dest = 3;
+
+    strbuf_init(&sb);
+
+    /* ATT syntax */
+    regalloc_set_x86_64(1);
+    regalloc_xmm_reset();
+    regalloc_set_asm_syntax(ASM_ATT);
+    emit_cplx_addsub(&sb, &ins, &ra, 1, "add", ASM_ATT);
+    int count = 0;
+    for (char *p = sb.data; (p = strstr(p, "addsd %xmm1, %xmm0")); p += 1)
+        count++;
+    if (count != 2) {
+        printf("ATT unexpected output: %s\n", sb.data);
+        fail = 1;
+    }
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+
+    /* Intel syntax */
+    regalloc_xmm_reset();
+    regalloc_set_asm_syntax(ASM_INTEL);
+    emit_cplx_addsub(&sb, &ins, &ra, 1, "add", ASM_INTEL);
+    count = 0;
+    for (char *p = sb.data; (p = strstr(p, "addsd xmm0, xmm1")); p += 1)
+        count++;
+    if (count != 2) {
+        printf("Intel unexpected output: %s\n", sb.data);
+        fail = 1;
+    }
+
+    strbuf_free(&sb);
+    if (fail)
+        return 1;
+    printf("emit_cplx_add tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- fix complex add/sub emission to accumulate results in reg0 for both real and imaginary parts
- add regression test verifying complex addition assembly for AT&T and Intel syntax

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896b9ddae948324ae33e3014adaca82