### PR TITLE
Fix Intel cmp operand order and add test

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -248,9 +248,14 @@ void emit_cmp(strbuf_t *sb, ir_instr_t *ins,
     x86_emit_mov(sb, sfx,
                  x86_loc_str(b1, ra, ins->src1, x64, syntax),
                  x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
-    strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
-                   x86_loc_str(b1, ra, ins->src2, x64, syntax),
-                   x86_loc_str(b2, ra, ins->dest, x64, syntax));
+    if (syntax == ASM_INTEL)
+        strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax),
+                       x86_loc_str(b1, ra, ins->src2, x64, syntax));
+    else
+        strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
+                       x86_loc_str(b1, ra, ins->src2, x64, syntax),
+                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
     strbuf_appendf(sb, "    set%s %s\n", cc, al);
     int loc = ra ? ra->loc[ins->dest] : 0;
     const char *dest = x86_loc_str(b2, ra, ins->dest, x64, syntax);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -249,6 +249,17 @@ if ! "$DIR/cmp_spill" >/dev/null; then
 fi
 rm -f "$DIR/cmp_spill"
 
+# verify compare emission order under Intel syntax
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_cmp_intel.c" \
+    "$DIR/../src/codegen_arith_int.c" "$DIR/../src/codegen_x86.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/cmp_intel"
+if ! "$DIR/cmp_intel" >/dev/null; then
+    echo "Test cmp_intel failed"
+    fail=1
+fi
+rm -f "$DIR/cmp_intel"
+
 # verify indexed load/store scale handling
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_store_idx_scale.c" \

--- a/tests/unit/test_cmp_intel.c
+++ b/tests/unit/test_cmp_intel.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_arith_int.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Stubs required by codegen_arith_int.c */
+const char *label_format_suffix(char buf[32], const char *prefix, int id,
+                                const char *suffix) { (void)buf; (void)prefix; (void)id; (void)suffix; return ""; }
+void emit_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                           int x64, asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax, const char *op) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; (void)op; }
+void emit_cplx_mul(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cplx_div(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cast(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+               asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+int label_next_id(void) { return 0; }
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int contains(const char *s, const char *sub) { return strstr(s, sub) != NULL; }
+
+int main(void) {
+    int locs[4] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    ins.op = IR_CMPEQ;
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.dest = 3;
+    ins.type = TYPE_INT;
+
+    /* Register destination */
+    ra.loc[1] = 0; /* %eax */
+    ra.loc[2] = 1; /* %ebx */
+    ra.loc[3] = 2; /* %ecx */
+
+    strbuf_init(&sb);
+    emit_cmp(&sb, &ins, &ra, 0, ASM_INTEL);
+    const char *out = sb.data;
+    int fail = 0;
+    if (!contains(out, "cmpl ecx, ebx") || contains(out, "cmpl ebx, ecx")) {
+        printf("intel cmp order failed: %s\n", out);
+        fail = 1;
+    }
+    strbuf_free(&sb);
+
+    if (!fail)
+        printf("emit_cmp intel tests passed\n");
+    return fail;
+}


### PR DESCRIPTION
## Summary
- Swap operands for `cmp` when emitting Intel syntax
- Add unit test verifying Intel-style `cmp` generation

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896bb90605c83249677a477269128f8