### PR TITLE
Handle spilled pointer in load emission

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -227,6 +227,17 @@ if ! "$DIR/store_ptr_stack" >/dev/null; then
 fi
 rm -f "$DIR/store_ptr_stack"
 
+# verify loading through a stack-resident pointer
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_load_ptr_stack.c" \
+    "$DIR/../src/codegen_load.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/load_ptr_stack"
+if ! "$DIR/load_ptr_stack" >/dev/null; then
+    echo "Test load_ptr_stack failed"
+    fail=1
+fi
+rm -f "$DIR/load_ptr_stack"
+
 # verify pointer difference with zero element size
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_ptr_diff_zero.c" \

--- a/tests/unit/test_load_ptr_stack.c
+++ b/tests/unit/test_load_ptr_stack.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "codegen_loadstore.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Provide minimal stubs to satisfy linker requirements. */
+const char *fmt_stack(char buf[32], const char *name, int x64,
+                      asm_syntax_t syntax) {
+    (void)buf; (void)x64; (void)syntax;
+    return name;
+}
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+int main(void) {
+    int locs[3] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    ra.loc[1] = -1; /* pointer in stack slot */
+    ra.loc[2] = 1;  /* destination register %ebx */
+    ins.op = IR_LOAD_PTR;
+    ins.dest = 2;
+    ins.src1 = 1;
+    ins.type = TYPE_INT;
+
+    strbuf_init(&sb);
+    emit_load_ptr(&sb, &ins, &ra, 0, ASM_ATT);
+    const char *exp_att = "    movl -4(%ebp), %eax\n    movl (%eax), %ebx\n";
+    if (strcmp(sb.data, exp_att) != 0) {
+        printf("load ATT unexpected: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_load_ptr(&sb, &ins, &ra, 0, ASM_INTEL);
+    const char *exp_intel = "    movl eax, [ebp-4]\n    movl ebx, [eax]\n";
+    if (strcmp(sb.data, exp_intel) != 0) {
+        printf("load Intel unexpected: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("load ptr stack test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- correctly load and dereference pointers stored in spill slots
- add regression test for loading via stack-resident pointer
- run new regression test as part of test suite

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6896bf94a9cc83249d7e85385f0479bb