### PR TITLE
Handle non-power-of-two index scales

### DIFF
--- a/include/codegen_loadstore.h
+++ b/include/codegen_loadstore.h
@@ -30,11 +30,11 @@ static inline int idx_scale(const ir_instr_t *ins, int x64)
     case TYPE_FLOAT_COMPLEX:
         return 8;
     case TYPE_LDOUBLE:
-        return 10;
+        return (int)sizeof(long double);
     case TYPE_DOUBLE_COMPLEX:
-        return 16;
+        return 2 * (int)sizeof(double);
     case TYPE_LDOUBLE_COMPLEX:
-        return 20;
+        return 2 * (int)sizeof(long double);
     case TYPE_PTR:
         return x64 ? 8 : 4;
     default:

--- a/tests/unit/test_load_store_idx_scale.c
+++ b/tests/unit/test_load_store_idx_scale.c
@@ -147,6 +147,52 @@ int main(void) {
         strbuf_free(&sb);
     }
 
+    if (sizeof(long double) > 8) {
+        /* long double index requires multiply */
+        ins.imm = 0;
+        ins.type = TYPE_LDOUBLE;
+
+        char bad_att[32];
+        snprintf(bad_att, sizeof(bad_att), ",%zu)", sizeof(long double));
+        char bad_intel[32];
+        snprintf(bad_intel, sizeof(bad_intel), "*%zu", sizeof(long double));
+
+        ins.op = IR_LOAD_IDX;
+        strbuf_init(&sb);
+        emit_load_idx(&sb, &ins, &ra, 1, ASM_ATT);
+        if (!strstr(sb.data, "imul") || strstr(sb.data, bad_att)) {
+            printf("load idx long double ATT failed: %s\n", sb.data);
+            return 1;
+        }
+        strbuf_free(&sb);
+
+        strbuf_init(&sb);
+        emit_load_idx(&sb, &ins, &ra, 1, ASM_INTEL);
+        if (!strstr(sb.data, "imul") || strstr(sb.data, bad_intel)) {
+            printf("load idx long double Intel failed: %s\n", sb.data);
+            return 1;
+        }
+        strbuf_free(&sb);
+
+        ins.op = IR_STORE_IDX;
+        ins.src2 = 2;
+        strbuf_init(&sb);
+        emit_store_idx(&sb, &ins, &ra, 1, ASM_ATT);
+        if (!strstr(sb.data, "imul") || strstr(sb.data, bad_att)) {
+            printf("store idx long double ATT failed: %s\n", sb.data);
+            return 1;
+        }
+        strbuf_free(&sb);
+
+        strbuf_init(&sb);
+        emit_store_idx(&sb, &ins, &ra, 1, ASM_INTEL);
+        if (!strstr(sb.data, "imul") || strstr(sb.data, bad_intel)) {
+            printf("store idx long double Intel failed: %s\n", sb.data);
+            return 1;
+        }
+        strbuf_free(&sb);
+    }
+
     printf("load/store idx scale tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- compute correct long double sizes in `idx_scale`
- multiply index registers for unsupported scales in `emit_load_idx`/`emit_store_idx`
- add tests covering `long double` array indexing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6896c11e95208324afad7b4ca243be51