### PR TITLE
Handle XMM register exhaustion

### DIFF
--- a/src/codegen_complex.c
+++ b/src/codegen_complex.c
@@ -59,7 +59,18 @@ void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
     char b2[32];
     char b3[32];
     int r0 = regalloc_xmm_acquire();
+    if (r0 < 0) {
+        fprintf(stderr, "emit_cplx_addsub: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r1 = regalloc_xmm_acquire();
+    if (r1 < 0) {
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_addsub: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
     const char *reg1 = fmt_reg(regalloc_xmm_name(r1), syntax);
 
@@ -90,9 +101,35 @@ void emit_cplx_mul(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
 {
     char a[32], c[32], d[32], out[32];
     int r0 = regalloc_xmm_acquire();
+    if (r0 < 0) {
+        fprintf(stderr, "emit_cplx_mul: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r1 = regalloc_xmm_acquire();
+    if (r1 < 0) {
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_mul: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r2 = regalloc_xmm_acquire();
+    if (r2 < 0) {
+        regalloc_xmm_release(r1);
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_mul: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r3 = regalloc_xmm_acquire();
+    if (r3 < 0) {
+        regalloc_xmm_release(r2);
+        regalloc_xmm_release(r1);
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_mul: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     const char *x0 = fmt_reg(regalloc_xmm_name(r0), syntax);
     const char *x1 = fmt_reg(regalloc_xmm_name(r1), syntax);
     const char *x2 = fmt_reg(regalloc_xmm_name(r2), syntax);
@@ -127,10 +164,45 @@ void emit_cplx_div(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
 {
     char a[32], c[32], d[32], out[32];
     int r0 = regalloc_xmm_acquire();
+    if (r0 < 0) {
+        fprintf(stderr, "emit_cplx_div: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r1 = regalloc_xmm_acquire();
+    if (r1 < 0) {
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_div: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r2 = regalloc_xmm_acquire();
+    if (r2 < 0) {
+        regalloc_xmm_release(r1);
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_div: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r3 = regalloc_xmm_acquire();
+    if (r3 < 0) {
+        regalloc_xmm_release(r2);
+        regalloc_xmm_release(r1);
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_div: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r4 = regalloc_xmm_acquire();
+    if (r4 < 0) {
+        regalloc_xmm_release(r3);
+        regalloc_xmm_release(r2);
+        regalloc_xmm_release(r1);
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_cplx_div: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     const char *x0 = fmt_reg(regalloc_xmm_name(r0), syntax);
     const char *x1 = fmt_reg(regalloc_xmm_name(r1), syntax);
     const char *x2 = fmt_reg(regalloc_xmm_name(r2), syntax);

--- a/src/codegen_float.c
+++ b/src/codegen_float.c
@@ -58,7 +58,18 @@ void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
 {
     char b1[32];
     int r0 = regalloc_xmm_acquire();
+    if (r0 < 0) {
+        fprintf(stderr, "emit_float_binop: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     int r1 = regalloc_xmm_acquire();
+    if (r1 < 0) {
+        regalloc_xmm_release(r0);
+        fprintf(stderr, "emit_float_binop: XMM register allocation failed\n");
+        strbuf_appendf(sb, "    # XMM register allocation failed\n");
+        return;
+    }
     const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
     const char *reg1 = fmt_reg(regalloc_xmm_name(r1), syntax);
     if (syntax == ASM_INTEL) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -326,6 +326,17 @@ if ! "$DIR/shift_rcx" >/dev/null; then
 fi
 rm -f "$DIR/shift_rcx"
 
+# verify fallback when XMM registers are exhausted
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_xmm_fallback.c" \
+    "$DIR/../src/codegen_float.c" "$DIR/../src/codegen_complex.c" \
+    "$DIR/../src/codegen_x86.c" "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/xmm_fallback"
+if ! "$DIR/xmm_fallback" >/dev/null; then
+    echo "Test xmm_fallback failed"
+    fail=1
+fi
+rm -f "$DIR/xmm_fallback"
+
 # negative test for failing static assertion
 err=$(safe_mktemp)
 out=$(safe_mktemp)

--- a/tests/unit/test_xmm_fallback.c
+++ b/tests/unit/test_xmm_fallback.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_float.h"
+#include "strbuf.h"
+#include "regalloc_x86.h"
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int has_fail(const char *s) {
+    return strstr(s, "XMM register allocation failed") != NULL;
+}
+
+int main(void) {
+    ir_instr_t ins = {0};
+    strbuf_t sb;
+
+    regalloc_set_asm_syntax(ASM_ATT);
+
+    /* Exhaust XMM registers and test float binop fallback */
+    regalloc_xmm_reset();
+    while (regalloc_xmm_acquire() >= 0)
+        ;
+    strbuf_init(&sb);
+    emit_float_binop(&sb, &ins, NULL, 0, "addss", ASM_ATT);
+    if (!has_fail(sb.data)) {
+        printf("float binop fallback missing: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Exhaust again and test complex multiply fallback */
+    regalloc_xmm_reset();
+    while (regalloc_xmm_acquire() >= 0)
+        ;
+    strbuf_init(&sb);
+    emit_cplx_mul(&sb, &ins, NULL, 0, ASM_ATT);
+    if (!has_fail(sb.data)) {
+        printf("complex mul fallback missing: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("xmm fallback tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- detect and handle XMM register allocation failures in float and complex emitters
- add test for XMM register exhaustion and hook into test runner

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896c22de5d483249dee80534bf0a60f