### PR TITLE
Handle spill in bitwise operations

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -217,14 +217,19 @@ void emit_bitwise(strbuf_t *sb, ir_instr_t *ins,
                   asm_syntax_t syntax)
 {
     char b1[32];
-    char b2[32];
+    char destb[32];
+    char mem[32];
     const char *sfx = (x64 && ins->type != TYPE_INT) ? "q" : "l";
+    int dest_spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
+    const char *dest_reg = dest_spill ? x86_reg_str(SCRATCH_REG, syntax)
+                                      : x86_loc_str(destb, ra, ins->dest, x64, syntax);
+    const char *dest_mem = x86_loc_str(mem, ra, ins->dest, x64, syntax);
     x86_emit_mov(sb, sfx,
-                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
-                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+                 x86_loc_str(b1, ra, ins->src1, x64, syntax), dest_reg, syntax);
     x86_emit_op(sb, op, sfx,
-                x86_loc_str(b1, ra, ins->src2, x64, syntax),
-                x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
+                x86_loc_str(b1, ra, ins->src2, x64, syntax), dest_reg, syntax);
+    if (dest_spill)
+        x86_emit_mov(sb, sfx, dest_reg, dest_mem, syntax);
 }
 
 void emit_cmp(strbuf_t *sb, ir_instr_t *ins,


### PR DESCRIPTION
## Summary
- use scratch register for bitwise operations when destination is spilled

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6896d88b9d18832498d067344d5e7b05