### PR TITLE
Fix Intel-style store parameter addressing

### DIFF
--- a/src/codegen_mem_x86.c
+++ b/src/codegen_mem_x86.c
@@ -248,8 +248,8 @@ static void emit_store_param(strbuf_t *sb, ir_instr_t *ins,
     const char *sfx = x64 ? "q" : "l";
     int off = 8 + (int)ins->imm * (x64 ? 8 : 4);
     if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    mov%s %d(%s), %s\n", sfx,
-                       off, bp, loc_str(b1, ra, ins->src1, x64, syntax));
+        strbuf_appendf(sb, "    mov%s [%s+%d], %s\n", sfx,
+                       bp, off, loc_str(b1, ra, ins->src1, x64, syntax));
     else
         strbuf_appendf(sb, "    mov%s %s, %d(%s)\n", sfx,
                        loc_str(b1, ra, ins->src1, x64, syntax), off, bp);


### PR DESCRIPTION
## Summary
- Use `[bp+off]` formatting for parameter stores when generating Intel assembly
- Confirm other parameter helpers already follow Intel/AT&T syntax conventions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6897ca3cee44832486d873198c343ff0