### PR TITLE
Handle small integer load/store suffixes

### DIFF
--- a/tests/fixtures/alloca_call_x86-64.s
+++ b/tests/fixtures/alloca_call_x86-64.s
@@ -1,7 +1,7 @@
 caller:
     pushq %rbp
     movq %rsp, %rbp
-    movq 8(%rbp), %rax
+    movl 8(%rbp), %rax
     movq $1, %rbx
     movl %rax, %rcx
     imull %rbx, %rcx
@@ -17,7 +17,7 @@ caller:
     movq %rax, %rsi
     imulq $1, %rsi
     addq %rbx, %rsi
-    movq %rdx, (%rsi)
+    movl %rdx, (%rsi)
     movq %rbp, %rsp
     popq %rbp
     ret

--- a/tests/fixtures/bool_var.s
+++ b/tests/fixtures/bool_var.s
@@ -3,7 +3,8 @@ main:
     movl %esp, %ebp
     subl $4, %esp
     movl $1, %eax
-    movl %eax, -4(%ebp)
+    movl %eax, %eax
+    movb %al, -4(%ebp)
     movl $1, %eax
     movl %eax, %eax
     ret

--- a/tests/fixtures/char_param.s
+++ b/tests/fixtures/char_param.s
@@ -1,7 +1,7 @@
 id:
     pushl %ebp
     movl %esp, %ebp
-    movl 8(%ebp), %eax
+    movsbl 8(%ebp), %eax
     movl %eax, %eax
     ret
     movl %ebp, %esp

--- a/tests/fixtures/char_var.s
+++ b/tests/fixtures/char_var.s
@@ -3,7 +3,8 @@ main:
     movl %esp, %ebp
     subl $4, %esp
     movl $97, %eax
-    movl %eax, -4(%ebp)
+    movl %eax, %eax
+    movb %al, -4(%ebp)
     movl $97, %eax
     movl %eax, %eax
     ret

--- a/tests/fixtures/ldouble_arg_x86-64.s
+++ b/tests/fixtures/ldouble_arg_x86-64.s
@@ -2,7 +2,7 @@ main:
     pushq %rbp
     movq %rsp, %rbp
     movq $1, %rax
-    movq %rax, -0(%rbp)
+    movl %rax, -0(%rbp)
     movq $1, %rax
     sub $16, %rsp
     fldt %rax

--- a/tests/fixtures/mixed_args_x86-64.s
+++ b/tests/fixtures/mixed_args_x86-64.s
@@ -2,9 +2,9 @@ main:
     pushq %rbp
     movq %rsp, %rbp
     movq $2, %rax
-    movq %rax, -0(%rbp)
+    movl %rax, -0(%rbp)
     movq $3, %rax
-    movq %rax, -0(%rbp)
+    movl %rax, -0(%rbp)
     movq $1, %rax
     movq $3, %rbx
     movq $3, %rcx

--- a/tests/fixtures/pointer_basic_x86-64.s
+++ b/tests/fixtures/pointer_basic_x86-64.s
@@ -10,7 +10,7 @@ main:
     movq $42, %rax
     movl %rax, x
     movq p, %rax
-    movq (%rax), %rbx
+    movl (%rax), %rbx
     movq %rbx, %rax
     ret
     movq %rbp, %rsp

--- a/tests/fixtures/short_var.s
+++ b/tests/fixtures/short_var.s
@@ -5,7 +5,8 @@ main:
     pushl %ebp
     movl %esp, %ebp
     movl $1, %eax
-    movl %eax, s
+    movl %eax, %eax
+    movw %ax, s
     movl $1, %eax
     movl %eax, %eax
     ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -209,6 +209,7 @@ rm -f "${out}" "${err}"
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_store_spill.c" \
     "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/load_store_spill"
 if ! "$DIR/load_store_spill" >/dev/null; then
     echo "Test load_store_spill failed"
@@ -219,7 +220,7 @@ rm -f "$DIR/load_store_spill"
 # verify storing through a stack-resident pointer
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_store_ptr_stack.c" \
-    "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_store.c" "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/store_ptr_stack"
 if ! "$DIR/store_ptr_stack" >/dev/null; then
     echo "Test store_ptr_stack failed"
@@ -286,12 +287,25 @@ rm -f "$DIR/cmp_intel"
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_store_idx_scale.c" \
     "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/load_store_idx_scale"
 if ! "$DIR/load_store_idx_scale" >/dev/null; then
     echo "Test load_store_idx_scale failed"
     fail=1
 fi
 rm -f "$DIR/load_store_idx_scale"
+
+# verify loads/stores for small integer types
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_small_int_load_store.c" \
+    "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_x86.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/load_store_small"
+if ! "$DIR/load_store_small" >/dev/null; then
+    echo "Test load_store_small failed"
+    fail=1
+fi
+rm -f "$DIR/load_store_small"
 
 # verify 64-bit int/float cast emission
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \

--- a/tests/unit/test_small_int_load_store.c
+++ b/tests/unit/test_small_int_load_store.c
@@ -1,0 +1,106 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "codegen_loadstore.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Minimal stubs for helpers used by codegen modules. */
+const char *fmt_stack(char buf[32], const char *name, int x64, asm_syntax_t syntax) {
+    (void)buf; (void)x64; (void)syntax; return name;
+}
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int contains(const char *s, const char *sub) {
+    return strstr(s, sub) != NULL;
+}
+
+int main(void) {
+    int locs[3] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    /* destination/source register index 1 -> %eax/%rax */
+    ra.loc[1] = 0;
+
+    /* Signed char load */
+    ins.op = IR_LOAD;
+    ins.dest = 1;
+    ins.name = "c";
+    ins.type = TYPE_CHAR;
+    strbuf_init(&sb);
+    emit_load(&sb, &ins, &ra, 0, ASM_ATT);
+    if (!contains(sb.data, "movsbl")) {
+        printf("load char failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Unsigned char load */
+    ins.type = TYPE_UCHAR;
+    strbuf_init(&sb);
+    emit_load(&sb, &ins, &ra, 0, ASM_ATT);
+    if (!contains(sb.data, "movzbl")) {
+        printf("load uchar failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Signed short load */
+    ins.type = TYPE_SHORT;
+    strbuf_init(&sb);
+    emit_load(&sb, &ins, &ra, 0, ASM_ATT);
+    if (!contains(sb.data, "movswl")) {
+        printf("load short failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Unsigned short load */
+    ins.type = TYPE_USHORT;
+    strbuf_init(&sb);
+    emit_load(&sb, &ins, &ra, 0, ASM_ATT);
+    if (!contains(sb.data, "movzwl")) {
+        printf("load ushort failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Char store */
+    ins.op = IR_STORE;
+    ins.src1 = 1;
+    ins.name = "c";
+    ins.type = TYPE_CHAR;
+    strbuf_init(&sb);
+    emit_store(&sb, &ins, &ra, 0, ASM_ATT);
+    if (!(contains(sb.data, "movb") && contains(sb.data, "%al"))) {
+        printf("store char failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* Short store */
+    ins.type = TYPE_SHORT;
+    strbuf_init(&sb);
+    emit_store(&sb, &ins, &ra, 0, ASM_ATT);
+    if (!(contains(sb.data, "movw") && contains(sb.data, "%ax"))) {
+        printf("store short failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* 64-bit signed char load */
+    ins.type = TYPE_CHAR;
+    strbuf_init(&sb);
+    emit_load(&sb, &ins, &ra, 1, ASM_ATT);
+    if (!contains(sb.data, "movsbq")) {
+        printf("load char x64 failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("small int load/store tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add helper returning load/store suffixes and sign/zero-extension mnemonics
- apply helper across load/store emitters and x86 backend
- test char and short memory accesses and update fixtures

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897cc3aa9888324a63e6216f7e20176