### PR TITLE
Fix Intel float binop dest register

### DIFF
--- a/src/codegen_float.c
+++ b/src/codegen_float.c
@@ -77,15 +77,15 @@ void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
                        loc_str(b1, ra, ins->src1, x64, syntax));
         strbuf_appendf(sb, "    movd %s, %s\n", reg1,
                        loc_str(b1, ra, ins->src2, x64, syntax));
-        strbuf_appendf(sb, "    %s %s, %s\n", op, reg1, reg0);
+        strbuf_appendf(sb, "    %s %s, %s\n", op, reg0, reg1);
         if (ra && ra->loc[ins->dest] >= 0) {
             char b2[32];
             strbuf_appendf(sb, "    movd %s, %s\n",
-                           loc_str(b2, ra, ins->dest, x64, syntax), reg1);
+                           loc_str(b2, ra, ins->dest, x64, syntax), reg0);
         } else {
             char b2[32];
             strbuf_appendf(sb, "    movss %s, %s\n",
-                           loc_str(b2, ra, ins->dest, x64, syntax), reg1);
+                           loc_str(b2, ra, ins->dest, x64, syntax), reg0);
         }
     } else {
         strbuf_appendf(sb, "    movd %s, %s\n",
@@ -103,7 +103,6 @@ void emit_float_binop(strbuf_t *sb, ir_instr_t *ins,
                            loc_str(b2, ra, ins->dest, x64, syntax));
         }
     }
-    ins->dest = r1;
     regalloc_xmm_release(r1);
     regalloc_xmm_release(r0);
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -326,6 +326,17 @@ if ! "$DIR/emit_cast_float_int" >/dev/null; then
 fi
 rm -f "$DIR/emit_cast_float_int"
 
+# verify float binary operation emission
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_emit_float_binop.c" \
+    "$DIR/../src/codegen_float.c" "$DIR/../src/strbuf.c" \
+    "$DIR/../src/regalloc_x86.c" -o "$DIR/emit_float_binop"
+if ! "$DIR/emit_float_binop" >/dev/null; then
+    echo "Test emit_float_binop failed"
+    fail=1
+fi
+rm -f "$DIR/emit_float_binop"
+
 # verify complex addition emission
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_emit_cplx_add.c" \

--- a/tests/unit/test_emit_float_binop.c
+++ b/tests/unit/test_emit_float_binop.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_float.h"
+#include "strbuf.h"
+#include "regalloc_x86.h"
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int check(const char *s, const char *sub, const char *msg) {
+    if (!strstr(s, sub)) {
+        printf("%s failed: %s\n", msg, s);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    ir_instr_t ins = {0};
+    strbuf_t sb;
+    int locs[4] = {0, -1, -2, -3};
+    regalloc_t ra = { .loc = locs };
+    int fail = 0;
+
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.dest = 3;
+
+    strbuf_init(&sb);
+    regalloc_set_x86_64(1);
+
+    /* ATT syntax */
+    regalloc_xmm_reset();
+    regalloc_set_asm_syntax(ASM_ATT);
+    emit_float_binop(&sb, &ins, &ra, 1, "addss", ASM_ATT);
+    fail |= check(sb.data, "addss %xmm0, %xmm1", "ATT op order");
+    fail |= check(sb.data, "movss %xmm1, -24(%rbp)", "ATT dest register");
+    sb.len = 0; if (sb.data) sb.data[0] = '\0';
+
+    /* Intel syntax */
+    regalloc_xmm_reset();
+    regalloc_set_asm_syntax(ASM_INTEL);
+    emit_float_binop(&sb, &ins, &ra, 1, "addss", ASM_INTEL);
+    fail |= check(sb.data, "addss xmm0, xmm1", "Intel op order");
+    fail |= check(sb.data, "movss [rbp-24], xmm0", "Intel dest register");
+
+    strbuf_free(&sb);
+    if (fail) return 1;
+    printf("emit_float_binop tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure SSE float binops in Intel syntax write results from reg0
- drop incorrect `ins->dest` assignment and keep release order
- add unit test verifying float binop emission for both assembly syntaxes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6897e4c0604083248ca5dbce475c9faa