### PR TITLE
Handle spilled index in store operations

### DIFF
--- a/src/codegen_store.c
+++ b/src/codegen_store.c
@@ -144,9 +144,24 @@ void emit_store_idx(strbuf_t *sb, ir_instr_t *ins,
     int scale = idx_scale(ins, x64);
     if (scale != 1 && scale != 2 && scale != 4 && scale != 8)
         scale = 1;
+
+    char b2[32];
+    const char *idx;
+    if (ra && ins->src1 > 0 && ra->loc[ins->src1] < 0) {
+        /* Load spilled index into scratch register. */
+        const char *scratch = reg_str(SCRATCH_REG, syntax);
+        const char *src = loc_str(b2, ra, ins->src1, x64, syntax);
+        const char *psfx = x64 ? "q" : "l";
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    mov%s %s, %s\n", psfx, scratch, src);
+        else
+            strbuf_appendf(sb, "    mov%s %s, %s\n", psfx, src, scratch);
+        idx = scratch;
+    } else {
+        idx = loc_str(b2, ra, ins->src1, x64, syntax);
+    }
+
     if (syntax == ASM_INTEL) {
-        char b2[32];
-        const char *idx = loc_str(b2, ra, ins->src1, x64, syntax);
         const char *b = base;
         char inner[32];
         size_t len = strlen(base);
@@ -162,11 +177,9 @@ void emit_store_idx(strbuf_t *sb, ir_instr_t *ins,
             strbuf_appendf(sb, "    mov%s [%s+%s*%d], %s\n", sfx, b, idx, scale,
                            loc_str(b1, ra, ins->src2, x64, syntax));
     } else {
-        char b2[32];
         strbuf_appendf(sb, "    mov%s %s, %s(,%s,%d)\n", sfx,
                        loc_str(b1, ra, ins->src2, x64, syntax),
-                       base,
-                       loc_str(b2, ra, ins->src1, x64, syntax), scale);
+                       base, idx, scale);
     }
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -304,6 +304,17 @@ if ! "$DIR/load_idx_spill" >/dev/null; then
 fi
 rm -f "$DIR/load_idx_spill"
 
+# verify indexed store with spilled index operand
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_store_idx_spill.c" \
+    "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/store_idx_spill"
+if ! "$DIR/store_idx_spill" >/dev/null; then
+    echo "Test store_idx_spill failed"
+    fail=1
+fi
+rm -f "$DIR/store_idx_spill"
+
 # verify 64-bit int/float cast emission
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_emit_cast_int64.c" \

--- a/tests/unit/test_store_idx_spill.c
+++ b/tests/unit/test_store_idx_spill.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "codegen_loadstore.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Provide minimal stubs required by codegen helpers. */
+const char *fmt_stack(char buf[32], const char *name, int x64,
+                      asm_syntax_t syntax) {
+    (void)x64;
+    if (syntax == ASM_INTEL) {
+        snprintf(buf, 32, "[%s]", name);
+        return buf;
+    }
+    return name;
+}
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int has_invalid(const char *s) {
+    return strstr(s, "[[") || strstr(s, "((");
+}
+
+int main(void) {
+    int locs[3] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    /* index in stack slot, value in register */
+    ra.loc[1] = -1; /* spilled index */
+    ra.loc[2] = 1;  /* value register */
+    ins.op = IR_STORE_IDX;
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.name = "base";
+    ins.type = TYPE_PTR;
+    ins.imm = 4;
+
+    strbuf_init(&sb);
+    emit_store_idx(&sb, &ins, &ra, 0, ASM_ATT);
+    if (has_invalid(sb.data) || !strstr(sb.data, "(,%eax,")) {
+        printf("store idx spill ATT failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_store_idx(&sb, &ins, &ra, 0, ASM_INTEL);
+    if (has_invalid(sb.data) || !strstr(sb.data, "+eax*")) {
+        printf("store idx spill Intel failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("store idx spill tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Load spilled store indices into `SCRATCH_REG` and use it for addressing on both Intel and AT&T syntaxes
- Add unit test verifying stores with spilled index operands

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6897e4d6c134832494846d9053d79336