### PR TITLE
Fix Intel global string pointer emission

### DIFF
--- a/src/codegen_mem_x86.c
+++ b/src/codegen_mem_x86.c
@@ -540,7 +540,7 @@ static void emit_glob_string(strbuf_t *sb, ir_instr_t *ins,
     const char *slot = loc_str(mem, ra, ins->dest, x64, syntax);
     char srcbuf[32];
     if (syntax == ASM_INTEL)
-        snprintf(srcbuf, sizeof(srcbuf), "%s", ins->name);
+        snprintf(srcbuf, sizeof(srcbuf), "OFFSET FLAT:%s", ins->name);
     else
         snprintf(srcbuf, sizeof(srcbuf), "$%s", ins->name);
     emit_move_with_spill(sb, sfx, srcbuf, dest, slot, spill, syntax);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -282,6 +282,18 @@ if ! "$DIR/cmp_intel" >/dev/null; then
 fi
 rm -f "$DIR/cmp_intel"
 
+# verify global string address emission
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_glob_string.c" \
+    "$DIR/../src/codegen_mem_x86.c" "$DIR/../src/codegen_mem_common.c" \
+    "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/glob_string"
+if ! "$DIR/glob_string" >/dev/null; then
+    echo "Test glob_string failed"
+    fail=1
+fi
+rm -f "$DIR/glob_string"
+
 # verify indexed load/store scale handling
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_store_idx_scale.c" \

--- a/tests/unit/test_glob_string.c
+++ b/tests/unit/test_glob_string.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_mem.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+int main(void) {
+    int locs[2] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    ra.loc[1] = 0; /* %eax */
+
+    ins.op = IR_GLOB_STRING;
+    ins.dest = 1;
+    ins.name = "s";
+
+    strbuf_init(&sb);
+    emit_memory_instr(&sb, &ins, &ra, 0, ASM_ATT);
+    const char *exp_att = "    movl $s, %eax\n";
+    if (strcmp(sb.data, exp_att) != 0) {
+        printf("glob_string ATT unexpected: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_memory_instr(&sb, &ins, &ra, 0, ASM_INTEL);
+    const char *exp_intel = "    movl eax, OFFSET FLAT:s\n";
+    if (strcmp(sb.data, exp_intel) != 0) {
+        printf("glob_string Intel unexpected: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("glob_string test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Load string literals by address when generating Intel syntax, using `OFFSET FLAT:`
- Add unit test verifying IR_GLOB_STRING yields pointer in Intel syntax
- Run new test via `tests/run_tests.sh`

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897e6c9b10083248f6d03b0641b6fc2