### PR TITLE
Use movabs for symbol addresses on x86-64

### DIFF
--- a/src/codegen_mem_x86.c
+++ b/src/codegen_mem_x86.c
@@ -295,11 +295,24 @@ static void emit_addr(strbuf_t *sb, ir_instr_t *ins,
             strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, slot, dest);
         return;
     }
-    if (syntax == ASM_INTEL)
-        snprintf(srcbuf, sizeof(srcbuf), "%s", name);
-    else
-        snprintf(srcbuf, sizeof(srcbuf), "$%s", name);
-    emit_move_with_spill(sb, sfx, srcbuf, dest, slot, spill, syntax);
+    if (x64) {
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    movabs %s, %s\n", dest, name);
+        else
+            strbuf_appendf(sb, "    movabsq $%s, %s\n", name, dest);
+        if (spill) {
+            if (syntax == ASM_INTEL)
+                strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, slot, dest);
+            else
+                strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest, slot);
+        }
+    } else {
+        if (syntax == ASM_INTEL)
+            snprintf(srcbuf, sizeof(srcbuf), "%s", name);
+        else
+            snprintf(srcbuf, sizeof(srcbuf), "$%s", name);
+        emit_move_with_spill(sb, sfx, srcbuf, dest, slot, spill, syntax);
+    }
 }
 
 /* Load from a pointer (IR_LOAD_PTR).

--- a/tests/fixtures/pointer_basic_x86-64.s
+++ b/tests/fixtures/pointer_basic_x86-64.s
@@ -5,7 +5,7 @@
 main:
     pushq %rbp
     movq %rsp, %rbp
-    movq $x, %rax
+    movabsq $x, %rax
     movq %rax, p
     movq $42, %rax
     movl %rax, x

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -296,6 +296,18 @@ if ! "$DIR/glob_string" >/dev/null; then
 fi
 rm -f "$DIR/glob_string"
 
+# verify address emission uses movabs in x86-64 mode
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_addr_movabs.c" \
+    "$DIR/../src/codegen_mem_x86.c" "$DIR/../src/codegen_mem_common.c" \
+    "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/addr_movabs"
+if ! "$DIR/addr_movabs" >/dev/null; then
+    echo "Test addr_movabs failed"
+    fail=1
+fi
+rm -f "$DIR/addr_movabs"
+
 # verify indexed load/store scale handling
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_store_idx_scale.c" \

--- a/tests/unit/test_addr_movabs.c
+++ b/tests/unit/test_addr_movabs.c
@@ -1,0 +1,71 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_mem.h"
+#include "strbuf.h"
+#include "regalloc_x86.h"
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int contains(const char *s, const char *sub) { return strstr(s, sub) != NULL; }
+
+int main(void) {
+    int locs[2] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+    int fail = 0;
+
+    regalloc_set_x86_64(1);
+
+    ins.op = IR_ADDR;
+    ins.name = "foo";
+    ins.dest = 1;
+
+    /* Destination in register */
+    ra.loc[1] = 0;
+
+    strbuf_init(&sb);
+    regalloc_set_asm_syntax(ASM_ATT);
+    mem_emitters[IR_ADDR](&sb, &ins, &ra, 1, ASM_ATT);
+    if (!contains(sb.data, "movabs")) {
+        printf("ATT missing movabs: %s\n", sb.data);
+        fail = 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    regalloc_set_asm_syntax(ASM_INTEL);
+    mem_emitters[IR_ADDR](&sb, &ins, &ra, 1, ASM_INTEL);
+    if (!contains(sb.data, "movabs")) {
+        printf("Intel missing movabs: %s\n", sb.data);
+        fail = 1;
+    }
+    strbuf_free(&sb);
+
+    /* Destination spilled to stack */
+    ra.loc[1] = -1;
+
+    strbuf_init(&sb);
+    regalloc_set_asm_syntax(ASM_ATT);
+    mem_emitters[IR_ADDR](&sb, &ins, &ra, 1, ASM_ATT);
+    if (!contains(sb.data, "movabs") || !contains(sb.data, "movq")) {
+        printf("ATT spill failed: %s\n", sb.data);
+        fail = 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    regalloc_set_asm_syntax(ASM_INTEL);
+    mem_emitters[IR_ADDR](&sb, &ins, &ra, 1, ASM_INTEL);
+    if (!contains(sb.data, "movabs") || !contains(sb.data, "movq")) {
+        printf("Intel spill failed: %s\n", sb.data);
+        fail = 1;
+    }
+    strbuf_free(&sb);
+
+    if (!fail)
+        printf("emit_addr movabs tests passed\n");
+    return fail;
+}


### PR DESCRIPTION
## Summary
- emit `movabs` when loading symbol addresses in x86-64 mode and retain spill behavior
- add regression test for `IR_ADDR` and update pointer fixture

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68980373b84483249b2da623991247ae