### PR TITLE
Handle arbitrary index scales in load/store emitters

### DIFF
--- a/src/codegen_store.c
+++ b/src/codegen_store.c
@@ -167,8 +167,7 @@ void emit_store_idx(strbuf_t *sb, ir_instr_t *ins,
     char basebuf[32];
     const char *base = fmt_stack(basebuf, ins->name, x64, syntax);
     int scale = idx_scale(ins, x64);
-    if (scale != 1 && scale != 2 && scale != 4 && scale != 8)
-        scale = 1;
+    int manual = (scale != 1 && scale != 2 && scale != 4 && scale != 8);
 
     const char *val;
     if (ra && ins->src2 > 0 && ra->loc[ins->src2] < 0) {
@@ -186,11 +185,25 @@ void emit_store_idx(strbuf_t *sb, ir_instr_t *ins,
 
     char b2[32];
     const char *idx;
-    if (ra && ins->src1 > 0 && ra->loc[ins->src1] < 0) {
+    const char *psfx = x64 ? "q" : "l";
+    if (manual) {
+        /* Multiply index into scratch register for arbitrary scales. */
+        const char *scratch = reg_str(SCRATCH_REG, syntax);
+        const char *src = loc_str(b2, ra, ins->src1, x64, syntax);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    mov%s %s, %s\n", psfx, scratch, src);
+        else
+            strbuf_appendf(sb, "    mov%s %s, %s\n", psfx, src, scratch);
+        if (syntax == ASM_INTEL)
+            strbuf_appendf(sb, "    imul%s %s, %s, %d\n", psfx, scratch, scratch, scale);
+        else
+            strbuf_appendf(sb, "    imul%s $%d, %s, %s\n", psfx, scale, scratch, scratch);
+        idx = scratch;
+        scale = 1;
+    } else if (ra && ins->src1 > 0 && ra->loc[ins->src1] < 0) {
         /* Load spilled index into scratch register. */
         const char *scratch = reg_str(SCRATCH_REG, syntax);
         const char *src = loc_str(b2, ra, ins->src1, x64, syntax);
-        const char *psfx = x64 ? "q" : "l";
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    mov%s %s, %s\n", psfx, scratch, src);
         else


### PR DESCRIPTION
## Summary
- manually multiply indices with non-standard scale factors before using them in memory operations
- apply the same logic to x86 load index emission

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689805ec005083249b6a91910776452e