### PR TITLE
Handle arbitrary index scales in loads

### DIFF
--- a/tests/unit/test_load_store_idx_scale.c
+++ b/tests/unit/test_load_store_idx_scale.c
@@ -157,6 +157,52 @@ int main(void) {
         strbuf_free(&sb);
     }
 
+    /* manual scale not supported by addressing modes */
+    ins.imm = 3;
+
+    /* load */
+    ins.op = IR_LOAD_IDX;
+    strbuf_init(&sb);
+    emit_load_idx(&sb, &ins, &ra, 1, ASM_ATT);
+    if (!strstr(sb.data, "imulq") || !strstr(sb.data, "$3") ||
+        !strstr(sb.data, ",1)") || strstr(sb.data, ",3)")) {
+        printf("load idx manual ATT failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_load_idx(&sb, &ins, &ra, 1, ASM_INTEL);
+    if (!strstr(sb.data, "imulq") || !strstr(sb.data, ", 3") ||
+        !strstr(sb.data, "[base+") || strstr(sb.data, "*3") ||
+        strstr(sb.data, "[[base")) {
+        printf("load idx manual Intel failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    /* store */
+    ins.op = IR_STORE_IDX;
+    ins.src2 = 2;
+    strbuf_init(&sb);
+    emit_store_idx(&sb, &ins, &ra, 1, ASM_ATT);
+    if (!strstr(sb.data, "imulq") || !strstr(sb.data, "$3") ||
+        !strstr(sb.data, ",1)") || strstr(sb.data, ",3)")) {
+        printf("store idx manual ATT failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_store_idx(&sb, &ins, &ra, 1, ASM_INTEL);
+    if (!strstr(sb.data, "imulq") || !strstr(sb.data, ", 3") ||
+        !strstr(sb.data, "[base+") || strstr(sb.data, "*3") ||
+        strstr(sb.data, "[[base")) {
+        printf("store idx manual Intel failed: %s\n", sb.data);
+        return 1;
+    }
+    strbuf_free(&sb);
+
     printf("load/store idx scale tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- Multiply IR index in scratch register when scale isn't 1/2/4/8 before forming load address
- Add tests for manual index scaling to verify load/store index handling

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68981cb2f00c8324bffb400cf0a35f29