### PR TITLE
codegen: always restore stack after calls

### DIFF
--- a/src/codegen_branch.c
+++ b/src/codegen_branch.c
@@ -135,7 +135,9 @@ static void emit_return(strbuf_t *sb, ir_instr_t *ins,
     strbuf_append(sb, "    ret\n");
 }
 
-/* Emit a call instruction (IR_CALL). */
+/* Emit a call instruction (IR_CALL).
+ * Stack space for arguments and alignment is always restored with an
+ * add instruction when non-zero. */
 static void emit_call(strbuf_t *sb, ir_instr_t *ins,
                       regalloc_t *ra, int x64,
                       const char *sfx, const char *ax, const char *sp,
@@ -154,7 +156,9 @@ static void emit_call(strbuf_t *sb, ir_instr_t *ins,
     }
     strbuf_appendf(sb, "    call %s\n", ins->name);
     size_t total = arg_stack_bytes + align;
-    if (ins->imm > 0 && total > 0) {
+    /* Always restore any stack space used for arguments or alignment,
+       regardless of the instruction's immediate. */
+    if (total > 0) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    add%s %s, %zu\n", sfx, sp, total);
         else
@@ -173,7 +177,9 @@ static void emit_call(strbuf_t *sb, ir_instr_t *ins,
     }
 }
 
-/* Emit an indirect call instruction (IR_CALL_PTR). */
+/* Emit an indirect call instruction (IR_CALL_PTR).
+ * Stack space for arguments and alignment is always restored with an
+ * add instruction when non-zero. */
 static void emit_call_ptr(strbuf_t *sb, ir_instr_t *ins,
                           regalloc_t *ra, int x64,
                           const char *sfx, const char *ax, const char *sp,
@@ -195,7 +201,9 @@ static void emit_call_ptr(strbuf_t *sb, ir_instr_t *ins,
     else
         strbuf_appendf(sb, "    call *%s\n", loc_str(buf, ra, ins->src1, x64, syntax));
     size_t total = arg_stack_bytes + align;
-    if (ins->imm > 0 && total > 0) {
+    /* Always restore any stack space used for arguments or alignment,
+       regardless of the instruction's immediate. */
+    if (total > 0) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    add%s %s, %zu\n", sfx, sp, total);
         else

--- a/tests/fixtures/call_sret.c
+++ b/tests/fixtures/call_sret.c
@@ -1,0 +1,3 @@
+struct S { int a; };
+struct S foo(void) { struct S s = { 5 }; return s; }
+int main() { struct S s = foo(); return s.a; }

--- a/tests/fixtures/call_sret.s
+++ b/tests/fixtures/call_sret.s
@@ -1,0 +1,40 @@
+foo:
+    pushl %ebp
+    movl %esp, %ebp
+    leal -0(%ebp), %ebx
+    movl $0, %ecx
+    movl %ecx, %edx
+    imull $1, %edx
+    addl %ebx, %edx
+    movl $5, %ecx
+    movl %ecx, (%edx)
+    movl -0(%ebp), %ecx
+    movl 8(%ebp), %eax
+    movl %ecx, (%eax)
+    movl %eax, (%eax)
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret
+main:
+    pushl %ebp
+    movl %esp, %ebp
+    movl $4, %eax
+    subl %eax, %esp
+    movl %esp, %ecx
+    pushl %ecx
+    call foo
+    addl $4, %esp
+    movl %eax, %eax
+    movl %ecx, -0(%ebp)
+    leal -0(%ebp), %ecx
+    movl $0, %edx
+    movl %edx, %ebx
+    imull $1, %ebx
+    addl %ecx, %ebx
+    movl (%ebx), %edx
+    movl %edx, %eax
+    ret
+    movl %ebp, %esp
+    popl %ebp
+    ret

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -407,6 +407,17 @@ if ! "$DIR/xmm_fallback" >/dev/null; then
 fi
 rm -f "$DIR/xmm_fallback"
 
+# verify stack cleanup after function calls
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_call_stack_cleanup.c" \
+    "$DIR/../src/codegen_branch.c" "$DIR/../src/strbuf.c" \
+    "$DIR/../src/regalloc_x86.c" -o "$DIR/call_stack_cleanup"
+if ! "$DIR/call_stack_cleanup" >/dev/null; then
+    echo "Test call_stack_cleanup failed"
+    fail=1
+fi
+rm -f "$DIR/call_stack_cleanup"
+
 # negative test for failing static assertion
 err=$(safe_mktemp)
 out=$(safe_mktemp)

--- a/tests/unit/test_call_stack_cleanup.c
+++ b/tests/unit/test_call_stack_cleanup.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_branch.h"
+#include "strbuf.h"
+#include "regalloc_x86.h"
+
+size_t arg_stack_bytes;
+int arg_reg_idx;
+int float_reg_idx;
+int export_syms;
+int dwarf_enabled;
+
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int check(const char *out, const char *exp, const char *name) {
+    if (strcmp(out, exp) != 0) {
+        printf("%s unexpected: %s\n", name, out);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    strbuf_t sb;
+    int locs[2] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    int fail = 0;
+
+    regalloc_set_asm_syntax(ASM_ATT);
+
+    /* direct call with hidden stack args but zero arg count */
+    ir_instr_t ins = { .op = IR_CALL, .imm = 0, .name = "foo", .type = TYPE_INT, .dest = 0 };
+    arg_stack_bytes = 4;
+    strbuf_init(&sb);
+    emit_branch_instr(&sb, &ins, &ra, 0, ASM_ATT);
+    fail |= check(sb.data, "    call foo\n    addl $4, %esp\n", "direct");
+    strbuf_free(&sb);
+
+    /* indirect call with alignment adjustment */
+    regalloc_set_x86_64(1);
+    ra.loc[1] = 2; /* %rcx */
+    ins.op = IR_CALL_PTR;
+    ins.src1 = 1;
+    arg_stack_bytes = 8;
+    strbuf_init(&sb);
+    emit_branch_instr(&sb, &ins, &ra, 1, ASM_ATT);
+    fail |= check(sb.data, "    subq $8, %rsp\n    call *%rcx\n    addq $16, %rsp\n", "indirect");
+    strbuf_free(&sb);
+
+    if (!fail)
+        printf("call stack cleanup tests passed\n");
+    return fail;
+}


### PR DESCRIPTION
## Summary
- ensure call emitters always restore stack space used for arguments
- add regression tests for stack cleanup after direct and indirect calls
- document unconditional stack restoration in call emitters

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68981df7eb8883249961a1097b9e5fa4