### PR TITLE
Centralize scratch register indices

### DIFF
--- a/include/regalloc.h
+++ b/include/regalloc.h
@@ -18,6 +18,16 @@
 #include "ir_core.h"
 
 /*
+ * Indices of scratch registers kept out of the general allocation pool.
+ *
+ * REGALLOC_SCRATCH_REG is always available for temporary values. Some
+ * store operations may require a second temporary register which is
+ * provided by REGALLOC_SCRATCH_REG2.
+ */
+#define REGALLOC_SCRATCH_REG  0
+#define REGALLOC_SCRATCH_REG2 1
+
+/*
  * Location mapping for IR values returned by the allocator.
  *
  * `loc[i]` holds the location assigned to value `i`.  Non-negative

--- a/src/codegen_arith_float.c
+++ b/src/codegen_arith_float.c
@@ -6,7 +6,7 @@
 #include "codegen_arith_float.h"
 #include "regalloc_x86.h"
 #include "consteval.h"
-#define SCRATCH_REG 0
+#include "regalloc.h"
 
 static const char *reg_str(int reg, asm_syntax_t syntax)
 {
@@ -172,7 +172,7 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     int spill_src = ra && ra->loc[ins->src1] < 0;
     int spill_dest = ra && ra->loc[ins->dest] < 0;
     if (spill_src && spill_dest) {
-        const char *tmp = reg_str(SCRATCH_REG, syntax);
+        const char *tmp = reg_str(REGALLOC_SCRATCH_REG, syntax);
         if (syntax == ASM_INTEL) {
             strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, tmp,
                            loc_str(b1, ra, ins->src1, x64, syntax));

--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -11,8 +11,8 @@
 #include "codegen_x86.h"
 #include "regalloc_x86.h"
 #include "label.h"
+#include "regalloc.h"
 
-#define SCRATCH_REG 0
 
 void emit_ptr_add(strbuf_t *sb, ir_instr_t *ins,
                   regalloc_t *ra, int x64,
@@ -53,7 +53,7 @@ void emit_ptr_diff(strbuf_t *sb, ir_instr_t *ins,
     while (power_two && (tmp >>= 1) > 0) shift++;
 
     int dest_spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
-    const char *dest_reg = dest_spill ? x86_reg_str(SCRATCH_REG, syntax)
+    const char *dest_reg = dest_spill ? x86_reg_str(REGALLOC_SCRATCH_REG, syntax)
                                       : x86_loc_str(b2, ra, ins->dest, x64, syntax);
     const char *dest_mem = x86_loc_str(mem, ra, ins->dest, x64, syntax);
 
@@ -118,7 +118,7 @@ void emit_int_arith(strbuf_t *sb, ir_instr_t *ins,
     char mem[32];
     const char *sfx = (x64 && ins->type != TYPE_INT) ? "q" : "l";
     int dest_spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
-    const char *dest_reg = dest_spill ? x86_reg_str(SCRATCH_REG, syntax)
+    const char *dest_reg = dest_spill ? x86_reg_str(REGALLOC_SCRATCH_REG, syntax)
                                       : x86_loc_str(destb, ra, ins->dest, x64, syntax);
     const char *dest_mem = x86_loc_str(mem, ra, ins->dest, x64, syntax);
     x86_emit_mov(sb, sfx,
@@ -186,7 +186,7 @@ void emit_shift(strbuf_t *sb, ir_instr_t *ins,
     const char *cl = x86_fmt_reg("%cl", syntax);
     int dest_is_cx = (ra && ins->dest > 0 && ra->loc[ins->dest] == 2);
     if (dest_is_cx) {
-        const char *scratch = x86_reg_str(SCRATCH_REG, syntax);
+        const char *scratch = x86_reg_str(REGALLOC_SCRATCH_REG, syntax);
         const char *dest = x86_loc_str(b2, ra, ins->dest, x64, syntax);
         x86_emit_mov(sb, sfx,
                      x86_loc_str(b1, ra, ins->src1, x64, syntax), scratch, syntax);
@@ -221,7 +221,7 @@ void emit_bitwise(strbuf_t *sb, ir_instr_t *ins,
     char mem[32];
     const char *sfx = (x64 && ins->type != TYPE_INT) ? "q" : "l";
     int dest_spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
-    const char *dest_reg = dest_spill ? x86_reg_str(SCRATCH_REG, syntax)
+    const char *dest_reg = dest_spill ? x86_reg_str(REGALLOC_SCRATCH_REG, syntax)
                                       : x86_loc_str(destb, ra, ins->dest, x64, syntax);
     const char *dest_mem = x86_loc_str(mem, ra, ins->dest, x64, syntax);
     x86_emit_mov(sb, sfx,

--- a/src/regalloc.c
+++ b/src/regalloc.c
@@ -26,8 +26,12 @@
 #include "regalloc.h"
 #include "regalloc_x86.h"
 
-#define SCRATCH_REG (REGALLOC_NUM_REGS - 1)
-#define NUM_REGS REGALLOC_NUM_REGS
+/*
+ * One register is reserved for temporary values during code generation.
+ * The allocator itself never hands out this register so that codegen can
+ * freely use it for spills.  Its index is exposed via REGALLOC_SCRATCH_REG
+ * in regalloc.h.
+ */
 #define NUM_ALLOC_REGS (REGALLOC_NUM_REGS - 1)
 
 /*


### PR DESCRIPTION
## Summary
- Export scratch register indices via `regalloc.h`
- Update codegen helpers to use `REGALLOC_SCRATCH_REG` constants

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689a582eec64832487fdc3fbe6527811