### PR TITLE
Use scratch register for memory comparisons

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -238,6 +238,7 @@ void emit_cmp(strbuf_t *sb, ir_instr_t *ins,
 {
     char b1[32];
     char b2[32];
+    char destb[32];
     const char *sfx = (x64 && ins->type != TYPE_INT) ? "q" : "l";
     const char *cc = "";
     switch (ins->op) {
@@ -250,20 +251,27 @@ void emit_cmp(strbuf_t *sb, ir_instr_t *ins,
     default: break;
     }
     const char *al = x86_fmt_reg("%al", syntax);
-    x86_emit_mov(sb, sfx,
-                 x86_loc_str(b1, ra, ins->src1, x64, syntax),
-                 x86_loc_str(b2, ra, ins->dest, x64, syntax), syntax);
-    if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
-                       x86_loc_str(b2, ra, ins->dest, x64, syntax),
-                       x86_loc_str(b1, ra, ins->src2, x64, syntax));
-    else
-        strbuf_appendf(sb, "    cmp%s %s, %s\n", sfx,
-                       x86_loc_str(b1, ra, ins->src2, x64, syntax),
-                       x86_loc_str(b2, ra, ins->dest, x64, syntax));
+
+    int src1_spill = (ra && ins->src1 > 0 && ra->loc[ins->src1] < 0);
+    int src2_spill = (ra && ins->src2 > 0 && ra->loc[ins->src2] < 0);
+    int dest_spill = (ra && ins->dest > 0 && ra->loc[ins->dest] < 0);
+
+    const char *lhs;
+    if (src1_spill || src2_spill || dest_spill) {
+        const char *scratch = x86_reg_str(REGALLOC_SCRATCH_REG, syntax);
+        x86_emit_mov(sb, sfx,
+                     x86_loc_str(b1, ra, ins->src1, x64, syntax), scratch,
+                     syntax);
+        lhs = scratch;
+    } else {
+        lhs = x86_loc_str(b1, ra, ins->src1, x64, syntax);
+    }
+
+    const char *rhs = x86_loc_str(b2, ra, ins->src2, x64, syntax);
+    x86_emit_op(sb, "cmp", sfx, rhs, lhs, syntax);
     strbuf_appendf(sb, "    set%s %s\n", cc, al);
     int loc = ra ? ra->loc[ins->dest] : 0;
-    const char *dest = x86_loc_str(b2, ra, ins->dest, x64, syntax);
+    const char *dest = x86_loc_str(destb, ra, ins->dest, x64, syntax);
     if (loc < 0) {
         /* Destination on stack: write byte, then zero-extend via scratch register. */
         x86_emit_mov(sb, "b", al, dest, syntax);

--- a/tests/fixtures/do_while_loop.s
+++ b/tests/fixtures/do_while_loop.s
@@ -10,8 +10,7 @@ L0_start:
 L0_cond:
     movl -4(%ebp), %eax
     movl $3, %ebx
-    movl %eax, %ecx
-    cmpl %ebx, %ecx
+    cmpl %ebx, %eax
     setl %al
     movzbl %al, %ecx
     cmpl $0, %ecx

--- a/tests/fixtures/loops_O0.s
+++ b/tests/fixtures/loops_O0.s
@@ -15,8 +15,7 @@ main:
 L0_start:
     movl -12(%ebp), %eax
     movl -4(%ebp), %ebx
-    movl %eax, %ecx
-    cmpl %ebx, %ecx
+    cmpl %ebx, %eax
     setle %al
     movzbl %al, %ecx
     cmpl $0, %ecx

--- a/tests/fixtures/pointer_compare.s
+++ b/tests/fixtures/pointer_compare.s
@@ -16,8 +16,7 @@ main:
     movl %ecx, p2
     movl p1, %ecx
     movl p2, %ebx
-    movl %ecx, %eax
-    cmpl %ebx, %eax
+    cmpl %ebx, %ecx
     setl %al
     movzbl %al, %eax
     movl %eax, %eax

--- a/tests/fixtures/varargs_wrapper.s
+++ b/tests/fixtures/varargs_wrapper.s
@@ -20,8 +20,7 @@ sum:
 L0_start:
     movl $0, %ecx
     movl 8(%ebp), %ebx
-    movl %ecx, %eax
-    cmpl %ebx, %eax
+    cmpl %ebx, %ecx
     setl %al
     movzbl %al, %eax
     cmpl $0, %eax

--- a/tests/unit/test_cmp_intel.c
+++ b/tests/unit/test_cmp_intel.c
@@ -47,8 +47,24 @@ int main(void) {
     emit_cmp(&sb, &ins, &ra, 0, ASM_INTEL);
     const char *out = sb.data;
     int fail = 0;
-    if (!contains(out, "cmpl ecx, ebx") || contains(out, "cmpl ebx, ecx")) {
+    if (!contains(out, "cmpl eax, ebx") || contains(out, "cmpl ebx, eax")) {
         printf("intel cmp order failed: %s\n", out);
+        fail = 1;
+    }
+    strbuf_free(&sb);
+
+    /* Both operands spilled */
+    ra.loc[1] = -1; /* stack slot */
+    ra.loc[2] = -2; /* stack slot */
+    ra.loc[3] = 2;  /* %ecx */
+
+    strbuf_init(&sb);
+    emit_cmp(&sb, &ins, &ra, 0, ASM_INTEL);
+    out = sb.data;
+    if (!contains(out, "movl eax, [ebp-4]") ||
+        !contains(out, "cmpl eax, [ebp-8]") ||
+        contains(out, "cmpl [ebp-8], [ebp-4]")) {
+        printf("intel double spill failed: %s\n", out);
         fail = 1;
     }
     strbuf_free(&sb);


### PR DESCRIPTION
## Summary
- Ensure integer comparisons load at least one operand into a scratch register when any operand or destination is spilled
- Write comparison result back correctly after using the scratch register
- Add unit tests and update fixtures for cases where both operands spill

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8a83c94c83248152ad1ee2583b24