### PR TITLE
Omit size suffix in Intel x86 output

### DIFF
--- a/src/codegen_x86.c
+++ b/src/codegen_x86.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include "codegen_x86.h"
 #include "regalloc_x86.h"
 
@@ -43,19 +44,29 @@ void x86_emit_mov(strbuf_t *sb, const char *sfx,
                   const char *src, const char *dest,
                   asm_syntax_t syntax)
 {
-    if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest, src);
-    else
+    if (syntax == ASM_INTEL) {
+        if (strcmp(sfx, "b") == 0 || strcmp(sfx, "w") == 0 ||
+            strcmp(sfx, "l") == 0 || strcmp(sfx, "q") == 0)
+            strbuf_appendf(sb, "    mov %s, %s\n", dest, src);
+        else
+            strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, dest, src);
+    } else {
         strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, src, dest);
+    }
 }
 
 void x86_emit_op(strbuf_t *sb, const char *op, const char *sfx,
                  const char *src, const char *dest,
                  asm_syntax_t syntax)
 {
-    if (syntax == ASM_INTEL)
-        strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, dest, src);
-    else
+    if (syntax == ASM_INTEL) {
+        if (strcmp(sfx, "b") == 0 || strcmp(sfx, "w") == 0 ||
+            strcmp(sfx, "l") == 0 || strcmp(sfx, "q") == 0)
+            strbuf_appendf(sb, "    %s %s, %s\n", op, dest, src);
+        else
+            strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, dest, src);
+    } else {
         strbuf_appendf(sb, "    %s%s %s, %s\n", op, sfx, src, dest);
+    }
 }
 

--- a/src/compile_output.c
+++ b/src/compile_output.c
@@ -50,6 +50,8 @@ static const char nasm_macros[] =
     "%macro imulq 2\n    imul %1, %2\n%endmacro\n"
     "%macro cmpl 2\n    cmp %1, %2\n%endmacro\n"
     "%macro cmpq 2\n    cmp %1, %2\n%endmacro\n"
+    "%macro leal 2\n    lea %1, %2\n%endmacro\n"
+    "%macro leaq 2\n    lea %1, %2\n%endmacro\n"
     "%macro pushl 1\n    push %1\n%endmacro\n"
     "%macro pushq 1\n    push %1\n%endmacro\n"
     "%macro popl 1\n    pop %1\n%endmacro\n"

--- a/tests/fixtures/pointer_add_intel.s
+++ b/tests/fixtures/pointer_add_intel.s
@@ -9,9 +9,9 @@ main:
     movl p, eax
     movl eax, p
     movl ebx, 1
-    movl ecx, ebx
+    mov ecx, ebx
     imull ecx, 4
-    addl ecx, eax
+    add ecx, eax
     movl p, ecx
     movl ecx, 1
     movl ebx, 5

--- a/tests/fixtures/shift_var_intel.s
+++ b/tests/fixtures/shift_var_intel.s
@@ -6,21 +6,21 @@ main:
     movl [ebp-4], eax
     movl eax, 1
     movl ebx, [ebp-8]
-    movl eax, eax
-    movl ecx, ebx
+    mov eax, eax
+    mov ecx, ebx
     sal eax, cl
-    movl ecx, eax
+    mov ecx, eax
     movl [ebp-12], ecx
     movl ecx, 1
     movl ebx, [ebp-8]
-    movl eax, ecx
-    movl ecx, ebx
+    mov eax, ecx
+    mov ecx, ebx
     sar eax, cl
     movl [ebp-16], eax
     movl eax, [ebp-12]
     movl ebx, [ebp-16]
-    movl ecx, eax
-    addl ecx, ebx
+    mov ecx, eax
+    add ecx, ebx
     movl eax, ecx
     ret
     movl esp, ebp

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -902,34 +902,22 @@ if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
 fi
 rm -f "${obj_out}"
 
-# test --intel-syntax --compile option (requires nasm)
+# test Intel syntax assembler output (requires nasm)
 if command -v nasm >/dev/null; then
-    obj_tmp=$(safe_mktemp tmp.XXXXXX)
-    obj_out="${obj_tmp}.o"
-    rm -f "${obj_tmp}"
-    "$BINARY" --intel-syntax -c -o "${obj_out}" "$DIR/fixtures/simple_add.c"
-    if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
-        echo "Test compile_option_intel failed"
-        fail=1
-    fi
-    rm -f "${obj_out}"
+    for src in simple_add.c pointer_add.c while_loop.c shift_var.c \
+               float_add.c float_sub.c; do
+        obj_tmp=$(safe_mktemp tmp.XXXXXX)
+        obj_out="${obj_tmp}.o"
+        rm -f "${obj_tmp}"
+        "$BINARY" --intel-syntax -c -o "${obj_out}" "$DIR/fixtures/$src"
+        if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
+            echo "Test assemble_intel $(basename "$src" .c) failed"
+            fail=1
+        fi
+        rm -f "${obj_out}"
+    done
 else
-    echo "Skipping compile_option_intel (nasm not found)"
-fi
-
-# test --intel-syntax --compile with shift operations (requires nasm)
-if command -v nasm >/dev/null; then
-    obj_tmp=$(safe_mktemp tmp.XXXXXX)
-    obj_out="${obj_tmp}.o"
-    rm -f "${obj_tmp}"
-    "$BINARY" --intel-syntax -c -o "${obj_out}" "$DIR/fixtures/shift_var.c"
-    if ! od -An -t x1 "${obj_out}" | head -n 1 | grep -q "7f 45 4c 46"; then
-        echo "Test compile_option_shift_intel failed"
-        fail=1
-    fi
-    rm -f "${obj_out}"
-else
-    echo "Skipping compile_option_shift_intel (nasm not found)"
+    echo "Skipping assemble_intel (nasm not found)"
 fi
 
 # test --emit-dwarf option

--- a/tests/unit/test_cmp_intel.c
+++ b/tests/unit/test_cmp_intel.c
@@ -47,7 +47,7 @@ int main(void) {
     emit_cmp(&sb, &ins, &ra, 0, ASM_INTEL);
     const char *out = sb.data;
     int fail = 0;
-    if (!contains(out, "cmpl eax, ebx") || contains(out, "cmpl ebx, eax")) {
+    if (!contains(out, "cmp eax, ebx") || contains(out, "cmp ebx, eax")) {
         printf("intel cmp order failed: %s\n", out);
         fail = 1;
     }
@@ -61,9 +61,9 @@ int main(void) {
     strbuf_init(&sb);
     emit_cmp(&sb, &ins, &ra, 0, ASM_INTEL);
     out = sb.data;
-    if (!contains(out, "movl eax, [ebp-4]") ||
-        !contains(out, "cmpl eax, [ebp-8]") ||
-        contains(out, "cmpl [ebp-8], [ebp-4]")) {
+    if (!contains(out, "mov eax, [ebp-4]") ||
+        !contains(out, "cmp eax, [ebp-8]") ||
+        contains(out, "cmp [ebp-8], [ebp-4]")) {
         printf("intel double spill failed: %s\n", out);
         fail = 1;
     }


### PR DESCRIPTION
## Summary
- drop `b/w/l/q` suffixes for Intel-mode `mov` and ALU ops
- extend NASM macro support for `lea` to assemble Intel fixtures
- add assembler regression tests for Intel syntax

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac8c9934988324a3eb2a71bf2eafe0