### PR TITLE
Handle spilled division destination

### DIFF
--- a/src/codegen_arith_int.c
+++ b/src/codegen_arith_int.c
@@ -143,12 +143,15 @@ void emit_div(strbuf_t *sb, ir_instr_t *ins,
     strbuf_appendf(sb, "    %s\n", x64 ? "cqto" : "cltd");
     strbuf_appendf(sb, "    idiv%s %s\n", sfx,
                    x86_loc_str(b1, ra, ins->src2, x64, syntax));
-    if (ra && ra->loc[ins->dest] >= 0 &&
-        strcmp(regalloc_reg_name(ra->loc[ins->dest]), ax) != 0) {
-        char b2[32];
-        x86_emit_mov(sb, sfx, ax,
-                     x86_loc_str(b2, ra, ins->dest, x64, syntax),
-                     syntax);
+    if (ra && ins->dest > 0) {
+        int dest_loc = ra->loc[ins->dest];
+        if (dest_loc < 0 ||
+            strcmp(regalloc_reg_name(dest_loc), ax) != 0) {
+            char b2[32];
+            x86_emit_mov(sb, sfx, ax,
+                         x86_loc_str(b2, ra, ins->dest, x64, syntax),
+                         syntax);
+        }
     }
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -262,6 +262,17 @@ if ! "$DIR/ptr_add_spill" >/dev/null; then
 fi
 rm -f "$DIR/ptr_add_spill"
 
+# verify division with spilled destination
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_div_spill.c" \
+    "$DIR/../src/codegen_arith_int.c" "$DIR/../src/codegen_x86.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/div_spill"
+if ! "$DIR/div_spill" >/dev/null; then
+    echo "Test div_spill failed"
+    fail=1
+fi
+rm -f "$DIR/div_spill"
+
 # verify memory to memory casts
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_cast_mem2mem.c" \

--- a/tests/unit/test_div_spill.c
+++ b/tests/unit/test_div_spill.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen_arith_int.h"
+#include "strbuf.h"
+#include "regalloc.h"
+
+/* Stubs required by codegen_arith_int.c */
+const char *label_format_suffix(char buf[32], const char *prefix, int id,
+                                const char *suffix) { (void)buf; (void)prefix; (void)id; (void)suffix; return ""; }
+void emit_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                           int x64, asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax, const char *op) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; (void)op; }
+void emit_cplx_mul(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cplx_div(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+void emit_cast(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+               asm_syntax_t syntax) { (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; }
+int label_next_id(void) { return 0; }
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+static int contains(const char *s, const char *sub) { return strstr(s, sub) != NULL; }
+
+int main(void) {
+    int locs[4] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins;
+    strbuf_t sb;
+
+    ins.op = IR_DIV;
+    ins.dest = 3;
+    ins.src1 = 1;
+    ins.src2 = 2;
+    ins.type = TYPE_INT;
+
+    ra.loc[1] = 1;  /* %ebx */
+    ra.loc[2] = 2;  /* %ecx */
+    ra.loc[3] = -1; /* spilled destination */
+
+    strbuf_init(&sb);
+    emit_div(&sb, &ins, &ra, 0, ASM_ATT);
+    const char *out = sb.data;
+    if (!contains(out, "idivl %ecx") ||
+        !contains(out, "movl %eax, -4(%ebp)")) {
+        printf("div spill ATT failed: %s\n", out);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    strbuf_init(&sb);
+    emit_div(&sb, &ins, &ra, 0, ASM_INTEL);
+    out = sb.data;
+    if (!contains(out, "idivl ecx") ||
+        !contains(out, "mov [ebp-4], eax")) {
+        printf("div spill Intel failed: %s\n", out);
+        return 1;
+    }
+    strbuf_free(&sb);
+
+    printf("div spill tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- move idiv result in rax/eax into stack slot when destination is spilled
- add unit test for division with spilled destination and wire into test runner

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aca5aa0fd08324a685afef978e7533