### PR TITLE
Handle _vc_exit return value

### DIFF
--- a/libc/internal/_vc_syscalls.h
+++ b/libc/internal/_vc_syscalls.h
@@ -31,7 +31,7 @@ long _vc_write(int, const void *, unsigned long);
 long _vc_read(int, void *, unsigned long);
 long _vc_open(const char *, int, int);
 long _vc_close(int);
-void _vc_exit(int) __attribute__((noreturn));
+long _vc_exit(int);
 void _exit(int) __attribute__((noreturn));
 void *_vc_malloc(unsigned long);
 void _vc_free(void *);

--- a/libc/src/pthread.c
+++ b/libc/src/pthread.c
@@ -16,11 +16,13 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
     const char msg[] =
         "vc libc is single-threaded; pthread_create unsupported\n";
     _vc_write(2, msg, sizeof(msg) - 1);
-    void (*exit_ptr)(int) = _vc_exit;
-    exit_ptr(1);
-    const char fail[] = "vc libc: exit syscall failed\n";
-    _vc_write(2, fail, sizeof(fail) - 1);
-    exit_ptr(1);
-    _exit(1);
+    long (*exit_ptr)(int) = _vc_exit;
+    long ret = exit_ptr(1);
+    if (ret < 0) {
+        const char fail[] = "vc libc: exit syscall failed\n";
+        _vc_write(2, fail, sizeof(fail) - 1);
+        _exit(1);
+    }
+    return -1;
 }
 

--- a/libc/src/stdlib.c
+++ b/libc/src/stdlib.c
@@ -6,12 +6,14 @@ void _exit(int) __attribute__((noreturn));
 void exit(int status) __attribute__((noreturn));
 void exit(int status)
 {
-    void (*vc_exit_ptr)(int) = _vc_exit;
-    vc_exit_ptr(status);
-    const char msg[] = "vc libc: exit syscall failed\n";
-    _vc_write(2, msg, sizeof(msg) - 1);
-    vc_exit_ptr(1);
-    _exit(1);
+    long (*vc_exit_ptr)(int) = _vc_exit;
+    long ret = vc_exit_ptr(status);
+    if (ret < 0) {
+        const char msg[] = "vc libc: exit syscall failed\n";
+        _vc_write(2, msg, sizeof(msg) - 1);
+        _exit(1);
+    }
+    __builtin_unreachable();
 }
 
 void *malloc(size_t size)

--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -39,20 +39,9 @@ long _vc_close(int fd)
     SYSCALL_INVOKE(VC_SYS_CLOSE, fd, 0, 0);
 }
 
-void _vc_exit(int status)
+long _vc_exit(int status)
 {
-#ifdef __x86_64__
-    __asm__ volatile ("syscall"
-                      :
-                      : "a"(VC_SYS_EXIT), "D"(status)
-                      : "rcx", "r11", "memory");
-#elif defined(__i386__)
-    __asm__ volatile ("int $0x80"
-                      :
-                      : "a"(VC_SYS_EXIT), "b"(status)
-                      : "memory");
-#endif
-    __builtin_unreachable();
+    SYSCALL_INVOKE(VC_SYS_EXIT, status, 0, 0);
 }
 
 static unsigned long cur_brk = 0;

--- a/tests/unit/fail_vcexit.c
+++ b/tests/unit/fail_vcexit.c
@@ -1,3 +1,4 @@
-void _vc_exit(int status) {
+long _vc_exit(int status) {
     (void)status;
+    return -1;
 }


### PR DESCRIPTION
## Summary
- Make `exit` and `pthread_create` check `_vc_exit`'s return value
- Update `_vc_exit` to return a status code and expose this in the syscall header
- Adjust tests to simulate a failing `_vc_exit`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68acac6f1298832496f040921fd979e1