### PR TITLE
libc: add perror implementation

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -8,7 +8,7 @@ INCLUDEDIR ?= $(PREFIX)/include/vc
 CAN_COMPILE_32 := $(shell $(CC) -m32 -xc /dev/null -o /dev/null \
     >/dev/null 2>&1 && echo yes || echo no)
 
-SRC := src/stdio.c src/stdlib.c src/string.c src/syscalls.c src/file.c \
+SRC := src/stdio.c src/perror.c src/stdlib.c src/string.c src/syscalls.c src/file.c \
        src/pthread.c src/_exit.c src/errno.c
 HDR := include/stdarg.h include/stddef.h include/stdio.h \
        include/stdlib.h include/string.h include/pthread.h include/errno.h

--- a/libc/src/perror.c
+++ b/libc/src/perror.c
@@ -1,0 +1,47 @@
+#include <stddef.h>
+#include <string.h>
+#include "errno.h"
+#include "stdio.h"
+#include "../internal/_vc_syscalls.h"
+
+void perror(const char *msg)
+{
+    int err = *_errno_location();
+    char buf[64];
+    size_t pos = 0;
+
+    if (msg && *msg) {
+        size_t len = strlen(msg);
+        if (len > sizeof(buf) - 2)
+            len = sizeof(buf) - 2;
+        memcpy(buf, msg, len);
+        pos = len;
+        if (pos < sizeof(buf))
+            buf[pos++] = ':';
+        if (pos < sizeof(buf))
+            buf[pos++] = ' ';
+    }
+
+    char num[32];
+    char *p = num + sizeof(num);
+    unsigned int u = (unsigned int)err;
+    if (u == 0) {
+        *--p = '0';
+    } else {
+        while (u) {
+            *--p = (char)('0' + (u % 10));
+            u /= 10;
+        }
+    }
+    size_t nlen = (size_t)(num + sizeof(num) - p);
+    if (nlen > sizeof(buf) - pos - 1)
+        nlen = sizeof(buf) - pos - 1;
+    memcpy(buf + pos, p, nlen);
+    pos += nlen;
+
+    if (pos < sizeof(buf))
+        buf[pos++] = '\n';
+
+    _vc_write(2, buf, pos);
+}
+


### PR DESCRIPTION
## Summary
- implement `perror` using `_vc_write` and `_errno_location`
- compile `perror` as part of libc build

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68acae6ad830832485eb406c2184f8cc