### PR TITLE
Set errno after open and malloc failures

### DIFF
--- a/libc/src/file.c
+++ b/libc/src/file.c
@@ -40,11 +40,14 @@ FILE *fopen(const char *path, const char *mode)
     }
 
     long fd = _vc_open(path, flags, perm);
-    if (fd < 0)
+    if (fd < 0) {
+        errno = -fd;
         return NULL;
+    }
 
     FILE *f = malloc(sizeof(FILE));
     if (!f) {
+        errno = ENOMEM;
         _vc_close(fd);
         return NULL;
     }

--- a/libc/src/tmpfile.c
+++ b/libc/src/tmpfile.c
@@ -9,10 +9,12 @@ FILE *tmpfile(void)
 #ifdef O_TMPFILE
     long fd = _vc_open(".", O_TMPFILE | O_RDWR, 0600);
     if (fd < 0) {
+        errno = -fd;
         return NULL;
     }
     FILE *f = malloc(sizeof(FILE));
     if (!f) {
+        errno = ENOMEM;
         _vc_close(fd);
         return NULL;
     }


### PR DESCRIPTION
## Summary
- set errno to -fd when `_vc_open` fails in `fopen` and `tmpfile`
- set errno to `ENOMEM` on `malloc` failure before closing descriptor

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68acb6cd14b483249cb5914b2c5932e7