### PR TITLE
regalloc: add helper for 32-bit register names

### DIFF
--- a/include/regalloc_x86.h
+++ b/include/regalloc_x86.h
@@ -34,6 +34,12 @@
  */
 const char *regalloc_reg_name(int idx);
 
+/*
+ * Return the 32-bit CPU register name for allocator index `idx` regardless
+ * of the current 64-bit naming mode.
+ */
+const char *regalloc_reg_name32(int idx);
+
 /* Allocate and release temporary XMM registers. */
 int regalloc_xmm_acquire(void);
 void regalloc_xmm_release(int reg);

--- a/src/regalloc_x86.c
+++ b/src/regalloc_x86.c
@@ -61,6 +61,24 @@ const char *regalloc_reg_name(int idx)
     return name;
 }
 
+/*
+ * Return the 32-bit textual CPU register name for the allocator index `idx`.
+ *
+ * This helper always consults the 32-bit register table, ignoring the
+ * global 64-bit naming mode.  It is useful when a canonical 32-bit name
+ * ("%eax", "%ebx", ...) is required even when 64-bit mode has been
+ * selected globally.
+ */
+const char *regalloc_reg_name32(int idx)
+{
+    const char *name = "%eax";
+    if (idx >= 0 && idx < REGALLOC_NUM_REGS)
+        name = phys_regs_32[idx];
+    if (current_syntax == ASM_INTEL && name[0] == '%')
+        return name + 1;
+    return name;
+}
+
 /* Return textual name of an XMM register. */
 const char *regalloc_xmm_name(int idx)
 {


### PR DESCRIPTION
## Summary
- add `regalloc_reg_name32` helper to always choose 32-bit register names
- export the new API in `regalloc_x86.h`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68acc0f1212c8324b677a41418c864f1