### PR TITLE
Handle 32-bit register names for x86 codegen

### DIFF
--- a/include/codegen_x86.h
+++ b/include/codegen_x86.h
@@ -6,10 +6,10 @@
 #include "regalloc.h"
 #include "cli.h"
 
-const char *x86_reg_str(int reg, asm_syntax_t syntax);
+const char *x86_reg_str(int reg, const char *sfx, asm_syntax_t syntax);
 const char *x86_fmt_reg(const char *name, asm_syntax_t syntax);
 const char *x86_loc_str(char buf[32], regalloc_t *ra, int id, int x64,
-                        asm_syntax_t syntax);
+                        const char *sfx, asm_syntax_t syntax);
 
 void x86_emit_mov(strbuf_t *sb, const char *sfx,
                   const char *src, const char *dest,

--- a/src/codegen_x86.c
+++ b/src/codegen_x86.c
@@ -3,9 +3,13 @@
 #include "codegen_x86.h"
 #include "regalloc_x86.h"
 
-const char *x86_reg_str(int reg, asm_syntax_t syntax)
+const char *x86_reg_str(int reg, const char *sfx, asm_syntax_t syntax)
 {
-    const char *name = regalloc_reg_name(reg);
+    const char *name;
+    if (sfx && strcmp(sfx, "l") == 0)
+        name = regalloc_reg_name32(reg);
+    else
+        name = regalloc_reg_name(reg);
     if (syntax == ASM_INTEL && name[0] == '%')
         return name + 1;
     return name;
@@ -19,13 +23,13 @@ const char *x86_fmt_reg(const char *name, asm_syntax_t syntax)
 }
 
 const char *x86_loc_str(char buf[32], regalloc_t *ra, int id, int x64,
-                        asm_syntax_t syntax)
+                        const char *sfx, asm_syntax_t syntax)
 {
     if (!ra || id <= 0)
         return "";
     int loc = ra->loc[id];
     if (loc >= 0)
-        return x86_reg_str(loc, syntax);
+        return x86_reg_str(loc, sfx, syntax);
     if (x64) {
         if (syntax == ASM_INTEL)
             snprintf(buf, 32, "[rbp-%d]", -loc * 8);


### PR DESCRIPTION
## Summary
- Recognize 32-bit instruction suffixes when formatting x86 registers
- Use width-aware register names for register and location helpers
- Propagate suffix information through integer arithmetic emitters

## Testing
- `make test` (fails: Some tests failed)


------
https://chatgpt.com/codex/tasks/task_e_68acc1ce59c88324893e0c709233a73c