### PR TITLE
Disable stack protector in libc build

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 PROJECT_ROOT := $(abspath ..)
-CFLAGS ?= -Wall -Wextra -std=c99 -DPROJECT_ROOT=\"$(PROJECT_ROOT)\"
+CFLAGS ?= -Wall -Wextra -std=c99 -DPROJECT_ROOT=\"$(PROJECT_ROOT)\" -fno-stack-protector
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include/vc
 


### PR DESCRIPTION
## Summary
- build libc with `-fno-stack-protector` to avoid stack canary dependency

## Testing
- `make -C libc clean all`
- `make`
- `cd examples && ../vc --link --internal-libc --x86-64 -o hello hello.c && ./hello`


------
https://chatgpt.com/codex/tasks/task_e_68acccf4eac48324afb3f68e6accff2b