### PR TITLE
Add test assembling 32-bit code

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -85,3 +85,10 @@ Counts the number of lines in `example.txt`. Run with:
 ```sh
 ./file_count
 ```
+
+### movl_32bit.s
+Demonstrates assembling a single 32-bit instruction. Assemble with:
+
+```sh
+as movl_32bit.s -o movl_32bit.o
+```

--- a/examples/movl_32bit.s
+++ b/examples/movl_32bit.s
@@ -1,0 +1,2 @@
+# Demonstrates assembling a 32-bit move instruction
+movl %eax, %ecx

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -471,6 +471,17 @@ if ! "$DIR/shift_rcx" >/dev/null; then
 fi
 rm -f "$DIR/shift_rcx"
 
+# verify assembling generated 32-bit code with system as
+cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
+    "$DIR/unit/test_code_gen_32bit_as.c" \
+    "$DIR/../src/codegen_arith_int.c" "$DIR/../src/codegen_x86.c" \
+    "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/code_gen_32bit_as"
+if ! "$DIR/code_gen_32bit_as" >/dev/null; then
+    echo "Test code_gen_32bit_as failed"
+    fail=1
+fi
+rm -f "$DIR/code_gen_32bit_as"
+
 # verify fallback when XMM registers are exhausted
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_xmm_fallback.c" \

--- a/tests/unit/test_code_gen_32bit_as.c
+++ b/tests/unit/test_code_gen_32bit_as.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "codegen_arith_int.h"
+#include "strbuf.h"
+#include "regalloc_x86.h"
+
+/* Stub implementations required by codegen_arith_int.c */
+const char *label_format_suffix(char buf[32], const char *prefix, int id,
+                                const char *suffix) {
+    (void)buf; (void)prefix; (void)id; (void)suffix; return "";
+}
+void emit_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra,
+                           int x64, asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_cplx_addsub(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                      asm_syntax_t syntax, const char *op) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax; (void)op;
+}
+void emit_cplx_mul(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_cplx_div(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+                   asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+void emit_cast(strbuf_t *sb, ir_instr_t *ins, regalloc_t *ra, int x64,
+               asm_syntax_t syntax) {
+    (void)sb; (void)ins; (void)ra; (void)x64; (void)syntax;
+}
+int label_next_id(void) { return 0; }
+void *vc_alloc_or_exit(size_t sz) { return malloc(sz); }
+void *vc_realloc_or_exit(void *p, size_t sz) { return realloc(p, sz); }
+
+int main(void) {
+    int locs[4] = {0};
+    regalloc_t ra = { .loc = locs, .stack_slots = 0 };
+    ir_instr_t ins = { .op = IR_SHL, .src1 = 1, .src2 = 2, .dest = 3, .type = TYPE_INT };
+    strbuf_t sb;
+    char asmfile[L_tmpnam];
+    char obj[sizeof asmfile + 2];
+    char cmd[sizeof asmfile + sizeof obj + 10];
+
+    regalloc_set_asm_syntax(ASM_ATT);
+    regalloc_set_x86_64(0);
+    ra.loc[1] = 3; /* %edx */
+    ra.loc[2] = 1; /* %ebx */
+    ra.loc[3] = 2; /* %ecx */
+
+    strbuf_init(&sb);
+    emit_shift(&sb, &ins, &ra, 0, "shl", ASM_ATT);
+
+    if (!tmpnam(asmfile)) {
+        perror("tmpnam");
+        strbuf_free(&sb);
+        return 1;
+    }
+    FILE *f = fopen(asmfile, "w");
+    fputs(sb.data, f);
+    fclose(f);
+    strbuf_free(&sb);
+
+    snprintf(obj, sizeof obj, "%s.o", asmfile);
+    snprintf(cmd, sizeof cmd, "as %s -o %s", asmfile, obj);
+    int ret = system(cmd);
+    unlink(asmfile);
+    unlink(obj);
+    if (ret != 0) {
+        printf("as failed\n");
+        return 1;
+    }
+    printf("32-bit assembly assembled successfully\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit test that emits a 32-bit shift sequence and assembles it with `as`
- wire new test into test harness
- document a simple 32-bit assembly example

## Testing
- `./tests/run_tests.sh` *(fails: Test alloca_call failed)*
- `cc -I include -Wall -Wextra -std=c99 tests/unit/test_code_gen_32bit_as.c src/codegen_arith_int.c src/codegen_x86.c src/strbuf.c src/regalloc_x86.c -o /tmp/test_code_gen_32bit_as && /tmp/test_code_gen_32bit_as`


------
https://chatgpt.com/codex/tasks/task_e_68acccd8f32883249e0f9d91931034f8