### PR TITLE
Fix 32-bit register naming in x86 codegen

### DIFF
--- a/src/codegen_arith_float.c
+++ b/src/codegen_arith_float.c
@@ -8,9 +8,10 @@
 #include "consteval.h"
 #include "regalloc.h"
 
-static const char *reg_str(int reg, asm_syntax_t syntax)
+static const char *reg_str(int reg, int size, asm_syntax_t syntax)
 {
-    const char *name = regalloc_reg_name(reg);
+    const char *name = (size == 4) ? regalloc_reg_name32(reg)
+                                  : regalloc_reg_name(reg);
     if (syntax == ASM_INTEL && name[0] == '%')
         return name + 1;
     return name;
@@ -24,13 +25,13 @@ static const char *fmt_reg(const char *name, asm_syntax_t syntax)
 }
 
 static const char *loc_str(char buf[32], regalloc_t *ra, int id, int x64,
-                           asm_syntax_t syntax)
+                           int size, asm_syntax_t syntax)
 {
     if (!ra || id <= 0)
         return "";
     int loc = ra->loc[id];
     if (loc >= 0)
-        return reg_str(loc, syntax);
+        return reg_str(loc, size, syntax);
     if (x64) {
         if (syntax == ASM_INTEL)
             snprintf(buf, 32, "[rbp-%d]", -loc * 8);
@@ -56,6 +57,8 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     type_kind_t dst = (type_kind_t)(ins->imm & 0xffffffffu);
     int src64 = (src == TYPE_LLONG || src == TYPE_ULLONG);
     int dst64 = (dst == TYPE_LLONG || dst == TYPE_ULLONG);
+    int src_size = src64 ? 8 : 4;
+    int dst_size = dst64 ? 8 : 4;
 
     int r0 = regalloc_xmm_acquire();
     if (r0 < 0) {
@@ -65,21 +68,22 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     }
     const char *reg0 = fmt_reg(regalloc_xmm_name(r0), syntax);
     const char *sfx = x64 ? "q" : "l";
+    int regsize = (sfx[0] == 'l') ? 4 : 8;
 
     if (is_intlike(src) && dst == TYPE_FLOAT) {
         const char *op = src64 ? "cvtsi2ssq" : "cvtsi2ss";
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
-                           loc_str(b1, ra, ins->src1, x64, syntax));
+                           loc_str(b1, ra, ins->src1, x64, src_size, syntax));
         else
             strbuf_appendf(sb, "    %s %s, %s\n", op,
-                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+                           loc_str(b1, ra, ins->src1, x64, src_size, syntax), reg0);
         if (ra && ra->loc[ins->dest] >= 0)
             strbuf_appendf(sb, "    movd %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 4, syntax));
         else
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 4, syntax));
         regalloc_xmm_release(r0);
         return;
     }
@@ -88,16 +92,16 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
         const char *op = src64 ? "cvtsi2sdq" : "cvtsi2sd";
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
-                           loc_str(b1, ra, ins->src1, x64, syntax));
+                           loc_str(b1, ra, ins->src1, x64, src_size, syntax));
         else
             strbuf_appendf(sb, "    %s %s, %s\n", op,
-                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+                           loc_str(b1, ra, ins->src1, x64, src_size, syntax), reg0);
         if (ra && ra->loc[ins->dest] >= 0)
             strbuf_appendf(sb, "    movq %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 8, syntax));
         else
             strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 8, syntax));
         regalloc_xmm_release(r0);
         return;
     }
@@ -105,17 +109,17 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     if (src == TYPE_FLOAT && is_intlike(dst)) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
-                           loc_str(b1, ra, ins->src1, x64, syntax));
+                           loc_str(b1, ra, ins->src1, x64, 4, syntax));
         else
             strbuf_appendf(sb, "    movss %s, %s\n",
-                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+                           loc_str(b1, ra, ins->src1, x64, 4, syntax), reg0);
         const char *op = dst64 ? "cvttss2siq" : "cvttss2si";
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    %s %s, %s\n", op,
-                           loc_str(b2, ra, ins->dest, x64, syntax), reg0);
+                           loc_str(b2, ra, ins->dest, x64, dst_size, syntax), reg0);
         else
             strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, dst_size, syntax));
         regalloc_xmm_release(r0);
         return;
     }
@@ -123,17 +127,17 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     if (src == TYPE_DOUBLE && is_intlike(dst)) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                           loc_str(b1, ra, ins->src1, x64, syntax));
+                           loc_str(b1, ra, ins->src1, x64, 8, syntax));
         else
             strbuf_appendf(sb, "    movsd %s, %s\n",
-                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+                           loc_str(b1, ra, ins->src1, x64, 8, syntax), reg0);
         const char *op = dst64 ? "cvttsd2siq" : "cvttsd2si";
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    %s %s, %s\n", op,
-                           loc_str(b2, ra, ins->dest, x64, syntax), reg0);
+                           loc_str(b2, ra, ins->dest, x64, dst_size, syntax), reg0);
         else
             strbuf_appendf(sb, "    %s %s, %s\n", op, reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, dst_size, syntax));
         regalloc_xmm_release(r0);
         return;
     }
@@ -141,17 +145,17 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     if (src == TYPE_FLOAT && dst == TYPE_DOUBLE) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
-                           loc_str(b1, ra, ins->src1, x64, syntax));
+                           loc_str(b1, ra, ins->src1, x64, 4, syntax));
         else
             strbuf_appendf(sb, "    movss %s, %s\n",
-                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+                           loc_str(b1, ra, ins->src1, x64, 4, syntax), reg0);
         strbuf_appendf(sb, "    cvtss2sd %s, %s\n", reg0, reg0);
         if (ra && ra->loc[ins->dest] >= 0)
             strbuf_appendf(sb, "    movq %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 8, syntax));
         else
             strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 8, syntax));
         regalloc_xmm_release(r0);
         return;
     }
@@ -159,17 +163,17 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     if (src == TYPE_DOUBLE && dst == TYPE_FLOAT) {
         if (syntax == ASM_INTEL)
             strbuf_appendf(sb, "    movsd %s, %s\n", reg0,
-                           loc_str(b1, ra, ins->src1, x64, syntax));
+                           loc_str(b1, ra, ins->src1, x64, 8, syntax));
         else
             strbuf_appendf(sb, "    movsd %s, %s\n",
-                           loc_str(b1, ra, ins->src1, x64, syntax), reg0);
+                           loc_str(b1, ra, ins->src1, x64, 8, syntax), reg0);
         strbuf_appendf(sb, "    cvtsd2ss %s, %s\n", reg0, reg0);
         if (ra && ra->loc[ins->dest] >= 0)
             strbuf_appendf(sb, "    movd %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 4, syntax));
         else
             strbuf_appendf(sb, "    movss %s, %s\n", reg0,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, 4, syntax));
         regalloc_xmm_release(r0);
         return;
     }
@@ -177,17 +181,17 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
     int spill_src = ra && ra->loc[ins->src1] < 0;
     int spill_dest = ra && ra->loc[ins->dest] < 0;
     if (spill_src && spill_dest) {
-        const char *tmp = reg_str(REGALLOC_SCRATCH_REG, syntax);
+        const char *tmp = reg_str(REGALLOC_SCRATCH_REG, regsize, syntax);
         if (syntax == ASM_INTEL) {
             strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, tmp,
-                           loc_str(b1, ra, ins->src1, x64, syntax));
+                           loc_str(b1, ra, ins->src1, x64, regsize, syntax));
             strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                           loc_str(b2, ra, ins->dest, x64, syntax), tmp);
+                           loc_str(b2, ra, ins->dest, x64, regsize, syntax), tmp);
         } else {
             strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                           loc_str(b1, ra, ins->src1, x64, syntax), tmp);
+                           loc_str(b1, ra, ins->src1, x64, regsize, syntax), tmp);
             strbuf_appendf(sb, "    mov%s %s, %s\n", sfx, tmp,
-                           loc_str(b2, ra, ins->dest, x64, syntax));
+                           loc_str(b2, ra, ins->dest, x64, regsize, syntax));
         }
         regalloc_xmm_release(r0);
         return;
@@ -195,12 +199,12 @@ void emit_cast(strbuf_t *sb, ir_instr_t *ins,
 
     if (syntax == ASM_INTEL)
         strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b2, ra, ins->dest, x64, syntax),
-                       loc_str(b1, ra, ins->src1, x64, syntax));
+                       loc_str(b2, ra, ins->dest, x64, regsize, syntax),
+                       loc_str(b1, ra, ins->src1, x64, regsize, syntax));
     else
         strbuf_appendf(sb, "    mov%s %s, %s\n", sfx,
-                       loc_str(b1, ra, ins->src1, x64, syntax),
-                       loc_str(b2, ra, ins->dest, x64, syntax));
+                       loc_str(b1, ra, ins->src1, x64, regsize, syntax),
+                       loc_str(b2, ra, ins->dest, x64, regsize, syntax));
     regalloc_xmm_release(r0);
 }
 
@@ -211,9 +215,9 @@ void emit_long_float_binop(strbuf_t *sb, ir_instr_t *ins,
 {
     char b1[32];
     char b2[32];
-    strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src1, x64, syntax));
-    strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src2, x64, syntax));
+    strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src1, x64, x64 ? 8 : 4, syntax));
+    strbuf_appendf(sb, "    fldt %s\n", loc_str(b1, ra, ins->src2, x64, x64 ? 8 : 4, syntax));
     strbuf_appendf(sb, "    %s\n", op);
-    strbuf_appendf(sb, "    fstpt %s\n", loc_str(b2, ra, ins->dest, x64, syntax));
+    strbuf_appendf(sb, "    fstpt %s\n", loc_str(b2, ra, ins->dest, x64, x64 ? 8 : 4, syntax));
 }
 


### PR DESCRIPTION
## Summary
- ensure x86 emitters use 32-bit register names for 32-bit ops
- pass operand size through load/store and float helpers
- rebuild examples to verify assembler errors

## Testing
- `make`
- `./examples/build_examples.sh` *(fails: copy_string, file_count, file_io, gcd, malloc_sum)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2a7c7db083248e937c5f617afa4e