### PR TITLE
Allow pointer arguments in calls and test example compilation

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -151,6 +151,17 @@ else
 fi
 rm -f "$asmfile" "$objfile"
 
+# ensure all example programs compile successfully with the internal libc
+for src in "$DIR/../examples"/*.c; do
+    [ -e "$src" ] || continue
+    exe=$(safe_mktemp)
+    if ! "$BINARY" --x86-64 --internal-libc --link -o "$exe" "$src" >/dev/null 2>&1; then
+        echo "Test example_$(basename "$src" .c) failed"
+        fail=1
+    fi
+    rm -f "$exe" "$exe.s" "$exe.o" "$exe.log" 2>/dev/null || true
+done
+
 # negative test for parse error message
 err=$(safe_mktemp)
 out=$(safe_mktemp)


### PR DESCRIPTION
## Summary
- relax function-call argument checking to permit array decay and pointer arguments
- exercise example programs in test suite to ensure they compile

## Testing
- `make`
- `tests/run_tests.sh` *(fails: Test example_copy_string failed, Test example_file_count failed, Test example_file_io failed, Test example_gcd failed, Test example_malloc_sum failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3153158083248263e4c9cc089b4c