### PR TITLE
Improve semantic error reporting

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -28,6 +28,7 @@ void error_set(size_t line, size_t col, const char *file, const char *func);
  * error_set().
  */
 void error_print(const char *msg);
+void error_printf(const char *fmt, ...);
 
 /* Current context used by error diagnostics */
 extern const char *error_current_file;

--- a/src/compile_stage.c
+++ b/src/compile_stage.c
@@ -79,7 +79,7 @@ static int register_function_prototypes(func_t **func_list, size_t fcount,
                     mismatch = 1;
             if (mismatch) {
                 error_set(0, 0, error_current_file, error_current_function);
-                error_print("Semantic error");
+                error_printf("conflicting declarations for function '%s'", func_list[i]->name);
                 return 0;
             }
             existing->is_prototype = 0;
@@ -109,10 +109,8 @@ static int check_global_decls(stmt_t **glob_list, size_t gcount,
                               symtable_t *globals, ir_builder_t *ir)
 {
     for (size_t i = 0; i < gcount; i++) {
-        if (!check_global(glob_list[i], globals, ir)) {
-            error_print("Semantic error");
+        if (!check_global(glob_list[i], globals, ir))
             return 0;
-        }
     }
     return 1;
 }
@@ -122,10 +120,8 @@ static int check_function_defs(func_t **func_list, size_t fcount,
                                ir_builder_t *ir)
 {
     for (size_t i = 0; i < fcount; i++) {
-        if (!check_func(func_list[i], funcs, globals, ir)) {
-            error_print("Semantic error");
+        if (!check_func(func_list[i], funcs, globals, ir))
             return 0;
-        }
     }
     return 1;
 }

--- a/src/error.c
+++ b/src/error.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stdarg.h>
 #include "error.h"
 
 /* Active file and function for diagnostics */
@@ -57,5 +58,15 @@ void error_print(const char *msg)
     if (color)
         fprintf(stderr, "\x1b[0m");
     fputc('\n', stderr);
+}
+
+void error_printf(const char *fmt, ...)
+{
+    char buf[256];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    error_print(buf);
 }
 

--- a/src/semantic_call.c
+++ b/src/semantic_call.c
@@ -37,6 +37,7 @@ type_kind_t check_call_expr(expr_t *expr, symtable_t *vars,
         if (!fsym || fsym->type != TYPE_PTR ||
             fsym->func_ret_type == TYPE_UNKNOWN) {
             error_set(expr->line, expr->column, error_current_file, error_current_function);
+            error_printf("undeclared function '%s'", expr->data.call.name);
             return TYPE_UNKNOWN;
         }
         via_ptr = 1;
@@ -49,6 +50,7 @@ type_kind_t check_call_expr(expr_t *expr, symtable_t *vars,
     if ((!variadic && expected != expr->data.call.arg_count) ||
         (variadic && expr->data.call.arg_count < expected)) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
+        error_printf("wrong number of arguments to function '%s'", expr->data.call.name);
         return TYPE_UNKNOWN;
     }
     ir_value_t *vals = NULL;
@@ -87,6 +89,7 @@ type_kind_t check_call_expr(expr_t *expr, symtable_t *vars,
                 ok = 1;
             if (!ok) {
                 error_set(expr->data.call.args[i]->line, expr->data.call.args[i]->column, error_current_file, error_current_function);
+                error_printf("incompatible argument %zu in call to '%s'", i + 1, expr->data.call.name);
                 free(vals);
                 free(atypes);
                 return TYPE_UNKNOWN;

--- a/src/semantic_control.c
+++ b/src/semantic_control.c
@@ -159,6 +159,7 @@ static char **emit_case_branches(stmt_t *stmt, symtable_t *vars,
                 free(labels);
                 free(values);
                 error_set(STMT_SWITCH(stmt).cases[i].expr->line, STMT_SWITCH(stmt).cases[i].expr->column, error_current_file, error_current_function);
+                error_printf("duplicate case label '%lld'", cval);
                 return NULL;
             }
         }

--- a/src/semantic_decl_stmt.c
+++ b/src/semantic_decl_stmt.c
@@ -144,6 +144,7 @@ static symbol_t *register_var_symbol(stmt_t *stmt, symtable_t *vars)
     if (STMT_VAR_DECL(stmt).is_const && !STMT_VAR_DECL(stmt).init &&
         !STMT_VAR_DECL(stmt).init_list) {
         error_set(stmt->line, stmt->column, error_current_file, error_current_function);
+        error_printf("const variable '%s' requires an initializer", STMT_VAR_DECL(stmt).name);
         return NULL;
     }
     symbol_t *sym = insert_var_symbol(stmt, vars, ir_name);

--- a/src/semantic_expr.c
+++ b/src/semantic_expr.c
@@ -58,6 +58,7 @@ static type_kind_t check_ident_expr(expr_t *expr, symtable_t *vars,
             return TYPE_PTR;
         }
         error_set(expr->line, expr->column, error_current_file, error_current_function);
+        error_printf("undeclared identifier '%s'", expr->data.ident.name);
         if (out)
             *out = (ir_value_t){0};
         return TYPE_UNKNOWN;
@@ -217,7 +218,7 @@ static type_kind_t check_assign_expr(expr_t *expr, symtable_t *vars,
     symbol_t *sym = symtable_lookup(vars, expr->data.assign.name);
     if (!sym) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
-        error_print("unknown identifier");
+        error_printf("assignment to undeclared variable '%s'", expr->data.assign.name);
         if (out)
             *out = (ir_value_t){0};
         return TYPE_UNKNOWN;
@@ -226,7 +227,7 @@ static type_kind_t check_assign_expr(expr_t *expr, symtable_t *vars,
     /* Step 2: const protection */
     if (sym->is_const) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
-        error_print("assignment to const");
+        error_printf("assignment to const variable '%s'", expr->data.assign.name);
         if (out)
             *out = (ir_value_t){0};
         return TYPE_UNKNOWN;
@@ -236,7 +237,7 @@ static type_kind_t check_assign_expr(expr_t *expr, symtable_t *vars,
     type_kind_t vt = check_expr(expr->data.assign.value, vars, funcs, ir, &val);
     if (!types_compatible(sym->type, vt)) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
-        error_print("incompatible types in assignment");
+        error_printf("incompatible types in assignment to '%s'", expr->data.assign.name);
         if (out)
             *out = (ir_value_t){0};
         return TYPE_UNKNOWN;

--- a/src/semantic_mem.c
+++ b/src/semantic_mem.c
@@ -75,6 +75,7 @@ type_kind_t check_index_expr(expr_t *expr, symtable_t *vars,
     (void)funcs;
     if (expr->data.index.array->kind != EXPR_IDENT) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
+        error_printf("accessing inactive union member '%s'", expr->data.member.member);
         return TYPE_UNKNOWN;
     }
     symbol_t *sym = symtable_lookup(vars, expr->data.index.array->data.ident.name);
@@ -329,6 +330,7 @@ type_kind_t check_member_expr(expr_t *expr, symtable_t *vars,
     if (!expr->data.member.via_ptr && obj_sym && obj_sym->type == TYPE_UNION &&
         obj_sym->active_member && strcmp(obj_sym->active_member, expr->data.member.member) != 0) {
         error_set(expr->line, expr->column, error_current_file, error_current_function);
+        error_printf("accessing inactive union member '%s'", expr->data.member.member);
         return TYPE_UNKNOWN;
     }
 

--- a/tests/invalid/undef_func.c
+++ b/tests/invalid/undef_func.c
@@ -1,0 +1,4 @@
+int main() {
+    foo();
+    return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -192,7 +192,7 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/undef_var.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "undeclared identifier 'x'" "${err}"; then
     echo "Test undef_var failed"
     fail=1
 fi
@@ -205,7 +205,7 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/const_assign.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "assignment to const variable 'x'" "${err}"; then
     echo "Test const_assign failed"
     fail=1
 fi
@@ -218,7 +218,7 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/const_no_init.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "const variable 'x' requires an initializer" "${err}"; then
     echo "Test const_no_init failed"
     fail=1
 fi
@@ -231,7 +231,7 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/undef_cond.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "undeclared identifier 'x'" "${err}"; then
     echo "Test undef_cond failed"
     fail=1
 fi
@@ -244,8 +244,21 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/undef_assign.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "assignment to undeclared variable 'y'" "${err}"; then
     echo "Test undef_assign failed"
+    fail=1
+fi
+rm -f "${out}" "${err}"
+
+# negative test for call to undeclared function
+err=$(safe_mktemp)
+out=$(safe_mktemp)
+set +e
+"$BINARY" -o "${out}" "$DIR/invalid/undef_func.c" 2> "${err}"
+ret=$?
+set -e
+if [ $ret -eq 0 ] || ! grep -q "undeclared function 'foo'" "${err}"; then
+    echo "Test undef_func failed"
     fail=1
 fi
 rm -f "${out}" "${err}"
@@ -254,6 +267,7 @@ rm -f "${out}" "${err}"
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_store_spill.c" \
     "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/load_store_spill"
 if ! "$DIR/load_store_spill" >/dev/null; then
     echo "Test load_store_spill failed"
@@ -265,6 +279,7 @@ rm -f "$DIR/load_store_spill"
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_store_ptr_stack.c" \
     "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/store_ptr_stack"
 if ! "$DIR/store_ptr_stack" >/dev/null; then
     echo "Test store_ptr_stack failed"
@@ -276,6 +291,7 @@ rm -f "$DIR/store_ptr_stack"
 cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_load_ptr_stack.c" \
     "$DIR/../src/codegen_load.c" \
+    "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/load_ptr_stack"
 if ! "$DIR/load_ptr_stack" >/dev/null; then
     echo "Test load_ptr_stack failed"
@@ -354,6 +370,7 @@ cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_glob_string.c" \
     "$DIR/../src/codegen_mem_x86.c" "$DIR/../src/codegen_mem_common.c" \
     "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/glob_string"
 if ! "$DIR/glob_string" >/dev/null; then
     echo "Test glob_string failed"
@@ -386,6 +403,7 @@ cc -I "$DIR/../include" -Wall -Wextra -std=c99 \
     "$DIR/unit/test_addr_movabs.c" \
     "$DIR/../src/codegen_mem_x86.c" "$DIR/../src/codegen_mem_common.c" \
     "$DIR/../src/codegen_load.c" "$DIR/../src/codegen_store.c" \
+    "$DIR/../src/codegen_x86.c" \
     "$DIR/../src/strbuf.c" "$DIR/../src/regalloc_x86.c" -o "$DIR/addr_movabs"
 if ! "$DIR/addr_movabs" >/dev/null; then
     echo "Test addr_movabs failed"
@@ -788,7 +806,7 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/duplicate_case.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "duplicate case label" "${err}"; then
     echo "Test duplicate_case failed"
     fail=1
 fi
@@ -801,7 +819,7 @@ set +e
 "$BINARY" -o "${out}" "$DIR/invalid/union_bad_access.c" 2> "${err}"
 ret=$?
 set -e
-if [ $ret -eq 0 ] || ! grep -q "Semantic error" "${err}"; then
+if [ $ret -eq 0 ] || ! grep -q "inactive union member 'c'" "${err}"; then
     echo "Test union_bad_access failed"
     fail=1
 fi


### PR DESCRIPTION
## Summary
- Add formatted error printing helper and include expression/function names in diagnostics
- Emit specific semantic error messages across expression, call, and control analysis
- Expand tests to check detailed diagnostics for various semantic failures

## Testing
- `./vc -o /tmp/out tests/invalid/undef_var.c` (fails: undeclared identifier 'x')
- `./vc -o /tmp/out tests/invalid/const_assign.c` (fails: assignment to const variable 'x')
- `./vc -o /tmp/out tests/invalid/const_no_init.c` (fails: const variable 'x' requires an initializer)
- `./vc -o /tmp/out tests/invalid/undef_cond.c` (fails: undeclared identifier 'x')
- `./vc -o /tmp/out tests/invalid/undef_assign.c` (fails: assignment to undeclared variable 'y')
- `./vc -o /tmp/out tests/invalid/undef_func.c` (fails: undeclared function 'foo')
- `./vc -o /tmp/out tests/invalid/duplicate_case.c` (fails: duplicate case label '1')
- `./vc -o /tmp/out tests/invalid/union_bad_access.c` (fails: accessing inactive union member 'c')


------
https://chatgpt.com/codex/tasks/task_e_68ad355067d883249f00c82762b4b16d