### PR TITLE
Handle quoted macro arguments in recursion

### DIFF
--- a/src/preproc_expand.c
+++ b/src/preproc_expand.c
@@ -188,10 +188,15 @@ static int expand_user_macro(macro_t *m, const char *line, size_t *pos,
         if ((m->params.count || m->variadic) && line[p] == '(') {
             size_t depth = 0;
             do {
-                strbuf_appendf(out, "%c", line[p]);
-                if (line[p] == '(')
+                char c = line[p];
+                if (c == '"' || c == '\'') {
+                    emit_quoted(line, &p, c, out);
+                    continue;
+                }
+                strbuf_appendf(out, "%c", c);
+                if (c == '(')
                     depth++;
-                else if (line[p] == ')')
+                else if (c == ')')
                     depth--;
                 p++;
             } while (line[p - 1] && depth > 0);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -279,6 +279,16 @@ $CC -Iinclude -Wall -Wextra -std=c99 -c src/preproc_builtin.c -o preproc_builtin
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_preproc_literal_args.c" -o "$DIR/test_preproc_literal_args.o"
 $CC -o "$DIR/preproc_literal_args" preproc_expand.o preproc_table.o strbuf_litargs.o vector_litargs.o util_litargs.o preproc_builtin_litargs.o "$DIR/test_preproc_literal_args.o"
 rm -f preproc_expand.o preproc_table.o strbuf_litargs.o vector_litargs.o util_litargs.o preproc_builtin_litargs.o "$DIR/test_preproc_literal_args.o"
+# build literal argument recursion tests
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/preproc_expand.c -o preproc_expand.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/preproc_table.c -o preproc_table.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_litargs_rec.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/vector.c -o vector_litargs_rec.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_litargs_rec.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c src/preproc_builtin.c -o preproc_builtin_litargs_rec.o
+$CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_preproc_literal_args_recurse.c" -o "$DIR/test_preproc_literal_args_recurse.o"
+$CC -o "$DIR/preproc_literal_args_recurse" preproc_expand.o preproc_table.o strbuf_litargs_rec.o vector_litargs_rec.o util_litargs_rec.o preproc_builtin_litargs_rec.o "$DIR/test_preproc_literal_args_recurse.o"
+rm -f preproc_expand.o preproc_table.o strbuf_litargs_rec.o vector_litargs_rec.o util_litargs_rec.o preproc_builtin_litargs_rec.o "$DIR/test_preproc_literal_args_recurse.o"
 # build pack pragma layout tests
 $CC -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/pack_pragma_tests" "$DIR/unit/test_pack_pragma.c"
@@ -658,6 +668,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/variadic_macro_tests"
 "$DIR/macro_stringize_escape"
 "$DIR/preproc_literal_args"
+"$DIR/preproc_literal_args_recurse"
 "$DIR/pack_pragma_tests"
 "$DIR/read_file_lines_large"
 "$DIR/preproc_stdio"

--- a/tests/unit/test_preproc_literal_args_recurse.c
+++ b/tests/unit/test_preproc_literal_args_recurse.c
@@ -1,0 +1,54 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_macros.h"
+#include "strbuf.h"
+#include "vector.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void add_recur_macro(vector_t *macros)
+{
+    vector_t params;
+    vector_init(&params, sizeof(char *));
+    char *p = strdup("x");
+    vector_push(&params, &p);
+    add_macro("RECUR", "RECUR(x)", &params, 0, macros);
+}
+
+static void run_case(const char *call)
+{
+    vector_t macros; vector_init(&macros, sizeof(macro_t));
+    add_recur_macro(&macros);
+
+    strbuf_t sb; strbuf_init(&sb);
+    preproc_context_t ctx = {0};
+    preproc_set_location(&ctx, "t.c", 1, 1);
+    ASSERT(expand_line(call, &macros, &sb, 0, 0, &ctx));
+    ASSERT(strcmp(sb.data, call) == 0);
+    strbuf_free(&sb);
+
+    macro_free(&((macro_t *)macros.data)[0]);
+    vector_free(&macros);
+}
+
+int main(void)
+{
+    run_case("RECUR(\"a,b\")");
+    run_case("RECUR(')')");
+    run_case("RECUR(',')");
+    run_case("RECUR(\"a\\\"b,\")");
+    run_case("RECUR(\")\")");
+    if (failures == 0)
+        printf("All preproc_literal_args_recurse tests passed\n");
+    else
+        printf("%d preproc_literal_args_recurse test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- ensure macro argument scanning skips over strings and character constants when avoiding recursive expansion
- add regression tests for literal arguments in self-recursive macros

## Testing
- `./preproc_literal_args`
- `./preproc_literal_args_recurse`
- `./tests/run.sh` *(fails: multiple definition of `ast_free_func`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad44ed78988324a15511d85426142f