### PR TITLE
Support both colon and semicolon env path separators

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -266,11 +266,7 @@ int append_env_paths(const char *env, vector_t *search_dirs)
         return 0;
     size_t start = search_dirs->count;
     char *tok, *sp;
-#if defined(_WIN32)
-    const char *sep = ";:";
-#else
-    const char *sep = ":";
-#endif
+    const char *sep = ":;";
     tok = strtok_r(tmp, sep, &sp);
     while (tok) {
         if (*tok) {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -195,8 +195,11 @@ rm -f strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
 $CC -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/append_env_paths_colon" "$DIR/unit/test_append_env_paths_colon.c" \
     src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
-$CC -Iinclude -Wall -Wextra -std=c99 -D_WIN32 \
+$CC -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/append_env_paths_semicolon" "$DIR/unit/test_append_env_paths_semicolon.c" \
+    src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
+$CC -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/append_env_paths_both" "$DIR/unit/test_append_env_paths_both.c" \
     src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c
 # build append_env_paths failure test
 $CC -Iinclude -Wall -Wextra -std=c99 -Dvector_push=test_vector_push \
@@ -653,6 +656,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/waitpid_retry"
 "$DIR/append_env_paths_colon"
 "$DIR/append_env_paths_semicolon"
+"$DIR/append_env_paths_both"
 "$DIR/append_env_paths_fail"
 "$DIR/parse_inline_hint_tests"
 "$DIR/temp_file_tests"

--- a/tests/unit/test_append_env_paths_both.c
+++ b/tests/unit/test_append_env_paths_both.c
@@ -1,0 +1,32 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "preproc_path.h"
+#include "util.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+int main(void)
+{
+    vector_t dirs; vector_init(&dirs, sizeof(char *));
+    ASSERT(append_env_paths("foo:bar;baz", &dirs));
+    ASSERT(dirs.count == 3);
+    if (dirs.count == 3) {
+        ASSERT(strcmp(((char **)dirs.data)[0], "foo") == 0);
+        ASSERT(strcmp(((char **)dirs.data)[1], "bar") == 0);
+        ASSERT(strcmp(((char **)dirs.data)[2], "baz") == 0);
+    }
+    free_string_vector(&dirs);
+    if (failures == 0)
+        printf("All append_env_paths_both tests passed\n");
+    else
+        printf("%d append_env_paths_both test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Always split environment path variables on both `:` and `;`
- Add unit test covering mixed `:` and `;` separators
- Ensure test runner builds and executes the new unit tests

## Testing
- `cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -DNO_VECTOR_FREE_STUB -DPROJECT_ROOT="$(pwd)" -o /tmp/append_env_paths_colon tests/unit/test_append_env_paths_colon.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c && /tmp/append_env_paths_colon`
- `cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -DNO_VECTOR_FREE_STUB -DPROJECT_ROOT="$(pwd)" -o /tmp/append_env_paths_semicolon tests/unit/test_append_env_paths_semicolon.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c && /tmp/append_env_paths_semicolon`
- `cc -Iinclude -Wall -Wextra -std=c99 -DUNIT_TESTING -DNO_VECTOR_FREE_STUB -DPROJECT_ROOT="$(pwd)" -o /tmp/append_env_paths_both tests/unit/test_append_env_paths_both.c src/include_path_cache.c src/preproc_path.c src/vector.c src/util.c && /tmp/append_env_paths_both`
- `tests/run.sh` *(fails: multiple definition of `ast_free_func`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62be91648324997f8176fbe0da56