### PR TITLE
Handle long command strings safely

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -149,21 +149,24 @@ $CC -o "$DIR/text_line_fail" strbuf_textfail_impl.o util_textfail.o "$DIR/test_t
 rm -f strbuf_textfail_impl.o util_textfail.o "$DIR/test_text_line_fail.o"
 # build command_to_string failure test
 $CC -Iinclude -Wall -Wextra -std=c99 \
-    -Dstrbuf_init=test_strbuf_init -Dstrbuf_append=test_strbuf_append \
-    -Dstrbuf_free=test_strbuf_free -Dposix_spawnp=test_posix_spawnp \
+    -Dposix_spawnp=test_posix_spawnp \
     -Dmalloc=test_malloc -Drealloc=test_realloc \
     -c src/command.c -o command_fail.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_command_fail.c" -o "$DIR/test_command_fail.o"
 $CC -o "$DIR/command_fail" command_fail.o "$DIR/test_command_fail.o"
 rm -f command_fail.o "$DIR/test_command_fail.o"
 # build command_to_string alloc failure test
-$CC -Iinclude -Wall -Wextra -std=c99 -c src/strbuf.c -o strbuf_cmdalloc_impl.o
-$CC -Iinclude -Wall -Wextra -std=c99 -Dstrbuf_append=test_strbuf_append \
+$CC -Iinclude -Wall -Wextra -std=c99 \
+    -Dmalloc=test_malloc -Drealloc=test_realloc \
     -c src/command.c -o command_alloc_fail.o
-$CC -Iinclude -Wall -Wextra -std=c99 -Dstrbuf_append=test_strbuf_append \
+$CC -Iinclude -Wall -Wextra -std=c99 \
+    -Dmalloc=test_malloc -Drealloc=test_realloc \
     -c "$DIR/unit/test_command_alloc_fail.c" -o "$DIR/test_command_alloc_fail.o"
-$CC -o "$DIR/command_alloc_fail" command_alloc_fail.o strbuf_cmdalloc_impl.o "$DIR/test_command_alloc_fail.o"
-rm -f command_alloc_fail.o strbuf_cmdalloc_impl.o "$DIR/test_command_alloc_fail.o"
+$CC -o "$DIR/command_alloc_fail" command_alloc_fail.o "$DIR/test_command_alloc_fail.o"
+rm -f command_alloc_fail.o "$DIR/test_command_alloc_fail.o"
+# build command_to_string long path regression test
+$CC -Iinclude -Wall -Wextra -std=c99 \
+    -o "$DIR/command_long_path" "$DIR/unit/test_command_long_path.c" src/command.c
 # build vc_strtoul_unsigned negative value rejection test
 $CC -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_strtoul_unsigned.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_vc_strtoul_unsigned.c" -o "$DIR/test_vc_strtoul_unsigned.o"

--- a/tests/unit/test_command_fail.c
+++ b/tests/unit/test_command_fail.c
@@ -6,7 +6,6 @@
 #include <errno.h>
 #include <spawn.h>
 #include "command.h"
-#include "strbuf.h"
 
 static int failures = 0;
 #define ASSERT(cond) do { \
@@ -27,48 +26,6 @@ void *test_realloc(void *ptr, size_t size) {
     if (fail_malloc)
         return NULL;
     return realloc(ptr, size);
-}
-
-/* minimal strbuf implementation using malloc stubs */
-void test_strbuf_init(strbuf_t *sb) {
-    sb->len = 0;
-    sb->cap = 16;
-    sb->data = test_malloc(sb->cap);
-    if (sb->data)
-        sb->data[0] = '\0';
-    else
-        sb->cap = 0;
-}
-int test_strbuf_append(strbuf_t *sb, const char *text) {
-    if (!sb->data) {
-        sb->cap = 16;
-        sb->data = test_malloc(sb->cap);
-        if (!sb->data) {
-            sb->cap = 0;
-            return -1;
-        }
-        sb->len = 0;
-        sb->data[0] = '\0';
-    }
-    size_t len = strlen(text);
-    if (sb->len + len + 1 > sb->cap) {
-        size_t new_cap = sb->cap * 2;
-        while (new_cap < sb->len + len + 1)
-            new_cap *= 2;
-        char *p = test_realloc(sb->data, new_cap);
-        if (!p)
-            return -1;
-        sb->data = p;
-        sb->cap = new_cap;
-    }
-    memcpy(sb->data + sb->len, text, len + 1);
-    sb->len += len;
-    return 0;
-}
-void test_strbuf_free(strbuf_t *sb) {
-    free(sb->data);
-    sb->data = NULL;
-    sb->len = sb->cap = 0;
 }
 
 /* posix_spawnp stub that always fails */

--- a/tests/unit/test_command_long_path.c
+++ b/tests/unit/test_command_long_path.c
@@ -1,0 +1,42 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "command.h"
+
+static int failures = 0;
+#define ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+        failures++; \
+    } \
+} while (0)
+
+static void test_long_path(void)
+{
+    size_t len = 8000; /* deliberately longer than typical PATH_MAX */
+    char *path = malloc(len + 1);
+    if (!path) {
+        perror("malloc");
+        exit(1);
+    }
+    memset(path, 'a', len);
+    path[len] = '\0';
+
+    char *argv[] = {"cmd", path, NULL};
+    char *s = command_to_string(argv);
+    ASSERT(s != NULL);
+    ASSERT(strstr(s, path) != NULL);
+    free(s);
+    free(path);
+}
+
+int main(void)
+{
+    test_long_path();
+    if (failures == 0)
+        printf("All command_long_path tests passed\n");
+    else
+        printf("%d command_long_path test(s) failed\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- rewrite command_to_string to dynamically grow its buffer and handle quoting without overflow
- adjust allocation-failure tests for new dynamic buffer
- add regression test for extremely long command paths

## Testing
- `cc -Iinclude -Wall -Wextra -std=c99 -Dposix_spawnp=test_posix_spawnp -Dmalloc=test_malloc -Drealloc=test_realloc -c src/command.c -o command_fail.o`
- `cc -Iinclude -Wall -Wextra -std=c99 -c tests/unit/test_command_fail.c -o tests/unit/test_command_fail.o`
- `cc -o tests/command_fail command_fail.o tests/unit/test_command_fail.o`
- `./tests/command_fail >/tmp/command_fail.out && tail -n 20 /tmp/command_fail.out`
- `cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Drealloc=test_realloc -c src/command.c -o command_alloc_fail.o`
- `cc -Iinclude -Wall -Wextra -std=c99 -Dmalloc=test_malloc -Drealloc=test_realloc -c tests/unit/test_command_alloc_fail.c -o tests/unit/test_command_alloc_fail.o`
- `cc -o tests/command_alloc_fail command_alloc_fail.o tests/unit/test_command_alloc_fail.o`
- `./tests/command_alloc_fail >/tmp/command_alloc_fail.out && tail -n 20 /tmp/command_alloc_fail.out`
- `cc -Iinclude -Wall -Wextra -std=c99 tests/unit/test_command_long_path.c src/command.c -o tests/command_long_path`
- `./tests/command_long_path >/tmp/command_long_path.out && tail -n 20 /tmp/command_long_path.out`


------
https://chatgpt.com/codex/tasks/task_e_68ae6a884c1483248699f409c0529d07