### PR TITLE
Use tee for example build logs

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -o pipefail
 
 # do not exit on first failure so all examples are attempted
 DIR="$(dirname "$0")"
@@ -31,9 +33,9 @@ for src in "$DIR"/*.c; do
 
     opts="--link $ARCH_OPT --internal-libc"
 
-    "$VC" $opts -o "$exe" "$src" >"$exe.log" 2>&1
+    "$VC" $opts -o "$exe" "$src" 2>&1 | tee "$exe.log"
     if [ $? -eq 0 ]; then
-        "$VC" $ARCH_OPT --internal-libc -o "$DIR/${base}.s" "$src" >>"$exe.log" 2>&1
+        "$VC" $ARCH_OPT --internal-libc -o "$DIR/${base}.s" "$src" 2>&1 | tee -a "$exe.log"
         success=$((success + 1))
     else
         echo "Failed to build $exe (see $exe.log)"


### PR DESCRIPTION
## Summary
- pipe vc build output through `tee` to mirror logs to stdout
- ensure pipelines fail correctly via `set -o pipefail`
- switch example builder to bash for pipefail support

## Testing
- `./examples/build_examples.sh` *(fails: file_io, gcd, malloc_sum)*
- `make test` *(fails: Test libc_printf_64, Test internal_libc_missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f3cb2fc8324926bc826c64f7f9e