### PR TITLE
Flush stderr after error messages

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -58,6 +58,7 @@ void error_print(const char *msg)
     if (color)
         fprintf(stderr, "\x1b[0m");
     fputc('\n', stderr);
+    fflush(stderr);
 }
 
 void error_printf(const char *fmt, ...)
@@ -68,5 +69,6 @@ void error_printf(const char *fmt, ...)
     vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
     error_print(buf);
+    fflush(stderr);
 }
 


### PR DESCRIPTION
## Summary
- ensure diagnostic utilities always flush stderr after printing

## Testing
- `make -j$(nproc)`
- `./examples/build_examples.sh > /tmp/examples_build.log 2>&1` and confirmed error text in the log

------
https://chatgpt.com/codex/tasks/task_e_68ae75acdc648324bec4448da43b787d