### PR TITLE
Compare while condition against zero

### DIFF
--- a/src/semantic_loops.c
+++ b/src/semantic_loops.c
@@ -38,6 +38,7 @@ int check_while_stmt(stmt_t *stmt, symtable_t *vars, symtable_t *funcs,
     ir_build_label(ir, start_label);
     if (check_expr(STMT_WHILE(stmt).cond, vars, funcs, ir, &cond_val) == TYPE_UNKNOWN)
         return 0;
+    cond_val = ir_build_binop(ir, IR_CMPNE, cond_val, ir_build_const(ir, 0), TYPE_INT);
     ir_build_bcond(ir, cond_val, end_label);
     if (!check_stmt(STMT_WHILE(stmt).body, vars, funcs, labels, ir,
                     func_ret_type, end_label, start_label))

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -189,6 +189,23 @@ else
 fi
 rm -f "$exe" "$exe.s" "$exe.o" "$exe.log" "$out" 2>/dev/null || true
 
+# verify loops example runs and terminates
+exe=$(safe_mktemp)
+if "$BINARY" --x86-64 --internal-libc --link -o "$exe" "$DIR/../examples/loops.c" >/dev/null 2>&1; then
+    set +e
+    "$exe" >/dev/null 2>&1
+    status=$?
+    set -e
+    if [ $status -ne 0 ]; then
+        echo "Test example_loops failed"
+        fail=1
+    fi
+else
+    echo "Test example_loops failed"
+    fail=1
+fi
+rm -f "$exe" "$exe.s" "$exe.o" "$exe.log" 2>/dev/null || true
+
 # negative test for parse error message
 err=$(safe_mktemp)
 out=$(safe_mktemp)


### PR DESCRIPTION
## Summary
- normalize while-loop conditions by explicitly comparing against zero before branching
- add regression test to compile and run `examples/loops.c`

## Testing
- `tests/run_tests.sh` *(failed: script did not complete, appears to hang)*

------
https://chatgpt.com/codex/tasks/task_e_68ae76ac23448324bc1a5becefa94d7c