### PR TITLE
Refine fopen allocation and enhance fprintf error handling

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -157,6 +157,13 @@ for src in "$DIR/../examples/file_count.c" "$DIR/../examples/file_io.c"; do
     if ! "$BINARY" --x86-64 --internal-libc --link -o "$exe" "$src" >/dev/null 2>&1; then
         echo "Test example_$(basename "$src" .c) failed"
         fail=1
+    elif [ "$(basename "$src")" = "file_io.c" ]; then
+        out="$($exe 2>/dev/null)"
+        if [ "$out" != "Read: Hello, file!" ]; then
+            echo "Test example_file_io_run failed"
+            fail=1
+        fi
+        rm -f example.txt
     fi
     rm -f "$exe" "$exe.s" "$exe.o" "$exe.log" 2>/dev/null || true
 done


### PR DESCRIPTION
## Summary
- allocate `FILE` structures only after `_vc_open` succeeds using a centralized malloc path
- centralize `fprintf` cleanup to avoid early returns that skip buffer flushes
- add regression test that runs the `file_io` example to verify open/write/read/close flow

## Testing
- `make test` *(fails: Test alignof_expr failed, Test array_basic failed, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68af5189b984832490ba89fe43138c2a