### PR TITLE
Track EOF separately from errors

### DIFF
--- a/examples/file_count.c
+++ b/examples/file_count.c
@@ -8,8 +8,17 @@ int main(void) {
     }
     char buf[64];
     int lines = 0;
-    while (fgets(buf, sizeof(buf), f))
-        lines++;
+    while (!f->eof) {
+        if (!fgets(buf, sizeof(buf), f)) {
+            if (f->err) {
+                perror("fgets");
+                fclose(f);
+                return 1;
+            }
+        } else {
+            lines++;
+        }
+    }
     fclose(f);
     printf("lines: %d\n", lines);
     return 0;

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -20,6 +20,7 @@ int printf(const char *format, ...);
 struct FILE_struct {
     int fd;
     int err;
+    int eof;
 };
 #define FILE struct FILE_struct
 

--- a/libc/src/fgets.c
+++ b/libc/src/fgets.c
@@ -14,6 +14,7 @@ char *fgets(char *s, int size, FILE *stream)
             return NULL;
         }
         if (r == 0) {
+            stream->eof = 1;
             if (i == 0)
                 return NULL;
             break;

--- a/libc/src/file.c
+++ b/libc/src/file.c
@@ -53,6 +53,7 @@ FILE *fopen(const char *path, const char *mode)
     }
     f->fd = (int)fd;
     f->err = 0;
+    f->eof = 0;
     return f;
 }
 

--- a/libc/src/tmpfile.c
+++ b/libc/src/tmpfile.c
@@ -20,6 +20,7 @@ FILE *tmpfile(void)
     }
     f->fd = (int)fd;
     f->err = 0;
+    f->eof = 0;
     return f;
 #else
     errno = ENOSYS;

--- a/tests/unit/test_fgets_eof.c
+++ b/tests/unit/test_fgets_eof.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+int main(void) {
+    FILE *f = fopen("tests/fixtures/line_comment.c", "r");
+    if (!f)
+        return 1;
+    char buf[64];
+    if (!fgets(buf, sizeof(buf), f))
+        return 2;
+    if (f->eof || f->err)
+        return 3;
+    while (fgets(buf, sizeof(buf), f))
+        ;
+    if (!f->eof || f->err)
+        return 4;
+    fclose(f);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `eof` indicator to `FILE` and set it from `fgets`
- Initialize EOF flag in `fopen`/`tmpfile`
- Update `file_count` example and tests to check EOF flag

## Testing
- `gcc -Ilibc/include tests/unit/test_fgets_eof.c libc/src/fgets.c libc/src/file.c libc/src/tmpfile.c libc/src/stdio.c libc/src/perror.c libc/src/stdlib.c libc/src/string.c libc/src/syscalls.c libc/src/pthread.c libc/src/_exit.c libc/src/errno.c -o /tmp/fgets_eof_test && /tmp/fgets_eof_test`
- ⚠️ `./tests/run_tests.sh` *(terminated due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68af54ad18b083249437c32bb900e81b