### PR TITLE
Handle builtin __COUNTER__ correctly

### DIFF
--- a/src/preproc_file.c
+++ b/src/preproc_file.c
@@ -309,7 +309,6 @@ static int define_default_macros(vector_t *macros, const char *base_file,
         return 0;
 
     /* Predefined macros for internal bookkeeping */
-    define_simple_macro(macros, "__COUNTER__", "0");
     if (base_file) {
         char *canon = realpath(base_file, NULL);
         if (!canon)

--- a/tests/unit/test_predef_counter_base.c
+++ b/tests/unit/test_predef_counter_base.c
@@ -32,6 +32,8 @@ int main(void)
                      "int offundef;\n"
                      "#endif\n"
                      "int c0 = __COUNTER__;\n"
+                     "int c1 = __COUNTER__;\n"
+                     "int c2 = __COUNTER__;\n"
                      "const char *b = __BASE_FILE__;\n";
     if (fd >= 0) {
         ASSERT(write(fd, src, strlen(src)) == (ssize_t)strlen(src));
@@ -48,7 +50,11 @@ int main(void)
         ASSERT(strstr(res, "int offdef;") == NULL);
         ASSERT(strstr(res, "int offundef;") != NULL);
         char cnt0[] = "int c0 = 0;";
+        char cnt1[] = "int c1 = 1;";
+        char cnt2[] = "int c2 = 2;";
         ASSERT(strstr(res, cnt0) != NULL);
+        ASSERT(strstr(res, cnt1) != NULL);
+        ASSERT(strstr(res, cnt2) != NULL);
         char quoted[512]; snprintf(quoted, sizeof(quoted), "\"%s\"", tmpl);
         ASSERT(strstr(res, quoted) != NULL);
     }


### PR DESCRIPTION
## Summary
- avoid defining `__COUNTER__` as a normal macro so it is handled by builtin expansion
- verify successive `__COUNTER__` expansions return increasing numbers

## Testing
- `gcc -Iinclude -Wall -Wextra -std=c99 /tmp/test_counter_increment.c src/preproc_builtin.c src/strbuf.c src/error.c util_test.o -o /tmp/test_counter_increment && /tmp/test_counter_increment`
- `gcc -Iinclude -Wall -Wextra -std=c99 -DMULTIARCH=\"${MULTIARCH}\" -DGCC_INCLUDE_DIR=\"${GCC_INCLUDE_DIR}\" -DPROJECT_ROOT=\"$(pwd)\" -o tests/preproc_counter_base tests/unit/test_predef_counter_base.c src/preproc_file.c src/preproc_directives.c src/preproc_file_io.c src/preproc_expand.c src/preproc_table.c src/preproc_builtin.c src/preproc_args.c src/preproc_cond.c src/preproc_expr_parse.c src/preproc_expr_lex.c src/preproc_expr_eval.c src/preproc_include.c src/preproc_includes.c src/preproc_macro_utils.c src/preproc_paste.c src/include_path_cache.c src/preproc_path.c src/vector.c src/strbuf.c src/error.c util_test.o && tests/preproc_counter_base` *(fails: Assertion failed: fd >= 0 (tests/unit/test_predef_counter_base.c:23))*

------
https://chatgpt.com/codex/tasks/task_e_68af5cd4a76883249fc90ef053148e57