### PR TITLE
libc: flush streams on exit

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -9,7 +9,7 @@ CAN_COMPILE_32 := $(shell $(CC) -m32 -xc /dev/null -o /dev/null \
     >/dev/null 2>&1 && echo yes || echo no)
 
 SRC := src/stdio.c src/perror.c src/stdlib.c src/string.c src/syscalls.c src/file.c \
-       src/fgets.c src/tmpfile.c src/pthread.c src/_exit.c src/errno.c
+       src/fgets.c src/tmpfile.c src/pthread.c src/_exit.c src/errno.c src/fflush.c
 HDR := include/stdarg.h include/stddef.h include/stdio.h \
        include/stdlib.h include/string.h include/pthread.h include/errno.h
 OBJ32 := $(SRC:src/%.c=src/%.32.o)

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -26,6 +26,7 @@ struct FILE_struct {
 
 FILE *fopen(const char *path, const char *mode);
 int fclose(FILE *stream);
+int fflush(FILE *stream);
 /* Returns the number of characters written. If the length would overflow an
  * int, INT_MAX is returned instead. */
 int fprintf(FILE *stream, const char *format, ...);

--- a/libc/src/fflush.c
+++ b/libc/src/fflush.c
@@ -1,0 +1,7 @@
+#include "stdio.h"
+
+int fflush(FILE *stream)
+{
+    (void)stream;
+    return 0;
+}

--- a/libc/src/stdlib.c
+++ b/libc/src/stdlib.c
@@ -1,11 +1,13 @@
 #include <stddef.h>
 #include "stdlib.h"
+#include "stdio.h"
 #include "../internal/_vc_syscalls.h"
 void _exit(int) __attribute__((noreturn));
 
 void exit(int status) __attribute__((noreturn));
 void exit(int status)
 {
+    fflush(NULL);
     long (*vc_exit_ptr)(int) = _vc_exit;
     long ret = vc_exit_ptr(status);
     if (ret < 0) {


### PR DESCRIPTION
## Summary
- add stub `fflush` implementation
- call `fflush(NULL)` from `exit` to flush stdio before `_vc_exit`
- include new source in libc build

## Testing
- `make`
- `./tests/run_tests.sh` (fails: macro_cli_undef, example_file_count, example_file_io, fgets_eof, example_copy_string, example_malloc_sum)
- `../vc --link --internal-libc -o calc calc.c` (fails: cannot execute binary file: Exec format error)


------
https://chatgpt.com/codex/tasks/task_e_68af5b279bc083248cabf8b8d1e8c424