### PR TITLE
Fix include_next search start index

### DIFF
--- a/src/preproc_path.c
+++ b/src/preproc_path.c
@@ -199,20 +199,22 @@ char *find_include_path(const char *fname, char endc, const char *dir,
         free(out_path);
         return NULL;
     }
-    int n = snprintf(out_path, max_len, "%s", fname);
-    if (n < 0 || (size_t)n >= max_len) {
-        free(out_path);
-        fprintf(stderr, "vc: include path truncated\n");
-        return NULL;
-    }
-    if (verbose_includes)
-        fprintf(stderr, "checking %s\n", out_path);
-    if (access(out_path, R_OK) == 0) {
-        if (out_idx)
-            *out_idx = (size_t)-1;
+    if (start == 0) {
+        int n = snprintf(out_path, max_len, "%s", fname);
+        if (n < 0 || (size_t)n >= max_len) {
+            free(out_path);
+            fprintf(stderr, "vc: include path truncated\n");
+            return NULL;
+        }
         if (verbose_includes)
-            fprintf(stderr, "found %s\n", out_path);
-        return out_path;
+            fprintf(stderr, "checking %s\n", out_path);
+        if (access(out_path, R_OK) == 0) {
+            if (out_idx)
+                *out_idx = (size_t)-1;
+            if (verbose_includes)
+                fprintf(stderr, "found %s\n", out_path);
+            return out_path;
+        }
     }
     for (size_t i = builtin_start; i < extra_sys_dirs.count; i++) {
         const char *base = ((const char **)extra_sys_dirs.data)[i];

--- a/tests/include_next/skip_current.c
+++ b/tests/include_next/skip_current.c
@@ -1,0 +1,2 @@
+#include "dir1/foo.h"
+int main() { return VALUE; }

--- a/tests/include_next_quote/skip_current.c
+++ b/tests/include_next_quote/skip_current.c
@@ -1,0 +1,2 @@
+#include "dir1/foo.h"
+int main() { return VALUE; }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -114,6 +114,10 @@ compile_fixture "$DIR/fixtures/include_next.c" "$DIR/fixtures/include_next.s" -I
 # verify quoted #include_next directive
 compile_fixture "$DIR/fixtures/include_next_quote.c" "$DIR/fixtures/include_next_quote.s" -I "$DIR/include_next_quote/dir1" -I "$DIR/include_next_quote/dir2" -I "$DIR/include_next_quote/dir3"
 
+# regression: include_next should skip the directory of the current header
+compile_fixture "$DIR/include_next/skip_current.c" "$DIR/fixtures/include_next.s" -I "$DIR/include_next/dir1" -I "$DIR/include_next/dir2" -I "$DIR/include_next/dir3"
+compile_fixture "$DIR/include_next_quote/skip_current.c" "$DIR/fixtures/include_next_quote.s" -I "$DIR/include_next_quote/dir1" -I "$DIR/include_next_quote/dir2" -I "$DIR/include_next_quote/dir3"
+
 # verify command-line macro definitions
 compile_fixture "$DIR/fixtures/macro_cli.c" "$DIR/fixtures/macro_cli.s" -DVAL=4 -DFLAG
 


### PR DESCRIPTION
## Summary
- compute `#include_next` start index after the directory of the current header
- honor `start_idx` when resolving includes in `find_include_path`
- add regression tests ensuring `#include_next` skips the current directory

## Testing
- `./vc -I tests/include_next/dir1 -I tests/include_next/dir2 -I tests/include_next/dir3 -o /tmp/out.s tests/include_next/skip_current.c`
- `./vc -I tests/include_next_quote/dir1 -I tests/include_next_quote/dir2 -I tests/include_next_quote/dir3 -o /tmp/outq.s tests/include_next_quote/skip_current.c`
- `tests/run_tests.sh` *(fails: macro_cli_undef, example_file_count, example_file_io, fgets_eof, example_copy_string, example_malloc_sum)*

------
https://chatgpt.com/codex/tasks/task_e_68af6313d060832488a2a20744d3f468