### PR TITLE
Retry fgets on EINTR and add regression test

### DIFF
--- a/libc/src/fgets.c
+++ b/libc/src/fgets.c
@@ -1,4 +1,5 @@
 #include "stdio.h"
+#include "errno.h"
 #include "../internal/_vc_syscalls.h"
 
 char *fgets(char *s, int size, FILE *stream)
@@ -8,13 +9,18 @@ char *fgets(char *s, int size, FILE *stream)
     int i = 0;
     while (i < size - 1) {
         char c;
-        long r = _vc_read(stream->fd, &c, 1);
+        long r;
+        do {
+            r = _vc_read(stream->fd, &c, 1);
+        } while (r < 0 && errno == EINTR);
         if (r < 0) {
             stream->err = 1;
+            stream->eof = 0;
             return NULL;
         }
         if (r == 0) {
             stream->eof = 1;
+            stream->err = 0;
             if (i == 0)
                 return NULL;
             break;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -218,6 +218,13 @@ $CC -Iinclude -Wall -Wextra -std=c99 -c src/util.c -o util_eintr.o
 $CC -Iinclude -Wall -Wextra -std=c99 -c "$DIR/unit/test_waitpid_retry.c" -o "$DIR/test_waitpid_retry.o"
 $CC -o "$DIR/waitpid_retry" strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
 rm -f strbuf_eintr_impl.o util_eintr.o "$DIR/test_waitpid_retry.o"
+# build fgets EINTR retry test
+$CC -I"$DIR/../libc/include" -Wall -Wextra -std=c99 -c "$DIR/../libc/src/syscalls.c" -o syscalls_fgets_eintr.o
+$CC -I"$DIR/../libc/include" -Wall -Wextra -std=c99 -c "$DIR/../libc/src/errno.c" -o errno_fgets_eintr.o
+$CC -I"$DIR/../libc/include" -Wall -Wextra -std=c99 -c "$DIR/../libc/src/fgets.c" -o fgets_impl.o
+$CC -I"$DIR/../libc/include" -Wall -Wextra -std=c99 -c "$DIR/unit/test_fgets_eintr.c" -o "$DIR/test_fgets_eintr.o"
+$CC -o "$DIR/fgets_eintr" syscalls_fgets_eintr.o errno_fgets_eintr.o fgets_impl.o "$DIR/test_fgets_eintr.o"
+rm -f syscalls_fgets_eintr.o errno_fgets_eintr.o fgets_impl.o "$DIR/test_fgets_eintr.o"
 # build append_env_paths tests
 $CC -Iinclude -Wall -Wextra -std=c99 \
     -o "$DIR/append_env_paths_colon" "$DIR/unit/test_append_env_paths_colon.c" \
@@ -682,6 +689,7 @@ rm -f ir_licm.o util_licm.o label_licm.o error_licm.o opt_main_licm.o \
 "$DIR/number_overflow"
 "$DIR/number_suffix"
 "$DIR/waitpid_retry"
+"$DIR/fgets_eintr"
 "$DIR/append_env_paths_colon"
 "$DIR/append_env_paths_semicolon"
 "$DIR/append_env_paths_both"

--- a/tests/unit/test_fgets_eintr.c
+++ b/tests/unit/test_fgets_eintr.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <signal.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+static void handle_alarm(int sig) {
+    (void)sig;
+}
+
+int main(void) {
+    int pipefd[2];
+    if (pipe(pipefd) != 0)
+        return 1;
+
+    signal(SIGALRM, handle_alarm);
+
+    pid_t pid = fork();
+    if (pid == -1)
+        return 2;
+    if (pid == 0) {
+        close(pipefd[0]);
+        sleep(2);
+        if (write(pipefd[1], "ok\n", 3) != 3)
+            _exit(3);
+        close(pipefd[1]);
+        _exit(0);
+    }
+    close(pipefd[1]);
+
+    FILE f = { .fd = pipefd[0], .err = 0, .eof = 0 };
+    char buf[16];
+    alarm(1);
+    if (!fgets(buf, sizeof(buf), &f))
+        return 4;
+    if (buf[0] != 'o' || buf[1] != 'k' || buf[2] != '\n' || buf[3] != '\0')
+        return 5;
+    if (f.err || f.eof)
+        return 6;
+
+    alarm(0);
+    close(pipefd[0]);
+    waitpid(pid, NULL, 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- retry `_vc_read` in `fgets` when interrupted by a signal instead of flagging an error
- keep `errno`, `stream->err` and `stream->eof` consistent on read failures and EOF
- add regression test exercising EINTR handling in `fgets`

## Testing
- `cc -Ilibc/include -Wall -Wextra -std=c99 -c libc/src/syscalls.c -o syscalls.o`
- `cc -Ilibc/include -Wall -Wextra -std=c99 -c libc/src/errno.c -o errno.o`
- `cc -Ilibc/include -Wall -Wextra -std=c99 -c libc/src/fgets.c -o fgets.o`
- `cc -Ilibc/include -Wall -Wextra -std=c99 -c tests/unit/test_fgets_eintr.c -o test_fgets_eintr.o`
- `cc -o test_fgets_eintr syscalls.o errno.o fgets.o test_fgets_eintr.o`
- `./test_fgets_eintr`


------
https://chatgpt.com/codex/tasks/task_e_68af6858132c832498a243436a06a63e