### PR TITLE
propagate fprintf errors and test error flag

### DIFF
--- a/examples/file_io.c
+++ b/examples/file_io.c
@@ -8,7 +8,11 @@ int main(void)
         return 1;
     }
 
-    fprintf(f, "Hello, file!\n");
+    if (fprintf(f, "Hello, file!\n") < 0 || f->err) {
+        perror("fprintf");
+        fclose(f);
+        return 1;
+    }
     fclose(f);
 
     f = fopen("example.txt", "r");

--- a/libc/src/file.c
+++ b/libc/src/file.c
@@ -226,6 +226,9 @@ int fprintf(FILE *stream, const char *fmt, ...)
     return (int)written;
 
 error:
+    int saved_errno = errno;
+    stream->err = 1;
     va_end(ap);
+    errno = saved_errno;
     return -1;
 }

--- a/tests/fixtures/libc_fileio.c
+++ b/tests/fixtures/libc_fileio.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <errno.h>
 
 int main(void)
 {
@@ -8,6 +9,12 @@ int main(void)
     char buf[64];
     if (fgets(buf, sizeof(buf), f))
         printf("%s", buf);
+
+    errno = 0;
+    if (fprintf(f, "fail") >= 0 || !f->err || errno == 0) {
+        fclose(f);
+        return 1;
+    }
     fclose(f);
     return 0;
 }


### PR DESCRIPTION
## Summary
- set stream error flag and preserve errno in fprintf error path
- ensure example checks f->err after writing
- extend libc_fileio fixture to assert error propagation

## Testing
- `./tests/run_tests.sh` *(failed: macro_cli_undef, example_file_io, and others)*
- `./examples/build_examples.sh` *(failed: copy_string, file_count, file_io, malloc_sum)*

------
https://chatgpt.com/codex/tasks/task_e_68afc52363e48324b2149f82a4541548