### PR TITLE
Ensure malloc alignment and add stress test

### DIFF
--- a/libc/src/syscalls.c
+++ b/libc/src/syscalls.c
@@ -76,11 +76,13 @@ typedef struct block {
     struct block *next;
 } block_t;
 
+#define ALIGN_UP(x) (((x) + sizeof(void *) - 1) & ~(sizeof(void *) - 1))
 static unsigned long cur_brk = 0;
 static block_t *free_list = 0;
 
 void *_vc_malloc(unsigned long size)
 {
+    size = ALIGN_UP(size);
     long ret;
     block_t **prevp = &free_list;
     block_t *curr = free_list;
@@ -149,13 +151,16 @@ void _vc_free(void *ptr)
     blk->next = curr;
     if (curr && (unsigned long)blk + sizeof(block_t) + blk->size == (unsigned long)curr) {
         blk->size += sizeof(block_t) + curr->size;
+        blk->size = ALIGN_UP(blk->size);
         blk->next = curr->next;
     }
 
     if (*prevp && (unsigned long)*prevp + sizeof(block_t) + (*prevp)->size == (unsigned long)blk) {
         (*prevp)->size += sizeof(block_t) + blk->size;
+        (*prevp)->size = ALIGN_UP((*prevp)->size);
         (*prevp)->next = blk->next;
     } else {
+        blk->size = ALIGN_UP(blk->size);
         *prevp = blk;
     }
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1543,6 +1543,21 @@ if [ $ret -ne 0 ]; then
 fi
 rm -f "$prog" "$clamp" "$libvclib"
 
+# stress test malloc alignment
+libvclib="$DIR/libvclib.so"
+cc -shared -fPIC -I "$DIR/../libc/include" \
+    "$DIR/../libc/src/stdio.c" "$DIR/../libc/src/stdlib.c" \
+    "$DIR/../libc/src/string.c" "$DIR/../libc/src/syscalls.c" \
+    "$DIR/../libc/src/file.c" "$DIR/../libc/src/errno.c" -o "$libvclib"
+prog=$(safe_mktemp)
+cc -I "$DIR/../libc/include" "$DIR/unit/test_malloc_alignment.c" \
+    -L"$DIR" -Wl,-rpath="$DIR" -lvclib -o "$prog"
+if ! "$prog" >/dev/null; then
+    echo "Test malloc_alignment_stress failed"
+    fail=1
+fi
+rm -f "$prog" "$libvclib"
+
 # regression test for long command error message
 long_tmpdir=$(safe_mktemp -d)
 long_out="$long_tmpdir/$(printf 'a%.0s' $(seq 1 50))/$(printf 'b%.0s' $(seq 1 50))/$(printf 'c%.0s' $(seq 1 50))/$(printf 'd%.0s' $(seq 1 50))/$(printf 'e%.0s' $(seq 1 50))/out.o"

--- a/tests/unit/test_malloc_alignment.c
+++ b/tests/unit/test_malloc_alignment.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+struct strict_align {
+    char c;
+} __attribute__((aligned(sizeof(void *))));
+
+int main(void)
+{
+    enum { COUNT = 10000 };
+    struct strict_align *ptrs[COUNT];
+
+    for (int i = 0; i < COUNT; ++i) {
+        ptrs[i] = malloc(sizeof(struct strict_align));
+        if (!ptrs[i] || ((uintptr_t)ptrs[i] % sizeof(void *)) != 0) {
+            printf("alignment failed on initial allocation %d\n", i);
+            return 1;
+        }
+    }
+
+    for (int i = 0; i < COUNT; i += 2)
+        free(ptrs[i]);
+
+    for (int i = 0; i < COUNT; i += 2) {
+        ptrs[i] = malloc(sizeof(struct strict_align));
+        if (!ptrs[i] || ((uintptr_t)ptrs[i] % sizeof(void *)) != 0) {
+            printf("alignment failed on re-allocation %d\n", i);
+            return 1;
+        }
+        free(ptrs[i]);
+    }
+
+    for (int i = 1; i < COUNT; i += 2)
+        free(ptrs[i]);
+
+    printf("malloc alignment stress passed\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Align allocator block sizes to pointer width and maintain alignment when coalescing free-list nodes
- Add stress test verifying pointer-aligned allocations

## Testing
- `./tests/run_tests.sh` *(fails: Test macro_cli_undef, Test example_file_count, Test example_file_io, Test fgets_eof, Test example_copy_string, Test example_file_count, Test example_file_io, Test example_malloc_sum, Test example_malloc_sum)*

------
https://chatgpt.com/codex/tasks/task_e_68afcaf31ef4832480b772b75682cc63